### PR TITLE
PRD-A: Signals operational vocabulary parity with goSignals

### DIFF
--- a/docs/Signals.md
+++ b/docs/Signals.md
@@ -112,6 +112,14 @@ was made to develop a Security Event Router called goSignals (soon to be release
 | scim.signals.rcv.iss.jwksJson                | The issuer public key in JWKS JSON format used to validate signed events<BR>Use either jwksurl or jwksjson                | NONE                 |
 | scim.signals.rcv.pem.path                    | The location of an PKCS8 PEM format private key which may be used to decrypt JWE encoded events                           | NONE                 |
 | scim.signals.rcv.pem.value                   | PKCS8 encoded private key value used to decrypt JWE encoded events                                                        | NONE                 |
+| <BR>**Operational Recovery**                 |
+| scim.signals.pub.unauthorized.retry.max      | Maximum 401 retries on a push stream before disabling the stream                                                          | 10                   |
+| scim.signals.pub.unauthorized.retry.delay    | Fixed delay (ms) between 401 retries on a push stream                                                                     | 15000                |
+| scim.signals.pub.status.check.interval       | Interval (ms) between transmitter `/status` re-checks while a push stream is `paused`                                     | 30000                |
+| scim.signals.pub.idle.verify.interval        | Interval (ms) of push-stream idleness after which a [SSF verification event](https://openid.net/specs/openid-sharedsignals-framework-1_0.html#name-verification-event) is emitted as a keepalive | 300000               |
+| scim.signals.rcv.unauthorized.retry.max      | Maximum 401 retries on a poll stream before disabling the stream                                                          | 10                   |
+| scim.signals.rcv.unauthorized.retry.delay    | Fixed delay (ms) between 401 retries on a poll stream                                                                     | 15000                |
+| scim.signals.rcv.status.check.interval       | Interval (ms) between transmitter `/status` re-checks while a poll stream is `paused`                                     | 30000                |
 
 ## Configuration Options
 
@@ -194,6 +202,98 @@ should use the same output push stream but only one node should be receiving eve
 In manual configuration mode, all stream parameters are configured using environment variables as described in the table
 above.
 
+## Operational Behavior
 
+i2scim mirrors the operational vocabulary defined by the goSignals project so that local stream behavior aligns with
+what an operator sees on the transmitter side. The vocabulary covers stream lifecycle, HTTP failure classification,
+remote `/status` interrogation, idle keepalive verification events, and RFC8935 §2.4 protocol-error handling.
 
+### Stream lifecycle (tri-state)
 
+Each `PushStream` and `PollStream` maintains a `status` of:
+
+| Status     | Meaning                                                                                                                                            | Persisted? |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------------|------------|
+| `enabled`  | Stream is healthy and producing/consuming events.                                                                                                  | yes        |
+| `paused`   | The remote peer reports the stream as paused (typically operator-driven on the goSignals side). i2scim auto-recovers when the remote re-enables.   | no         |
+| `disabled` | A terminal failure was observed (403, 4xx-other, exhausted retries, RFC8935 protocol error). Operator intervention is required.                    | yes        |
+
+`paused` is **never written to `ssfConfig.json`** — it is a runtime-only state derived from peer status. On restart,
+the stream re-enters `enabled` and a successful first push or poll re-derives the true state.
+
+A short structured `errorMsg` accompanies any `disabled` transition (for example
+`"403 Forbidden: stream revoked"` or `"RFC8935 invalid_audience: bad aud; jti=..."`).
+
+### HTTP failure classification
+
+Both push and poll responses are classified into a small set of categories. The push table includes RFC8935 §2.4
+detection on `400`; the poll table is otherwise identical.
+
+| Response                              | Action                                                                                                          |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `2xx`                                 | Success.                                                                                                        |
+| Transport error / `5xx`               | Exponential backoff (`retry.interval` → `retry.maxInterval`), capped at `retry.max` attempts. T1 fires.         |
+| `401 Unauthorized`                    | Fixed-delay retry (`unauthorized.retry.delay`), capped at `unauthorized.retry.max`, then disable.               |
+| `403 Forbidden`                       | Immediate disable (the stream has been revoked or is unauthorized at the policy layer).                         |
+| `429 Too Many Requests`               | Honor `Retry-After`; no attempt cap.                                                                            |
+| `4xx` (other)                         | Immediate disable.                                                                                              |
+| `400 Bad Request` with RFC8935 body   | Parse the `err` field per RFC8935 §2.4. Disable with a structured `errorMsg`. See below for the JWS carve-out. |
+
+Once a stream is `disabled`, normal event flow stops until an operator re-enables it.
+
+### `/status` interrogation (T1 and T2)
+
+T1 ("reactive") and T2 ("pre-flight") use the SSF transmitter `/status` endpoint to discover whether the remote stream
+is `enabled`, `paused`, or `disabled` from the transmitter's perspective:
+
+- **T1** runs after a transport/5xx failure or any failure where the remote may have entered a non-`enabled` state. If
+  the remote reports `paused`, the local stream transitions to `paused` (and a paused-recheck task takes over).
+- **T2** runs before the first push or poll after init/restart. It cheaply verifies the remote is healthy without
+  triggering retry storms when the remote was paused before i2scim started.
+
+The `/status` URL is discovered lazily:
+
+1. Fetch the SSF [well-known configuration](https://openid.net/specs/openid-sharedsignals-framework-1_0.txt) and use
+   its declared `status_endpoint`.
+2. If the well-known is unreachable, fall back to a derived URL (path-segment replacement) **once**, then continue with
+   exponential backoff.
+3. If the well-known is reachable but does not declare a `status_endpoint`, T1 is permanently skipped for that stream.
+
+Well-known failure alone never causes a stream to be disabled.
+
+### Paused-recheck
+
+When a stream enters `paused`, a per-stream task polls the remote `/status` every
+`scim.signals.{pub|rcv}.status.check.interval` ms. When the remote reports `enabled`, the local stream automatically
+recovers and resumes producing/consuming events. No operator action is required to recover from `paused`.
+
+### Idle keepalive verification (push only)
+
+Push streams emit an SSF
+[verification event](https://openid.net/specs/openid-sharedsignals-framework-1_0.html#name-verification-event)
+when no event has been pushed for `scim.signals.pub.idle.verify.interval` ms. The verification event is signed with the
+issuer key (or unsigned if `pub.algNone.override=true`) and is delivered through the same push channel. It serves as a
+liveness check so a long-idle stream does not silently rot.
+
+The keepalive is **suppressed while the stream is `paused` or in active retry backoff**. After a restart the idle timer
+resets, so the first verification event will fire one full interval after restart even if the stream was idle
+beforehand.
+
+### RFC8935 §2.4 protocol errors
+
+When a push receives `400` with an RFC8935-shaped JSON body, the `err` field is matched against the documented codes
+(`authentication_failed`, `invalid_request`, `invalid_audience`, `invalid_issuer`, `invalid_key`,
+`jws_signature_failed`, `jwe_decryption_failed`). The stream is disabled with
+`errorMsg = "RFC8935 <code>: <description>; jti=<jti>"`.
+
+A single carve-out applies: `jws_signature_failed` triggers a one-time PEM reload of the issuer private key from
+`scim.signals.pub.pem.path` / `scim.signals.pub.pem.value` followed by a single retry of the SET. If the retry also
+fails, the stream is disabled. When `pub.algNone.override=true`, this carve-out does not apply (there is no key to
+reload) and the stream is disabled immediately.
+
+### `ssfConfig.json` migration
+
+`ssfConfig.json` files written by pre-PRD-A builds used a boolean `errorState` field. On load, the file is migrated
+in-place: `errorState=true` becomes `status=disabled` with `errorMsg="migrated from legacy errorState"`, and
+`errorState=false` becomes `status=enabled`. New builds only ever write `status` and `errorMsg`. Rolling back to a
+pre-PRD-A build will not understand the new shape.

--- a/docs/Signals.md
+++ b/docs/Signals.md
@@ -259,6 +259,11 @@ The `/status` URL is discovered lazily:
    exponential backoff.
 3. If the well-known is reachable but does not declare a `status_endpoint`, T1 is permanently skipped for that stream.
 
+Each probe issues `GET <status_endpoint>?stream_id=<id>` per
+[SSF §7.1.2](https://openid.net/specs/openid-sharedsignals-framework-1_0.html#name-reading-a-streams-status). The
+`stream_id` is the local stream's id (the same id used during stream registration). If a stream has no id (e.g.
+incomplete configuration) the probe is skipped and the stream falls back to ordinary retry/backoff.
+
 Well-known failure alone never causes a stream to be disabled.
 
 ### Paused-recheck

--- a/i2scim-server/pom.xml
+++ b/i2scim-server/pom.xml
@@ -188,6 +188,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/LoadScimClusterTest.java</exclude>
+                        <exclude>**/SignalsGoSignalsIT.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/i2scim-server/pom.xml
+++ b/i2scim-server/pom.xml
@@ -138,6 +138,12 @@
             <version>1.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/i2scim-server/src/main/java/com/independentid/set/SecurityEventToken.java
+++ b/i2scim-server/src/main/java/com/independentid/set/SecurityEventToken.java
@@ -131,7 +131,9 @@ public class SecurityEventToken {
 
     @JsonSetter("txn")
     public String getTxn() throws MalformedClaimException {
-        return this.claims.get("txn").asText();
+        // Per RFC 8417 §2.2 "txn" is OPTIONAL — return null when absent (e.g. SSF verification events).
+        JsonNode txnNode = this.claims.get("txn");
+        return txnNode == null ? null : txnNode.asText();
     }
 
     @JsonSetter("toe")

--- a/i2scim-server/src/main/java/com/independentid/signals/FailureClassification.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/FailureClassification.java
@@ -19,4 +19,6 @@ public sealed interface FailureClassification {
     record RateLimited429(int code, String reason, Optional<Duration> retryAfter) implements FailureClassification {}
 
     record OtherClient4xx(int code, String body) implements FailureClassification {}
+
+    record Rfc8935(Rfc8935Error error) implements FailureClassification {}
 }

--- a/i2scim-server/src/main/java/com/independentid/signals/FailureClassification.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/FailureClassification.java
@@ -1,0 +1,22 @@
+package com.independentid.signals;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+public sealed interface FailureClassification {
+
+    record Success() implements FailureClassification {}
+
+    record Transport(IOException cause) implements FailureClassification {}
+
+    record Server5xx(int code, String reason) implements FailureClassification {}
+
+    record Unauthorized401(String reason) implements FailureClassification {}
+
+    record Forbidden403(String reason) implements FailureClassification {}
+
+    record RateLimited429(int code, String reason, Optional<Duration> retryAfter) implements FailureClassification {}
+
+    record OtherClient4xx(int code, String body) implements FailureClassification {}
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/HttpFailureClassifier.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/HttpFailureClassifier.java
@@ -1,0 +1,61 @@
+package com.independentid.signals;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+final class HttpFailureClassifier {
+
+    private HttpFailureClassifier() {
+    }
+
+    static FailureClassification classifyHttp(int httpCode, String reason, byte[] body, String retryAfterHeader) {
+        if (httpCode >= 200 && httpCode < 300) {
+            return new FailureClassification.Success();
+        }
+        if (httpCode == 401) {
+            return new FailureClassification.Unauthorized401(httpCode + " " + reason);
+        }
+        if (httpCode == 403) {
+            return new FailureClassification.Forbidden403(httpCode + " " + reason);
+        }
+        if (httpCode == 429) {
+            return new FailureClassification.RateLimited429(httpCode, reason, parseRetryAfter(retryAfterHeader));
+        }
+        if (httpCode >= 500 && httpCode < 600) {
+            return new FailureClassification.Server5xx(httpCode, reason);
+        }
+        if (httpCode >= 400 && httpCode < 500) {
+            return new FailureClassification.OtherClient4xx(httpCode, body == null ? "" : new String(body));
+        }
+        throw new IllegalArgumentException("Unsupported HTTP code: " + httpCode);
+    }
+
+    static FailureClassification classifyTransport(IOException cause) {
+        return new FailureClassification.Transport(cause);
+    }
+
+    static Optional<Duration> parseRetryAfter(String header) {
+        if (header == null || header.isBlank()) {
+            return Optional.empty();
+        }
+        String trimmed = header.trim();
+        try {
+            long seconds = Long.parseLong(trimmed);
+            return Optional.of(Duration.ofSeconds(seconds));
+        } catch (NumberFormatException ignored) {
+            try {
+                ZonedDateTime when = ZonedDateTime.parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME);
+                Duration delay = Duration.between(ZonedDateTime.now(), when);
+                if (delay.isNegative()) {
+                    return Optional.of(Duration.ZERO);
+                }
+                return Optional.of(delay);
+            } catch (Exception alsoIgnored) {
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/PollFailureClassifier.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PollFailureClassifier.java
@@ -1,0 +1,17 @@
+package com.independentid.signals;
+
+import java.io.IOException;
+
+public final class PollFailureClassifier {
+
+    private PollFailureClassifier() {
+    }
+
+    public static FailureClassification classify(int httpCode, String reason, byte[] body, String retryAfterHeader) {
+        return HttpFailureClassifier.classifyHttp(httpCode, reason, body, retryAfterHeader);
+    }
+
+    public static FailureClassification classify(IOException cause) {
+        return HttpFailureClassifier.classifyTransport(cause);
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.Key;
 import java.security.PublicKey;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -57,9 +58,11 @@ public class PollStream {
     public int maxRetries = 10;
     public int initialDelay = 2000;
     public int maxDelay = 300000;
+    public int unauthorizedRetryMax = 10;
+    public int unauthorizedRetryDelay = 15000;
 
     @JsonIgnore
-    CloseableHttpClient client;
+    public CloseableHttpClient client;
 
     public void setSslContext(javax.net.ssl.SSLContext sslContext) {
         if (sslContext != null) {
@@ -145,19 +148,22 @@ public class PollStream {
             ackNode.add(item);
         }
 
-        int attempt = 0;
-        long delay = this.initialDelay;
-
         if (this.client == null)
             setSslContext(null);
 
-        while (attempt <= retries && !Thread.currentThread().isInterrupted()) {
-            // Check for interruption before each attempt
-            if (Thread.currentThread().isInterrupted()) {
-                logger.info("Polling aborted - thread interrupted before attempt " + (attempt + 1));
-                return eventMap;
-            }
+        boolean shutdownMode = (retries == 0);
+        RetryStrategyConfig retryConfig = new RetryStrategyConfig(
+                retries,
+                Duration.ofMillis(this.initialDelay),
+                Duration.ofMillis(this.maxDelay),
+                this.unauthorizedRetryMax,
+                Duration.ofMillis(this.unauthorizedRetryDelay)
+        );
 
+        int attempt = 0;
+
+        while (!Thread.currentThread().isInterrupted()) {
+            FailureClassification classification;
             try {
                 if (attempt > 0)
                     logger.info("Polling " + this.endpointUrl + " (Attempt " + (attempt + 1) + ")");
@@ -168,53 +174,27 @@ public class PollStream {
                 if (!this.authorization.equals("NONE")) {
                     pollRequest.setHeader("Authorization", this.authorization);
                 }
-
                 StringEntity bodyEntity = new StringEntity(reqNode.toPrettyString(), ContentType.APPLICATION_JSON);
                 pollRequest.setEntity(bodyEntity);
 
                 try (CloseableHttpResponse resp = client.execute(pollRequest)) {
                     int statusCode = resp.getCode();
-                    if (statusCode >= 400) {
-                        if (statusCode == 429 || statusCode >= 500) {
-                            logger.warn("Retryable error response: " + statusCode + " " + resp.getReasonPhrase());
-                            // Fall through to retry logic below
-                        } else {
-                            // Fatal error
-                            switch (statusCode) {
-                                case HttpStatus.SC_UNAUTHORIZED:
-                                    logger.error("Poll response was an Authorization Error. Check poll authorization configuration.");
-                                    break;
-                                case HttpStatus.SC_BAD_REQUEST:
-                                    logger.error("Received BAD request response.");
-                                    HttpEntity respEntity = resp.getEntity();
-                                    if (respEntity != null) {
-                                        byte[] respBytes = respEntity.getContent().readAllBytes();
-                                        String msg = new String(respBytes);
-                                        logger.error("\n" + msg);
-                                    }
-                                    break;
-                                default:
-                                    logger.error("Error response: " + statusCode + " " + resp.getReasonPhrase());
-                            }
-                            logger.error("POLLING DISABLED.");
-                            this.state.transitionTo(StreamStatus.DISABLED, statusCode + " " + resp.getReasonPhrase());
-                            return eventMap;
-                        }
-                    } else {
-                        // Success path
-                        // Update the acks pending list
+                    String reason = resp.getReasonPhrase();
+                    HttpEntity respEntity = resp.getEntity();
+                    byte[] body = (respEntity == null) ? null : respEntity.getContent().readAllBytes();
+                    String retryAfter = headerValue(resp, "Retry-After");
+                    classification = PollFailureClassifier.classify(statusCode, reason, body, retryAfter);
+
+                    if (classification instanceof FailureClassification.Success) {
                         if (statusCode == HttpStatus.SC_OK && !acknowledgements.isEmpty()) {
                             logger.info("Updating acknowledgments");
                             for (String item : acknowledgements) {
                                 SignalsEventHandler.acksPending.remove(item);
                             }
                         }
-                        HttpEntity respEntity = resp.getEntity();
-                        if (respEntity != null) {
-                            byte[] respBytes = respEntity.getContent().readAllBytes();
-                            JsonNode respNode = JsonUtil.getJsonTree(respBytes);
+                        if (body != null) {
+                            JsonNode respNode = JsonUtil.getJsonTree(body);
                             JsonNode setNode = respNode.get("sets");
-
                             if (setNode != null && setNode.isObject()) {
                                 for (JsonNode item : setNode) {
                                     String tokenEncoded = item.textValue();
@@ -224,76 +204,94 @@ public class PollStream {
                                         logger.info("Received Event: " + token.getJti());
                                     } catch (InvalidJwtException | JoseException e) {
                                         logger.error("Invalid token received: " + e.getMessage());
-                                        // TODO Need to respond with error ack
                                     }
                                 }
                             }
                         }
                         return eventMap;
                     }
+                    logger.warn("Poll response classified as " + classification.getClass().getSimpleName()
+                            + " (code=" + statusCode + ")");
                 }
             } catch (IOException e) {
-                // Check if this was caused by interruption
                 if (Thread.currentThread().isInterrupted()) {
                     logger.info("Polling aborted - thread interrupted during HTTP request");
                     return eventMap;
                 }
-                // Walk the cause chain to find TLS/SSL root cause
-                Throwable root = e;
-                while (root.getCause() != null) root = root.getCause();
-                boolean isTls = e instanceof javax.net.ssl.SSLException
-                        || root instanceof javax.net.ssl.SSLException
-                        || e.getClass().getName().contains("SSL")
-                        || root.getClass().getName().contains("SSL");
-                if (isTls) {
-                    logger.warn("TLS/SSL error while polling {} (attempt {}): [{}] {}{}",
-                            this.endpointUrl, attempt + 1,
-                            e.getClass().getSimpleName(), e.getMessage(),
-                            root != e ? " caused by [" + root.getClass().getSimpleName() + "] " + root.getMessage() : "",
-                            e);
-                } else {
-                    logger.warn("Communications error while polling {} (attempt {}): [{}] {}",
-                            this.endpointUrl, attempt + 1,
-                            e.getClass().getSimpleName(), e.getMessage(), e);
-                }
+                logTransportError(e, attempt);
+                classification = PollFailureClassifier.classify(e);
             } catch (Exception e) {
-                // Catch unexpected runtime exceptions (e.g. NPE, IllegalStateException from stale SSLContext)
                 if (Thread.currentThread().isInterrupted()) {
                     logger.info("Polling aborted - thread interrupted during HTTP request");
                     return eventMap;
                 }
                 logger.error("Unexpected error during poll {} (attempt {}): [{}] {}",
-                        this.endpointUrl, attempt + 1,
-                        e.getClass().getName(), e.getMessage(), e);
-                // Treat as retryable — fall through to retry logic
+                        this.endpointUrl, attempt + 1, e.getClass().getName(), e.getMessage(), e);
+                classification = PollFailureClassifier.classify(new IOException(e));
             }
 
-            attempt++;
-            if (attempt > retries) {
-                if (retries > 0) {
-                    logger.error("Max retries reached. POLLING DISABLED.");
-                    this.state.transitionTo(StreamStatus.DISABLED, "Max retries reached after " + retries + " attempts");
-                }
-                break;
-            }
-
-            // Check for interruption before sleeping
-            if (Thread.currentThread().isInterrupted()) {
-                logger.info("Polling aborted - thread interrupted before retry delay");
+            if (shutdownMode) {
                 return eventMap;
             }
 
-            try {
-                logger.info("Retrying in " + delay + "ms...");
-                Thread.sleep(delay);
-                delay = Math.min(delay * 2, maxDelay);
-            } catch (InterruptedException ie) {
-                logger.info("Interrupted while waiting for retry");
-                Thread.currentThread().interrupt();
-                break;
+            RetryDecision decision = RetryStrategy.decide(classification, attempt, retryConfig);
+            switch (decision) {
+                case RetryDecision.Disable d -> {
+                    logger.error("POLLING DISABLED: " + d.reason());
+                    this.state.transitionTo(StreamStatus.DISABLED, d.reason());
+                    return eventMap;
+                }
+                case RetryDecision.SleepThenRetry s -> {
+                    if (!sleep(s.delay().toMillis())) return eventMap;
+                    attempt++;
+                }
+                case RetryDecision.RetryNoCap n -> {
+                    if (!sleep(n.delay().toMillis())) return eventMap;
+                    attempt++;
+                }
             }
         }
         return eventMap;
+    }
+
+    private boolean sleep(long ms) {
+        if (Thread.currentThread().isInterrupted()) {
+            return false;
+        }
+        try {
+            logger.info("Retrying in " + ms + "ms...");
+            Thread.sleep(ms);
+            return !Thread.currentThread().isInterrupted();
+        } catch (InterruptedException ie) {
+            logger.info("Interrupted while waiting for retry");
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private void logTransportError(IOException e, int attempt) {
+        Throwable root = e;
+        while (root.getCause() != null) root = root.getCause();
+        boolean isTls = e instanceof javax.net.ssl.SSLException
+                || root instanceof javax.net.ssl.SSLException
+                || e.getClass().getName().contains("SSL")
+                || root.getClass().getName().contains("SSL");
+        if (isTls) {
+            logger.warn("TLS/SSL error while polling {} (attempt {}): [{}] {}{}",
+                    this.endpointUrl, attempt + 1,
+                    e.getClass().getSimpleName(), e.getMessage(),
+                    root != e ? " caused by [" + root.getClass().getSimpleName() + "] " + root.getMessage() : "",
+                    e);
+        } else {
+            logger.warn("Communications error while polling {} (attempt {}): [{}] {}",
+                    this.endpointUrl, attempt + 1,
+                    e.getClass().getSimpleName(), e.getMessage(), e);
+        }
+    }
+
+    private static String headerValue(CloseableHttpResponse resp, String name) {
+        var header = resp.getFirstHeader(name);
+        return header == null ? null : header.getValue();
     }
 
     public void Close() throws IOException {

--- a/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.security.Key;
 import java.security.PublicKey;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class PollStream {
     private final static Logger logger = LoggerFactory.getLogger(PollStream.class);
@@ -60,6 +62,13 @@ public class PollStream {
     public int maxDelay = 300000;
     public int unauthorizedRetryMax = 10;
     public int unauthorizedRetryDelay = 15000;
+    public int statusCheckInterval = 30000;
+
+    @JsonIgnore
+    public StatusEndpointResolver statusResolver;
+
+    @JsonIgnore
+    private final java.util.concurrent.atomic.AtomicBoolean preflightDone = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     @JsonIgnore
     public CloseableHttpClient client;
@@ -152,6 +161,14 @@ public class PollStream {
             setSslContext(null);
 
         boolean shutdownMode = (retries == 0);
+
+        // T2 — pre-flight status check before first poll after init/restart (skip in shutdown-mode)
+        if (!shutdownMode && preflightDone.compareAndSet(false, true)) {
+            if (probeRemoteAndTransitionIfNonEnabled("pre-flight")) {
+                return eventMap;
+            }
+        }
+
         RetryStrategyConfig retryConfig = new RetryStrategyConfig(
                 retries,
                 Duration.ofMillis(this.initialDelay),
@@ -234,6 +251,14 @@ public class PollStream {
                 return eventMap;
             }
 
+            // T1 — interrogate transmitter /status before backoff on transport/5xx
+            if (classification instanceof FailureClassification.Transport
+                    || classification instanceof FailureClassification.Server5xx) {
+                if (probeRemoteAndTransitionIfNonEnabled("on-failure")) {
+                    return eventMap;
+                }
+            }
+
             RetryDecision decision = RetryStrategy.decide(classification, attempt, retryConfig);
             switch (decision) {
                 case RetryDecision.Disable d -> {
@@ -252,6 +277,62 @@ public class PollStream {
             }
         }
         return eventMap;
+    }
+
+    public void pausedRecheck() {
+        if (this.state.getStatus() != StreamStatus.PAUSED || this.statusResolver == null) {
+            return;
+        }
+        URI host = transmitterHost();
+        if (host == null) return;
+        Optional<URI> statusUrl = this.statusResolver.resolve(host, URI.create(this.endpointUrl));
+        if (statusUrl.isEmpty()) return;
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        switch (remote) {
+            case ENABLED -> this.state.transitionTo(StreamStatus.ENABLED, null);
+            case DISABLED -> this.state.transitionTo(StreamStatus.DISABLED,
+                    "Transmitter /status reports disabled (paused-recheck)");
+            case PAUSED, UNKNOWN -> {}
+        }
+    }
+
+    boolean probeRemoteAndTransitionIfNonEnabled(String context) {
+        if (this.statusResolver == null) {
+            return false;
+        }
+        URI host = transmitterHost();
+        if (host == null) {
+            return false;
+        }
+        Optional<URI> statusUrl = this.statusResolver.resolve(host, URI.create(this.endpointUrl));
+        if (statusUrl.isEmpty()) {
+            return false;
+        }
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        switch (remote) {
+            case PAUSED -> {
+                this.state.transitionTo(StreamStatus.PAUSED,
+                        "Transmitter /status reports paused (" + context + ")");
+                return true;
+            }
+            case DISABLED -> {
+                this.state.transitionTo(StreamStatus.DISABLED,
+                        "Transmitter /status reports disabled (" + context + ")");
+                return true;
+            }
+            default -> {
+                return false;
+            }
+        }
+    }
+
+    URI transmitterHost() {
+        try {
+            URI endpoint = URI.create(this.endpointUrl);
+            return new URI(endpoint.getScheme(), endpoint.getAuthority(), null, null, null);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private boolean sleep(long ms) {

--- a/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
@@ -287,7 +287,7 @@ public class PollStream {
         if (host == null) return;
         Optional<URI> statusUrl = this.statusResolver.resolve(host, URI.create(this.endpointUrl));
         if (statusUrl.isEmpty()) return;
-        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.streamId, this.authorization);
         switch (remote) {
             case ENABLED -> this.state.transitionTo(StreamStatus.ENABLED, null);
             case DISABLED -> this.state.transitionTo(StreamStatus.DISABLED,
@@ -308,7 +308,7 @@ public class PollStream {
         if (statusUrl.isEmpty()) {
             return false;
         }
-        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.streamId, this.authorization);
         switch (remote) {
             case PAUSED -> {
                 this.state.transitionTo(StreamStatus.PAUSED,

--- a/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PollStream.java
@@ -1,6 +1,7 @@
 package com.independentid.signals;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -48,8 +49,10 @@ public class PollStream {
     int timeOutSecs = 3600; // 1 hour by default
     int maxEvents = 1000;
     boolean returnImmediately = false; // long polling
-    boolean errorState = false;
     public String issJwksUrl;
+
+    @JsonUnwrapped
+    public StreamStateHolder state = new StreamStateHolder();
 
     public int maxRetries = 10;
     public int initialDelay = 2000;
@@ -194,7 +197,7 @@ public class PollStream {
                                     logger.error("Error response: " + statusCode + " " + resp.getReasonPhrase());
                             }
                             logger.error("POLLING DISABLED.");
-                            this.errorState = true;
+                            this.state.transitionTo(StreamStatus.DISABLED, statusCode + " " + resp.getReasonPhrase());
                             return eventMap;
                         }
                     } else {
@@ -267,9 +270,10 @@ public class PollStream {
 
             attempt++;
             if (attempt > retries) {
-                if (retries > 0)
+                if (retries > 0) {
                     logger.error("Max retries reached. POLLING DISABLED.");
-                this.errorState = (retries > 0);
+                    this.state.transitionTo(StreamStatus.DISABLED, "Max retries reached after " + retries + " attempts");
+                }
                 break;
             }
 

--- a/i2scim-server/src/main/java/com/independentid/signals/PushFailureClassifier.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushFailureClassifier.java
@@ -1,0 +1,17 @@
+package com.independentid.signals;
+
+import java.io.IOException;
+
+public final class PushFailureClassifier {
+
+    private PushFailureClassifier() {
+    }
+
+    public static FailureClassification classify(int httpCode, String reason, byte[] body, String retryAfterHeader) {
+        return HttpFailureClassifier.classifyHttp(httpCode, reason, body, retryAfterHeader);
+    }
+
+    public static FailureClassification classify(IOException cause) {
+        return HttpFailureClassifier.classifyTransport(cause);
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/PushFailureClassifier.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushFailureClassifier.java
@@ -8,6 +8,11 @@ public final class PushFailureClassifier {
     }
 
     public static FailureClassification classify(int httpCode, String reason, byte[] body, String retryAfterHeader) {
+        if (httpCode == 400) {
+            return Rfc8935ErrorParser.parse(body)
+                    .map(err -> (FailureClassification) new FailureClassification.Rfc8935(err))
+                    .orElseGet(() -> HttpFailureClassifier.classifyHttp(httpCode, reason, body, retryAfterHeader));
+        }
         return HttpFailureClassifier.classifyHttp(httpCode, reason, body, retryAfterHeader);
     }
 

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -19,9 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
 import java.security.Key;
 import java.security.PublicKey;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PushStream {
@@ -48,6 +50,13 @@ public class PushStream {
     public int maxDelay = 300000;
     public int unauthorizedRetryMax = 10;
     public int unauthorizedRetryDelay = 15000;
+    public int statusCheckInterval = 30000;
+
+    @JsonIgnore
+    public StatusEndpointResolver statusResolver;
+
+    @JsonIgnore
+    private final java.util.concurrent.atomic.AtomicBoolean preflightDone = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     @JsonIgnore
     public CloseableHttpClient client;
@@ -126,6 +135,13 @@ public class PushStream {
         if (this.client == null)
             setSslContext(null);
 
+        // T2 — pre-flight status check before first send after init/restart
+        if (preflightDone.compareAndSet(false, true)) {
+            if (probeRemoteAndTransitionIfNonEnabled("pre-flight")) {
+                return false;
+            }
+        }
+
         RetryStrategyConfig retryConfig = new RetryStrategyConfig(
                 this.maxRetries,
                 Duration.ofMillis(this.initialDelay),
@@ -171,6 +187,14 @@ public class PushStream {
                 classification = PushFailureClassifier.classify(e);
             }
 
+            // T1 — interrogate remote /status before backoff on transport/5xx
+            if (classification instanceof FailureClassification.Transport
+                    || classification instanceof FailureClassification.Server5xx) {
+                if (probeRemoteAndTransitionIfNonEnabled("on-failure")) {
+                    return false;
+                }
+            }
+
             RetryDecision decision = RetryStrategy.decide(classification, attempt, retryConfig);
             switch (decision) {
                 case RetryDecision.Disable d -> {
@@ -189,6 +213,67 @@ public class PushStream {
             }
         }
         return false;
+    }
+
+    /**
+     * Probe the receiver's /status endpoint and transition local state if remote reports
+     * non-ENABLED. Returns true if the caller should abort (state transitioned to PAUSED
+     * or DISABLED), false otherwise (continue normal retry/backoff).
+     */
+    public void pausedRecheck() {
+        if (this.state.getStatus() != StreamStatus.PAUSED || this.statusResolver == null) {
+            return;
+        }
+        URI host = receiverHost();
+        if (host == null) return;
+        Optional<URI> statusUrl = this.statusResolver.resolve(host, URI.create(this.endpointUrl));
+        if (statusUrl.isEmpty()) return;
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        switch (remote) {
+            case ENABLED -> this.state.transitionTo(StreamStatus.ENABLED, null);
+            case DISABLED -> this.state.transitionTo(StreamStatus.DISABLED,
+                    "Remote /status reports disabled (paused-recheck)");
+            case PAUSED, UNKNOWN -> {}
+        }
+    }
+
+    boolean probeRemoteAndTransitionIfNonEnabled(String context) {
+        if (this.statusResolver == null) {
+            return false;
+        }
+        URI receiverHost = receiverHost();
+        if (receiverHost == null) {
+            return false;
+        }
+        Optional<URI> statusUrl = this.statusResolver.resolve(receiverHost, URI.create(this.endpointUrl));
+        if (statusUrl.isEmpty()) {
+            return false;
+        }
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        switch (remote) {
+            case PAUSED -> {
+                this.state.transitionTo(StreamStatus.PAUSED,
+                        "Remote /status reports paused (" + context + ")");
+                return true;
+            }
+            case DISABLED -> {
+                this.state.transitionTo(StreamStatus.DISABLED,
+                        "Remote /status reports disabled (" + context + ")");
+                return true;
+            }
+            default -> {
+                return false;
+            }
+        }
+    }
+
+    URI receiverHost() {
+        try {
+            URI endpoint = URI.create(this.endpointUrl);
+            return new URI(endpoint.getScheme(), endpoint.getAuthority(), null, null, null);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private boolean sleep(long ms) {

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -1,6 +1,7 @@
 package com.independentid.signals;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.independentid.set.SecurityEventToken;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
@@ -37,14 +38,16 @@ public class PushStream {
     public String iss;
     public String aud;
     public String issJwksUrl;
-    public boolean errorState = false;
+
+    @JsonUnwrapped
+    public StreamStateHolder state = new StreamStateHolder();
 
     public int maxRetries = 10;
     public int initialDelay = 2000;
     public int maxDelay = 300000;
 
     @JsonIgnore
-    CloseableHttpClient client;
+    public CloseableHttpClient client;
 
     public void setSslContext(javax.net.ssl.SSLContext sslContext) {
         if (sslContext != null) {
@@ -78,7 +81,7 @@ public class PushStream {
     }
 
     public boolean pushEvent(SecurityEventToken event) {
-        if (this.errorState || this.shuttingDown.get())
+        if (this.state.getStatus() != StreamStatus.ENABLED || this.shuttingDown.get())
             return false;
         if (this.aud != null)
             event.setAud(this.aud);
@@ -146,17 +149,22 @@ public class PushStream {
                         // Fall through to retry logic
                     } else {
                         // Fatal error
+                        String reason;
                         if (code == 400) {
                             logger.error("Received BAD request response.");
                             HttpEntity respEntity = resp.getEntity();
+                            String body = "";
                             if (respEntity != null) {
                                 byte[] respBytes = respEntity.getContent().readAllBytes();
-                                String msg = new String(respBytes);
-                                logger.error("\n" + msg);
+                                body = new String(respBytes);
+                                logger.error("\n" + body);
                             }
-                        } else
+                            reason = code + " Bad Request: " + body;
+                        } else {
                             logger.error("Received fatal error on event submission: " + code + " " + resp.getReasonPhrase());
-                        this.errorState = true;
+                            reason = code + " " + resp.getReasonPhrase();
+                        }
+                        this.state.transitionTo(StreamStatus.DISABLED, reason);
                         return false;
                     }
                 }
@@ -171,7 +179,7 @@ public class PushStream {
             attempt++;
             if (attempt > this.maxRetries) {
                 logger.error("Max retries reached. Event push failed.");
-                this.errorState = true;
+                this.state.transitionTo(StreamStatus.DISABLED, "Max retries reached after " + this.maxRetries + " attempts");
                 break;
             }
 

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -261,7 +261,7 @@ public class PushStream {
         if (host == null) return;
         Optional<URI> statusUrl = this.statusResolver.resolve(host, URI.create(this.endpointUrl));
         if (statusUrl.isEmpty()) return;
-        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.streamId, this.authorization);
         switch (remote) {
             case ENABLED -> this.state.transitionTo(StreamStatus.ENABLED, null);
             case DISABLED -> this.state.transitionTo(StreamStatus.DISABLED,
@@ -282,7 +282,7 @@ public class PushStream {
         if (statusUrl.isEmpty()) {
             return false;
         }
-        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.authorization);
+        RemoteStatus remote = RemoteStatusProbe.probe(this.client, statusUrl.get(), this.streamId, this.authorization);
         switch (remote) {
             case PAUSED -> {
                 this.state.transitionTo(StreamStatus.PAUSED,

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -23,8 +23,10 @@ import java.net.URI;
 import java.security.Key;
 import java.security.PublicKey;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class PushStream {
     private final static Logger logger = LoggerFactory.getLogger(PushStream.class);
@@ -51,12 +53,16 @@ public class PushStream {
     public int unauthorizedRetryMax = 10;
     public int unauthorizedRetryDelay = 15000;
     public int statusCheckInterval = 30000;
+    public int idleVerifyInterval = 300000;
 
     @JsonIgnore
     public StatusEndpointResolver statusResolver;
 
     @JsonIgnore
-    private final java.util.concurrent.atomic.AtomicBoolean preflightDone = new java.util.concurrent.atomic.AtomicBoolean(false);
+    private final AtomicBoolean preflightDone = new AtomicBoolean(false);
+
+    @JsonIgnore
+    private final AtomicReference<Instant> lastSuccessfulPush = new AtomicReference<>(Instant.now());
 
     @JsonIgnore
     public CloseableHttpClient client;
@@ -173,6 +179,10 @@ public class PushStream {
                     classification = PushFailureClassifier.classify(code, reason, body, retryAfterHeader);
 
                     if (classification instanceof FailureClassification.Success) {
+                        this.lastSuccessfulPush.set(Instant.now());
+                        if (this.state.getStatus() != StreamStatus.ENABLED) {
+                            this.state.transitionTo(StreamStatus.ENABLED, null);
+                        }
                         return true;
                     }
                     logger.warn("Push response classified as " + classification.getClass().getSimpleName()
@@ -265,6 +275,10 @@ public class PushStream {
                 return false;
             }
         }
+    }
+
+    public Instant getLastSuccessfulPush() {
+        return this.lastSuccessfulPush.get();
     }
 
     URI receiverHost() {

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.security.Key;
 import java.security.PublicKey;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class PushStream {
@@ -45,6 +46,8 @@ public class PushStream {
     public int maxRetries = 10;
     public int initialDelay = 2000;
     public int maxDelay = 300000;
+    public int unauthorizedRetryMax = 10;
+    public int unauthorizedRetryDelay = 15000;
 
     @JsonIgnore
     public CloseableHttpClient client;
@@ -120,13 +123,21 @@ public class PushStream {
             logger.error("Event signing error: " + e.getMessage());
             return false;
         }
-        int attempt = 0;
-        long delay = this.initialDelay;
-
         if (this.client == null)
             setSslContext(null);
 
-        while (attempt <= this.maxRetries && !this.shuttingDown.get()) {
+        RetryStrategyConfig retryConfig = new RetryStrategyConfig(
+                this.maxRetries,
+                Duration.ofMillis(this.initialDelay),
+                Duration.ofMillis(this.maxDelay),
+                this.unauthorizedRetryMax,
+                Duration.ofMillis(this.unauthorizedRetryDelay)
+        );
+
+        int attempt = 0;
+
+        while (!this.shuttingDown.get()) {
+            FailureClassification classification;
             try {
                 if (attempt > 0)
                     logger.info("Pushing event to " + this.endpointUrl + " (Attempt " + (attempt + 1) + ")");
@@ -140,33 +151,16 @@ public class PushStream {
 
                 try (CloseableHttpResponse resp = client.execute(req)) {
                     int code = resp.getCode();
-                    if (code >= 200 && code < 300) {
+                    String reason = resp.getReasonPhrase();
+                    byte[] body = readBody(resp);
+                    String retryAfterHeader = headerValue(resp, "Retry-After");
+                    classification = PushFailureClassifier.classify(code, reason, body, retryAfterHeader);
+
+                    if (classification instanceof FailureClassification.Success) {
                         return true;
                     }
-
-                    if (code == 429 || code >= 500) {
-                        logger.warn("Retryable error response: " + code + " " + resp.getReasonPhrase());
-                        // Fall through to retry logic
-                    } else {
-                        // Fatal error
-                        String reason;
-                        if (code == 400) {
-                            logger.error("Received BAD request response.");
-                            HttpEntity respEntity = resp.getEntity();
-                            String body = "";
-                            if (respEntity != null) {
-                                byte[] respBytes = respEntity.getContent().readAllBytes();
-                                body = new String(respBytes);
-                                logger.error("\n" + body);
-                            }
-                            reason = code + " Bad Request: " + body;
-                        } else {
-                            logger.error("Received fatal error on event submission: " + code + " " + resp.getReasonPhrase());
-                            reason = code + " " + resp.getReasonPhrase();
-                        }
-                        this.state.transitionTo(StreamStatus.DISABLED, reason);
-                        return false;
-                    }
+                    logger.warn("Push response classified as " + classification.getClass().getSimpleName()
+                            + " (code=" + code + ")");
                 }
             } catch (IOException e) {
                 if (this.shuttingDown.get()) {
@@ -174,31 +168,54 @@ public class PushStream {
                     return false;
                 }
                 logger.warn("Communications error while pushing event (attempt " + (attempt + 1) + "): " + e.getMessage());
+                classification = PushFailureClassifier.classify(e);
             }
 
-            attempt++;
-            if (attempt > this.maxRetries) {
-                logger.error("Max retries reached. Event push failed.");
-                this.state.transitionTo(StreamStatus.DISABLED, "Max retries reached after " + this.maxRetries + " attempts");
-                break;
-            }
-
-            if (this.shuttingDown.get()) {
-                logger.info("Push stream shutting down, aborting retry");
-                return false;
-            }
-
-            try {
-                logger.info("Retrying in " + delay + "ms...");
-                Thread.sleep(delay);
-                delay = Math.min(delay * 2, maxDelay);
-            } catch (InterruptedException ie) {
-                logger.warn("Interrupted while waiting for retry");
-                Thread.currentThread().interrupt();
-                break;
+            RetryDecision decision = RetryStrategy.decide(classification, attempt, retryConfig);
+            switch (decision) {
+                case RetryDecision.Disable d -> {
+                    logger.error("Push stream DISABLED: " + d.reason());
+                    this.state.transitionTo(StreamStatus.DISABLED, d.reason());
+                    return false;
+                }
+                case RetryDecision.SleepThenRetry s -> {
+                    if (!sleep(s.delay().toMillis())) return false;
+                    attempt++;
+                }
+                case RetryDecision.RetryNoCap n -> {
+                    if (!sleep(n.delay().toMillis())) return false;
+                    attempt++;
+                }
             }
         }
         return false;
+    }
+
+    private boolean sleep(long ms) {
+        if (this.shuttingDown.get()) {
+            logger.info("Push stream shutting down, aborting retry");
+            return false;
+        }
+        try {
+            logger.info("Retrying in " + ms + "ms...");
+            Thread.sleep(ms);
+            return !this.shuttingDown.get();
+        } catch (InterruptedException ie) {
+            logger.warn("Interrupted while waiting for retry");
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private static byte[] readBody(CloseableHttpResponse resp) throws IOException {
+        HttpEntity entity = resp.getEntity();
+        if (entity == null) return null;
+        return entity.getContent().readAllBytes();
+    }
+
+    private static String headerValue(CloseableHttpResponse resp, String name) {
+        var header = resp.getFirstHeader(name);
+        return header == null ? null : header.getValue();
     }
 
     public void Close() throws IOException {

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -39,7 +39,7 @@ public class PushStream {
     public Key issuerKey;
     @JsonIgnore
     public PublicKey receiverKey;
-    boolean isUnencrypted;
+    public boolean isUnencrypted;
     public String iss;
     public String aud;
     public String issJwksUrl;
@@ -57,6 +57,9 @@ public class PushStream {
 
     @JsonIgnore
     public StatusEndpointResolver statusResolver;
+
+    @JsonIgnore
+    public java.util.function.Supplier<Key> issuerKeyReloader;
 
     @JsonIgnore
     private final AtomicBoolean preflightDone = new AtomicBoolean(false);
@@ -157,6 +160,7 @@ public class PushStream {
         );
 
         int attempt = 0;
+        boolean jwsRetryAttempted = false;
 
         while (!this.shuttingDown.get()) {
             FailureClassification classification;
@@ -195,6 +199,25 @@ public class PushStream {
                 }
                 logger.warn("Communications error while pushing event (attempt " + (attempt + 1) + "): " + e.getMessage());
                 classification = PushFailureClassifier.classify(e);
+            }
+
+            // RFC8935 §2.4 jws_signature_failed carve-out: reload PEM and retry once
+            if (classification instanceof FailureClassification.Rfc8935 rfcErr
+                    && Rfc8935Error.JWS_SIGNATURE_FAILED.equals(rfcErr.error().code())
+                    && !this.isUnencrypted
+                    && !jwsRetryAttempted
+                    && this.issuerKeyReloader != null) {
+                jwsRetryAttempted = true;
+                this.issuerKey = this.issuerKeyReloader.get();
+                try {
+                    signed = event.JWS(this.issuerKey);
+                    logger.info("Reloaded issuer PEM and re-signed SET; retrying once");
+                    continue;
+                } catch (JoseException | MalformedClaimException e) {
+                    this.state.transitionTo(StreamStatus.DISABLED,
+                            "Failed to re-sign after PEM reload: " + e.getMessage());
+                    return false;
+                }
             }
 
             // T1 — interrogate remote /status before backoff on transport/5xx

--- a/i2scim-server/src/main/java/com/independentid/signals/RemoteStatus.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RemoteStatus.java
@@ -1,0 +1,8 @@
+package com.independentid.signals;
+
+public enum RemoteStatus {
+    ENABLED,
+    PAUSED,
+    DISABLED,
+    UNKNOWN
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RemoteStatusProbe.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RemoteStatusProbe.java
@@ -1,0 +1,58 @@
+package com.independentid.signals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.serializer.JsonUtil;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+
+public final class RemoteStatusProbe {
+
+    private static final Logger logger = LoggerFactory.getLogger(RemoteStatusProbe.class);
+
+    private RemoteStatusProbe() {
+    }
+
+    public static RemoteStatus probe(CloseableHttpClient client, URI statusUrl, String authorization) {
+        HttpGet req = new HttpGet(statusUrl);
+        if (authorization != null && !authorization.equals("NONE")) {
+            req.setHeader("Authorization", authorization);
+        }
+        try (CloseableHttpResponse resp = client.execute(req)) {
+            int code = resp.getCode();
+            if (code < 200 || code >= 300) {
+                logger.warn("Remote /status returned {} from {}", code, statusUrl);
+                return RemoteStatus.UNKNOWN;
+            }
+            HttpEntity entity = resp.getEntity();
+            if (entity == null) {
+                return RemoteStatus.UNKNOWN;
+            }
+            byte[] body = entity.getContent().readAllBytes();
+            JsonNode node = JsonUtil.getJsonTree(body);
+            JsonNode statusNode = node.get("status");
+            if (statusNode == null || !statusNode.isTextual()) {
+                return RemoteStatus.UNKNOWN;
+            }
+            return parseStatus(statusNode.asText());
+        } catch (Exception e) {
+            logger.warn("Remote /status probe failed for {}: {}", statusUrl, e.getMessage());
+            return RemoteStatus.UNKNOWN;
+        }
+    }
+
+    private static RemoteStatus parseStatus(String value) {
+        if (value == null) return RemoteStatus.UNKNOWN;
+        return switch (value.toLowerCase()) {
+            case "enabled" -> RemoteStatus.ENABLED;
+            case "paused" -> RemoteStatus.PAUSED;
+            case "disabled" -> RemoteStatus.DISABLED;
+            default -> RemoteStatus.UNKNOWN;
+        };
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RemoteStatusProbe.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RemoteStatusProbe.java
@@ -10,6 +10,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public final class RemoteStatusProbe {
 
@@ -18,15 +20,20 @@ public final class RemoteStatusProbe {
     private RemoteStatusProbe() {
     }
 
-    public static RemoteStatus probe(CloseableHttpClient client, URI statusUrl, String authorization) {
-        HttpGet req = new HttpGet(statusUrl);
+    public static RemoteStatus probe(CloseableHttpClient client, URI statusUrl, String streamId, String authorization) {
+        if (streamId == null || streamId.isEmpty()) {
+            logger.warn("Skipping /status probe at {}: missing stream_id (required by SSF §7.1.2)", statusUrl);
+            return RemoteStatus.UNKNOWN;
+        }
+        URI requestUri = withStreamId(statusUrl, streamId);
+        HttpGet req = new HttpGet(requestUri);
         if (authorization != null && !authorization.equals("NONE")) {
             req.setHeader("Authorization", authorization);
         }
         try (CloseableHttpResponse resp = client.execute(req)) {
             int code = resp.getCode();
             if (code < 200 || code >= 300) {
-                logger.warn("Remote /status returned {} from {}", code, statusUrl);
+                logger.warn("Remote /status returned {} from {}", code, requestUri);
                 return RemoteStatus.UNKNOWN;
             }
             HttpEntity entity = resp.getEntity();
@@ -41,9 +48,20 @@ public final class RemoteStatusProbe {
             }
             return parseStatus(statusNode.asText());
         } catch (Exception e) {
-            logger.warn("Remote /status probe failed for {}: {}", statusUrl, e.getMessage());
+            logger.warn("Remote /status probe failed for {}: {}", requestUri, e.getMessage());
             return RemoteStatus.UNKNOWN;
         }
+    }
+
+    static URI withStreamId(URI base, String streamId) {
+        String encoded = URLEncoder.encode(streamId, StandardCharsets.UTF_8);
+        String existingQuery = base.getRawQuery();
+        String separator = (existingQuery == null || existingQuery.isEmpty()) ? "?" : "&";
+        String suffix = base.getRawFragment() == null ? "" : "#" + base.getRawFragment();
+        String baseStr = base.toString();
+        int fragIdx = baseStr.indexOf('#');
+        String withoutFrag = fragIdx < 0 ? baseStr : baseStr.substring(0, fragIdx);
+        return URI.create(withoutFrag + separator + "stream_id=" + encoded + suffix);
     }
 
     private static RemoteStatus parseStatus(String value) {

--- a/i2scim-server/src/main/java/com/independentid/signals/RetryDecision.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RetryDecision.java
@@ -1,0 +1,12 @@
+package com.independentid.signals;
+
+import java.time.Duration;
+
+public sealed interface RetryDecision {
+
+    record SleepThenRetry(Duration delay) implements RetryDecision {}
+
+    record Disable(String reason) implements RetryDecision {}
+
+    record RetryNoCap(Duration delay) implements RetryDecision {}
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RetryStrategy.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RetryStrategy.java
@@ -26,6 +26,12 @@ public final class RetryStrategy {
                 Duration delay = r.retryAfter().orElseGet(() -> expBackoffDelay(attemptCount, config));
                 yield new RetryDecision.RetryNoCap(delay);
             }
+            case FailureClassification.Rfc8935 r -> {
+                Rfc8935Error err = r.error();
+                String suffix = err.jti().map(j -> "; jti=" + j).orElse("");
+                String desc = err.description() == null ? "" : ": " + err.description();
+                yield new RetryDecision.Disable("RFC8935 " + err.code() + desc + suffix);
+            }
         };
     }
 

--- a/i2scim-server/src/main/java/com/independentid/signals/RetryStrategy.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RetryStrategy.java
@@ -1,0 +1,52 @@
+package com.independentid.signals;
+
+import java.time.Duration;
+
+public final class RetryStrategy {
+
+    private RetryStrategy() {
+    }
+
+    public static RetryDecision decide(FailureClassification c, int attemptCount, RetryStrategyConfig config) {
+        return switch (c) {
+            case FailureClassification.Success ignored ->
+                    throw new IllegalArgumentException("Success has no retry decision");
+            case FailureClassification.Forbidden403 f -> new RetryDecision.Disable(f.reason());
+            case FailureClassification.OtherClient4xx o -> new RetryDecision.Disable(o.code() + " " + o.body());
+            case FailureClassification.Unauthorized401 u -> {
+                if (attemptCount >= config.unauthorizedRetryMax()) {
+                    yield new RetryDecision.Disable("401 attempts exhausted ("
+                            + config.unauthorizedRetryMax() + " x " + config.unauthorizedDelay().toMillis() + "ms)");
+                }
+                yield new RetryDecision.SleepThenRetry(config.unauthorizedDelay());
+            }
+            case FailureClassification.Server5xx s -> transportLikeBackoff(attemptCount, config);
+            case FailureClassification.Transport t -> transportLikeBackoff(attemptCount, config);
+            case FailureClassification.RateLimited429 r -> {
+                Duration delay = r.retryAfter().orElseGet(() -> expBackoffDelay(attemptCount, config));
+                yield new RetryDecision.RetryNoCap(delay);
+            }
+        };
+    }
+
+    private static RetryDecision transportLikeBackoff(int attemptCount, RetryStrategyConfig config) {
+        if (attemptCount >= config.transportRetryMax()) {
+            return new RetryDecision.Disable("transport recovery exceeded "
+                    + config.transportRetryMax() + " attempts");
+        }
+        return new RetryDecision.SleepThenRetry(expBackoffDelay(attemptCount, config));
+    }
+
+    private static Duration expBackoffDelay(int attemptCount, RetryStrategyConfig config) {
+        long initialMs = config.transportInitialDelay().toMillis();
+        long maxMs = config.transportMaxDelay().toMillis();
+        if (attemptCount >= 62) {
+            return Duration.ofMillis(maxMs);
+        }
+        long shifted = initialMs << attemptCount;
+        if (shifted < 0 || shifted > maxMs) {
+            return Duration.ofMillis(maxMs);
+        }
+        return Duration.ofMillis(shifted);
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RetryStrategyConfig.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RetryStrategyConfig.java
@@ -1,0 +1,12 @@
+package com.independentid.signals;
+
+import java.time.Duration;
+
+public record RetryStrategyConfig(
+        int transportRetryMax,
+        Duration transportInitialDelay,
+        Duration transportMaxDelay,
+        int unauthorizedRetryMax,
+        Duration unauthorizedDelay
+) {
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/Rfc8935Error.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/Rfc8935Error.java
@@ -1,0 +1,25 @@
+package com.independentid.signals;
+
+import java.util.Optional;
+import java.util.Set;
+
+public record Rfc8935Error(String code, String description, Optional<String> jti) {
+
+    public static final String AUTHENTICATION_FAILED = "authentication_failed";
+    public static final String INVALID_REQUEST = "invalid_request";
+    public static final String INVALID_AUDIENCE = "invalid_audience";
+    public static final String INVALID_ISSUER = "invalid_issuer";
+    public static final String INVALID_KEY = "invalid_key";
+    public static final String JWS_SIGNATURE_FAILED = "jws_signature_failed";
+    public static final String JWE_DECRYPTION_FAILED = "jwe_decryption_failed";
+
+    public static final Set<String> KNOWN_CODES = Set.of(
+            AUTHENTICATION_FAILED,
+            INVALID_REQUEST,
+            INVALID_AUDIENCE,
+            INVALID_ISSUER,
+            INVALID_KEY,
+            JWS_SIGNATURE_FAILED,
+            JWE_DECRYPTION_FAILED
+    );
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/Rfc8935ErrorParser.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/Rfc8935ErrorParser.java
@@ -1,0 +1,41 @@
+package com.independentid.signals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.serializer.JsonUtil;
+
+import java.util.Optional;
+
+public final class Rfc8935ErrorParser {
+
+    private Rfc8935ErrorParser() {
+    }
+
+    public static Optional<Rfc8935Error> parse(byte[] body) {
+        if (body == null || body.length == 0) {
+            return Optional.empty();
+        }
+        JsonNode root;
+        try {
+            root = JsonUtil.getJsonTree(body);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+        if (root == null || !root.isObject()) {
+            return Optional.empty();
+        }
+        JsonNode errNode = root.get("err");
+        if (errNode == null || !errNode.isTextual()) {
+            return Optional.empty();
+        }
+        String code = errNode.asText();
+        if (!Rfc8935Error.KNOWN_CODES.contains(code)) {
+            return Optional.empty();
+        }
+        JsonNode descNode = root.get("description");
+        String description = descNode == null || !descNode.isTextual() ? null : descNode.asText();
+        JsonNode jtiNode = root.get("jti");
+        Optional<String> jti = jtiNode == null || !jtiNode.isTextual()
+                ? Optional.empty() : Optional.of(jtiNode.asText());
+        return Optional.of(new Rfc8935Error(code, description, jti));
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -100,6 +101,8 @@ public class SignalsEventHandler implements IEventHandler {
 
     SignalsEventMapper mapper;
 
+    StreamMaintenanceScheduler scheduler;
+
     boolean ready = false;
 
     public SignalsEventHandler() {
@@ -156,11 +159,45 @@ public class SignalsEventHandler implements IEventHandler {
         // ensure that config,schema managers are initialized.
         Operation.initialize(configMgr);
 
+        this.scheduler = new StreamMaintenanceScheduler();
+        installStatusInterrogation();
+
         if (rcvEnabled) {
             logger.debug("Starting SET Polling Receiver...");
             this.receiverThread = new SignalsEventReceiver(configMgr, this, ssfClient);
         }
         ready = true;
+    }
+
+    private void installStatusInterrogation() {
+        PushStream push = ssfClient.getPushStream();
+        if (push != null && push.enabled) {
+            if (push.client == null) push.setSslContext(null);
+            push.statusResolver = new StatusEndpointResolver(push.client);
+            String key = "push:" + (push.streamId == null ? "default" : push.streamId);
+            push.state.addTransitionListener((oldS, newS) -> {
+                if (newS == StreamStatus.PAUSED) {
+                    scheduler.schedulePausedRecheck(key, push::pausedRecheck,
+                            Duration.ofMillis(push.statusCheckInterval));
+                } else if (oldS == StreamStatus.PAUSED) {
+                    scheduler.cancelPausedRecheck(key);
+                }
+            });
+        }
+        PollStream poll = ssfClient.getPollStream();
+        if (poll != null && poll.enabled) {
+            if (poll.client == null) poll.setSslContext(null);
+            poll.statusResolver = new StatusEndpointResolver(poll.client);
+            String key = "poll:" + (poll.streamId == null ? "default" : poll.streamId);
+            poll.state.addTransitionListener((oldS, newS) -> {
+                if (newS == StreamStatus.PAUSED) {
+                    scheduler.schedulePausedRecheck(key, poll::pausedRecheck,
+                            Duration.ofMillis(poll.statusCheckInterval));
+                } else if (oldS == StreamStatus.PAUSED) {
+                    scheduler.cancelPausedRecheck(key);
+                }
+            });
+        }
     }
 
     public boolean notEnabled() {
@@ -274,6 +311,9 @@ public class SignalsEventHandler implements IEventHandler {
             this.ssfClient.getPushStream().Close();
         } catch (IOException ignore) {
 
+        }
+        if (this.scheduler != null) {
+            this.scheduler.shutdown();
         }
         acksPending.clear();
         pendingPubOps.clear();

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -176,6 +176,7 @@ public class SignalsEventHandler implements IEventHandler {
         if (push != null && push.enabled) {
             if (push.client == null) push.setSslContext(null);
             push.statusResolver = new StatusEndpointResolver(push.client);
+            push.issuerKeyReloader = configProps::getIssuerPrivateKey;
             String key = "push:" + (push.streamId == null ? "default" : push.streamId);
             Runnable idleVerifyRun = () -> runIdleVerify(push);
             push.state.addTransitionListener((oldS, newS) -> {

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -100,8 +100,6 @@ public class SignalsEventHandler implements IEventHandler {
 
     SignalsEventMapper mapper;
 
-    static boolean isErrorState = false;
-
     boolean ready = false;
 
     public SignalsEventHandler() {
@@ -258,8 +256,8 @@ public class SignalsEventHandler implements IEventHandler {
     @Override
     public boolean isProducing() {
         if (ssfClient == null || ssfClient.getPushStream() == null)
-            return !isErrorState;
-        return !isErrorState && !ssfClient.getPushStream().errorState;
+            return true;
+        return ssfClient.getPushStream().state.getStatus() == StreamStatus.ENABLED;
     }
 
     @Override

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -39,8 +39,10 @@ import org.jose4j.jwt.MalformedClaimException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.independentid.set.SecurityEventToken;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -175,14 +177,27 @@ public class SignalsEventHandler implements IEventHandler {
             if (push.client == null) push.setSslContext(null);
             push.statusResolver = new StatusEndpointResolver(push.client);
             String key = "push:" + (push.streamId == null ? "default" : push.streamId);
+            Runnable idleVerifyRun = () -> runIdleVerify(push);
             push.state.addTransitionListener((oldS, newS) -> {
                 if (newS == StreamStatus.PAUSED) {
                     scheduler.schedulePausedRecheck(key, push::pausedRecheck,
                             Duration.ofMillis(push.statusCheckInterval));
+                    scheduler.cancelIdleVerify(key);
                 } else if (oldS == StreamStatus.PAUSED) {
                     scheduler.cancelPausedRecheck(key);
+                    if (newS == StreamStatus.ENABLED) {
+                        scheduler.scheduleIdleVerify(key, idleVerifyRun,
+                                Duration.ofMillis(push.idleVerifyInterval));
+                    }
+                } else if (newS == StreamStatus.DISABLED) {
+                    scheduler.cancelIdleVerify(key);
                 }
             });
+            // Initial schedule (state holder starts in ENABLED)
+            if (push.state.getStatus() == StreamStatus.ENABLED) {
+                scheduler.scheduleIdleVerify(key, idleVerifyRun,
+                        Duration.ofMillis(push.idleVerifyInterval));
+            }
         }
         PollStream poll = ssfClient.getPollStream();
         if (poll != null && poll.enabled) {
@@ -198,6 +213,17 @@ public class SignalsEventHandler implements IEventHandler {
                 }
             });
         }
+    }
+
+    private void runIdleVerify(PushStream push) {
+        if (push.state.getStatus() != StreamStatus.ENABLED) return;
+        Instant last = push.getLastSuccessfulPush();
+        if (last == null) return;
+        long idleMs = Duration.between(last, Instant.now()).toMillis();
+        if (idleMs < push.idleVerifyInterval) return;
+        SecurityEventToken verify = VerifyEventBuilder.build(push);
+        logger.info("Idle threshold reached on push stream; sending verify event jti={}", verify.getJti());
+        push.pushEvent(verify);
     }
 
     public boolean notEnabled() {

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -248,13 +248,23 @@ public class SignalsEventHandler implements IEventHandler {
             Operation op = mapper.MapSetToOperation(event, configMgr.getSchemaManager());
             if (logger.isDebugEnabled())
                 logger.debug("\tReceived SCIM Event:\n" + event.toPrettyString());
+            if (op == null) {
+                // Non-provisioning event (e.g. SSF verification) or unsubscribed event type — ack and skip.
+                if (logger.isDebugEnabled())
+                    logger.debug("Acking non-provisioning event jti={}", event.getJti());
+                acksPending.add(event.getJti());
+                return;
+            }
             try {
-                ScimResource txnResource = backendHandler.getTransactionRecord(event.getTxn());
-                if (txnResource != null) {
-                    // Even though we've seen this, we want to ack it so we don't get it again.
-                    acksPending.add(event.getJti());
-                    logger.warn("Duplicate transaction detected, ignoring.");
-                    return;
+                String tranId = event.getTxn();
+                if (tranId != null) {
+                    ScimResource txnResource = backendHandler.getTransactionRecord(tranId);
+                    if (txnResource != null) {
+                        // Even though we've seen this, we want to ack it so we don't get it again.
+                        acksPending.add(event.getJti());
+                        logger.warn("Duplicate transaction detected, ignoring.");
+                        return;
+                    }
                 }
             } catch (BackendException e) {
                 logger.error("Backend error fetching transaction: " + e.getMessage());

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventReceiver.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventReceiver.java
@@ -18,6 +18,7 @@ package com.independentid.signals;
 import com.independentid.scim.core.ConfigMgr;
 import com.independentid.scim.op.Operation;
 import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.StreamStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +81,7 @@ public class SignalsEventReceiver implements Runnable {
             Thread.interrupted(); // Clear the interrupt status
         }
 
-        while (!closeRequest.get() && !this.ssfClient.getPollStream().errorState) {
+        while (!closeRequest.get() && this.ssfClient.getPollStream().state.getStatus() == StreamStatus.ENABLED) {
             if (eventHandler.ready) {
                 try {
                     Map<String, SecurityEventToken> events = this.ssfClient.getPollStream().pollEvents(SignalsEventHandler.acksPending, false);

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfConfigJsonMigrator.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfConfigJsonMigrator.java
@@ -1,0 +1,43 @@
+package com.independentid.signals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public final class SsfConfigJsonMigrator {
+
+    private static final String LEGACY_FIELD = "errorState";
+    private static final String STATUS_FIELD = "status";
+    private static final String ERROR_MSG_FIELD = "errorMsg";
+    private static final String MIGRATION_REASON = "migrated from legacy errorState";
+
+    private SsfConfigJsonMigrator() {
+    }
+
+    public static JsonNode migrate(JsonNode root) {
+        if (root == null || !root.isObject()) {
+            return root;
+        }
+        migrateStream((ObjectNode) root, "pushStream");
+        migrateStream((ObjectNode) root, "pollStream");
+        return root;
+    }
+
+    private static void migrateStream(ObjectNode root, String streamField) {
+        JsonNode stream = root.get(streamField);
+        if (stream == null || !stream.isObject()) {
+            return;
+        }
+        ObjectNode streamObj = (ObjectNode) stream;
+        if (streamObj.has(STATUS_FIELD) || !streamObj.has(LEGACY_FIELD)) {
+            return;
+        }
+        boolean wasError = streamObj.get(LEGACY_FIELD).asBoolean(false);
+        streamObj.remove(LEGACY_FIELD);
+        if (wasError) {
+            streamObj.put(STATUS_FIELD, StreamStatus.DISABLED.name());
+            streamObj.put(ERROR_MSG_FIELD, MIGRATION_REASON);
+        } else {
+            streamObj.put(STATUS_FIELD, StreamStatus.ENABLED.name());
+        }
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -271,6 +271,8 @@ public class SsfHandler {
         this.pushStream.maxRetries = configProps.pubRetryMax;
         this.pushStream.initialDelay = configProps.pubRetryInterval;
         this.pushStream.maxDelay = configProps.pubRetryMaxInterval;
+        this.pushStream.unauthorizedRetryMax = configProps.pubUnauthorizedRetryMax;
+        this.pushStream.unauthorizedRetryDelay = configProps.pubUnauthorizedRetryDelay;
         this.pushStream.enabled = true;
 
         resp.close();
@@ -318,6 +320,8 @@ public class SsfHandler {
         this.pollStream.maxRetries = configProps.rcvRetryMax;
         this.pollStream.initialDelay = configProps.rcvRetryInterval;
         this.pollStream.maxDelay = configProps.rcvRetryMaxInterval;
+        this.pollStream.unauthorizedRetryMax = configProps.rcvUnauthorizedRetryMax;
+        this.pollStream.unauthorizedRetryDelay = configProps.rcvUnauthorizedRetryDelay;
         this.pollStream.enabled = true;
         resp.close();
     }

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -273,6 +273,7 @@ public class SsfHandler {
         this.pushStream.maxDelay = configProps.pubRetryMaxInterval;
         this.pushStream.unauthorizedRetryMax = configProps.pubUnauthorizedRetryMax;
         this.pushStream.unauthorizedRetryDelay = configProps.pubUnauthorizedRetryDelay;
+        this.pushStream.statusCheckInterval = configProps.pubStatusCheckInterval;
         this.pushStream.enabled = true;
 
         resp.close();
@@ -322,6 +323,7 @@ public class SsfHandler {
         this.pollStream.maxDelay = configProps.rcvRetryMaxInterval;
         this.pollStream.unauthorizedRetryMax = configProps.rcvUnauthorizedRetryMax;
         this.pollStream.unauthorizedRetryDelay = configProps.rcvUnauthorizedRetryDelay;
+        this.pollStream.statusCheckInterval = configProps.rcvStatusCheckInterval;
         this.pollStream.enabled = true;
         resp.close();
     }

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -77,8 +77,13 @@ public class SsfHandler {
         if (props.configFileExists()) {
             File configFile = props.getConfigFile();
             try {
-                FileInputStream configStream = new FileInputStream(configFile);
-                client = JsonUtil.getMapper().readValue(configStream, SsfHandler.class);
+                ObjectMapper mapper = JsonUtil.getMapper();
+                JsonNode root;
+                try (FileInputStream configStream = new FileInputStream(configFile)) {
+                    root = mapper.readTree(configStream);
+                }
+                root = SsfConfigJsonMigrator.migrate(root);
+                client = mapper.treeToValue(root, SsfHandler.class);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -274,6 +274,7 @@ public class SsfHandler {
         this.pushStream.unauthorizedRetryMax = configProps.pubUnauthorizedRetryMax;
         this.pushStream.unauthorizedRetryDelay = configProps.pubUnauthorizedRetryDelay;
         this.pushStream.statusCheckInterval = configProps.pubStatusCheckInterval;
+        this.pushStream.idleVerifyInterval = configProps.pubIdleVerifyInterval;
         this.pushStream.enabled = true;
 
         resp.close();

--- a/i2scim-server/src/main/java/com/independentid/signals/StatusEndpointResolver.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StatusEndpointResolver.java
@@ -1,0 +1,122 @@
+package com.independentid.signals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.serializer.JsonUtil;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class StatusEndpointResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(StatusEndpointResolver.class);
+    private static final String WELL_KNOWN_PATH = "/.well-known/ssf-configuration";
+
+    private final CloseableHttpClient client;
+    private final Map<String, URI> cache = new ConcurrentHashMap<>();
+    private final Set<String> unsupported = ConcurrentHashMap.newKeySet();
+
+    public StatusEndpointResolver(CloseableHttpClient client) {
+        this.client = client;
+    }
+
+    public Optional<URI> resolve(URI receiverHost, URI fallbackEndpoint) {
+        String key = hostKey(receiverHost);
+        if (unsupported.contains(key)) {
+            return Optional.empty();
+        }
+        URI cached = cache.get(key);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        Optional<URI> wellKnown = fetchWellKnownStatusEndpoint(receiverHost);
+        if (wellKnown.isPresent()) {
+            cache.put(key, wellKnown.get());
+            return wellKnown;
+        }
+        if (unsupported.contains(key)) {
+            return Optional.empty();
+        }
+        Optional<URI> derived = deriveStatusUrl(fallbackEndpoint);
+        if (derived.isPresent()) {
+            cache.put(key, derived.get());
+        }
+        return derived;
+    }
+
+    public void markUnsupported(URI receiverHost) {
+        unsupported.add(hostKey(receiverHost));
+    }
+
+    public void invalidate(URI receiverHost) {
+        String key = hostKey(receiverHost);
+        cache.remove(key);
+        unsupported.remove(key);
+    }
+
+    public boolean isMarkedUnsupported(URI receiverHost) {
+        return unsupported.contains(hostKey(receiverHost));
+    }
+
+    private Optional<URI> fetchWellKnownStatusEndpoint(URI receiverHost) {
+        URI wellKnownUri = receiverHost.resolve(WELL_KNOWN_PATH);
+        HttpGet req = new HttpGet(wellKnownUri);
+        try (CloseableHttpResponse resp = client.execute(req)) {
+            int code = resp.getCode();
+            if (code < 200 || code >= 300) {
+                logger.warn("Well-known fetch returned {} for {}", code, wellKnownUri);
+                return Optional.empty();
+            }
+            HttpEntity entity = resp.getEntity();
+            if (entity == null) {
+                markUnsupported(receiverHost);
+                return Optional.empty();
+            }
+            byte[] body = entity.getContent().readAllBytes();
+            JsonNode root = JsonUtil.getJsonTree(body);
+            JsonNode statusNode = root.get("status_endpoint");
+            if (statusNode == null || !statusNode.isTextual()) {
+                logger.info("Well-known at {} has no status_endpoint; marking T1-unsupported for this stream",
+                        wellKnownUri);
+                markUnsupported(receiverHost);
+                return Optional.empty();
+            }
+            return Optional.of(URI.create(statusNode.asText()));
+        } catch (Exception e) {
+            logger.warn("Well-known fetch failed for {}: {}", wellKnownUri, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static Optional<URI> deriveStatusUrl(URI endpoint) {
+        if (endpoint == null) return Optional.empty();
+        String path = endpoint.getPath();
+        if (path == null || path.isEmpty()) return Optional.empty();
+        int lastSlash = path.lastIndexOf('/');
+        String parent = lastSlash >= 0 ? path.substring(0, lastSlash) : "";
+        String derivedPath = parent + "/status";
+        try {
+            return Optional.of(new URI(
+                    endpoint.getScheme(),
+                    endpoint.getAuthority(),
+                    derivedPath,
+                    null,
+                    null
+            ));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    private static String hostKey(URI receiverHost) {
+        return receiverHost.getScheme() + "://" + receiverHost.getAuthority();
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamConfigProps.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamConfigProps.java
@@ -183,6 +183,12 @@ public class StreamConfigProps {
     @ConfigProperty(name = "scim.signals.rcv.unauthorized.retry.delay", defaultValue = "15000")
     public int rcvUnauthorizedRetryDelay;
 
+    @ConfigProperty(name = "scim.signals.pub.status.check.interval", defaultValue = "30000")
+    public int pubStatusCheckInterval;
+
+    @ConfigProperty(name = "scim.signals.rcv.status.check.interval", defaultValue = "30000")
+    public int rcvStatusCheckInterval;
+
     @ConfigProperty(name = "scim.signals.test", defaultValue = "false")
     boolean isTest;
 
@@ -207,6 +213,7 @@ public class StreamConfigProps {
             pushStream.maxDelay = pubRetryMaxInterval;
             pushStream.unauthorizedRetryMax = pubUnauthorizedRetryMax;
             pushStream.unauthorizedRetryDelay = pubUnauthorizedRetryDelay;
+            pushStream.statusCheckInterval = pubStatusCheckInterval;
             if (pubIsUnsigned) {
                 pushStream.isUnencrypted = true;
             } else {
@@ -237,6 +244,7 @@ public class StreamConfigProps {
             pollStream.maxDelay = rcvRetryMaxInterval;
             pollStream.unauthorizedRetryMax = rcvUnauthorizedRetryMax;
             pollStream.unauthorizedRetryDelay = rcvUnauthorizedRetryDelay;
+            pollStream.statusCheckInterval = rcvStatusCheckInterval;
 
             if (!unSignedMode) {
                 pollStream.receiverKey = getAudPrivateKey();

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamConfigProps.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamConfigProps.java
@@ -189,6 +189,9 @@ public class StreamConfigProps {
     @ConfigProperty(name = "scim.signals.rcv.status.check.interval", defaultValue = "30000")
     public int rcvStatusCheckInterval;
 
+    @ConfigProperty(name = "scim.signals.pub.idle.verify.interval", defaultValue = "300000")
+    public int pubIdleVerifyInterval;
+
     @ConfigProperty(name = "scim.signals.test", defaultValue = "false")
     boolean isTest;
 
@@ -214,6 +217,7 @@ public class StreamConfigProps {
             pushStream.unauthorizedRetryMax = pubUnauthorizedRetryMax;
             pushStream.unauthorizedRetryDelay = pubUnauthorizedRetryDelay;
             pushStream.statusCheckInterval = pubStatusCheckInterval;
+            pushStream.idleVerifyInterval = pubIdleVerifyInterval;
             if (pubIsUnsigned) {
                 pushStream.isUnencrypted = true;
             } else {

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamConfigProps.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamConfigProps.java
@@ -171,6 +171,18 @@ public class StreamConfigProps {
     @ConfigProperty(name = "scim.signals.pub.retry.maxInterval", defaultValue = "300000")
     public int pubRetryMaxInterval;
 
+    @ConfigProperty(name = "scim.signals.pub.unauthorized.retry.max", defaultValue = "10")
+    public int pubUnauthorizedRetryMax;
+
+    @ConfigProperty(name = "scim.signals.pub.unauthorized.retry.delay", defaultValue = "15000")
+    public int pubUnauthorizedRetryDelay;
+
+    @ConfigProperty(name = "scim.signals.rcv.unauthorized.retry.max", defaultValue = "10")
+    public int rcvUnauthorizedRetryMax;
+
+    @ConfigProperty(name = "scim.signals.rcv.unauthorized.retry.delay", defaultValue = "15000")
+    public int rcvUnauthorizedRetryDelay;
+
     @ConfigProperty(name = "scim.signals.test", defaultValue = "false")
     boolean isTest;
 
@@ -193,6 +205,8 @@ public class StreamConfigProps {
             pushStream.maxRetries = pubRetryMax;
             pushStream.initialDelay = pubRetryInterval;
             pushStream.maxDelay = pubRetryMaxInterval;
+            pushStream.unauthorizedRetryMax = pubUnauthorizedRetryMax;
+            pushStream.unauthorizedRetryDelay = pubUnauthorizedRetryDelay;
             if (pubIsUnsigned) {
                 pushStream.isUnencrypted = true;
             } else {
@@ -221,6 +235,8 @@ public class StreamConfigProps {
             pollStream.maxRetries = rcvRetryMax;
             pollStream.initialDelay = rcvRetryInterval;
             pollStream.maxDelay = rcvRetryMaxInterval;
+            pollStream.unauthorizedRetryMax = rcvUnauthorizedRetryMax;
+            pollStream.unauthorizedRetryDelay = rcvUnauthorizedRetryDelay;
 
             if (!unSignedMode) {
                 pollStream.receiverKey = getAudPrivateKey();

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamMaintenanceScheduler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamMaintenanceScheduler.java
@@ -1,0 +1,91 @@
+package com.independentid.signals;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public final class StreamMaintenanceScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(StreamMaintenanceScheduler.class);
+
+    private final ScheduledExecutorService executor;
+    private final Map<String, ScheduledFuture<?>> pausedTasks = new ConcurrentHashMap<>();
+    private final Map<String, ScheduledFuture<?>> idleTasks = new ConcurrentHashMap<>();
+
+    public StreamMaintenanceScheduler() {
+        this(Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "signals-stream-maintenance");
+            t.setDaemon(true);
+            return t;
+        }));
+    }
+
+    StreamMaintenanceScheduler(ScheduledExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public void schedulePausedRecheck(String streamKey, Runnable task, Duration interval) {
+        replaceTask(pausedTasks, streamKey, task, interval);
+    }
+
+    public void cancelPausedRecheck(String streamKey) {
+        cancelTask(pausedTasks, streamKey);
+    }
+
+    public void scheduleIdleVerify(String streamKey, Runnable task, Duration interval) {
+        replaceTask(idleTasks, streamKey, task, interval);
+    }
+
+    public void cancelIdleVerify(String streamKey) {
+        cancelTask(idleTasks, streamKey);
+    }
+
+    public void shutdown() {
+        pausedTasks.values().forEach(f -> f.cancel(false));
+        pausedTasks.clear();
+        idleTasks.values().forEach(f -> f.cancel(false));
+        idleTasks.clear();
+        executor.shutdownNow();
+        try {
+            executor.awaitTermination(5, TimeUnit.SECONDS);
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void replaceTask(Map<String, ScheduledFuture<?>> registry, String streamKey, Runnable task, Duration interval) {
+        if (executor.isShutdown()) {
+            return;
+        }
+        ScheduledFuture<?> previous = registry.put(streamKey, executor.scheduleAtFixedRate(
+                () -> safeRun(task, streamKey),
+                interval.toMillis(),
+                interval.toMillis(),
+                TimeUnit.MILLISECONDS));
+        if (previous != null) {
+            previous.cancel(false);
+        }
+    }
+
+    private void cancelTask(Map<String, ScheduledFuture<?>> registry, String streamKey) {
+        ScheduledFuture<?> existing = registry.remove(streamKey);
+        if (existing != null) {
+            existing.cancel(false);
+        }
+    }
+
+    private void safeRun(Runnable task, String streamKey) {
+        try {
+            task.run();
+        } catch (Throwable t) {
+            logger.warn("Maintenance task for stream {} threw {}: {}", streamKey, t.getClass().getSimpleName(), t.getMessage());
+        }
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamStateHolder.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamStateHolder.java
@@ -3,8 +3,8 @@ package com.independentid.signals;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 
 public class StreamStateHolder {
@@ -15,7 +15,7 @@ public class StreamStateHolder {
     private String errorMsg;
 
     @JsonIgnore
-    private final List<BiConsumer<StreamStatus, StreamStatus>> listeners = new ArrayList<>();
+    private final List<BiConsumer<StreamStatus, StreamStatus>> listeners = new CopyOnWriteArrayList<>();
 
     public StreamStatus getStatus() {
         return status;
@@ -25,7 +25,7 @@ public class StreamStateHolder {
         return errorMsg;
     }
 
-    public void transitionTo(StreamStatus newStatus, String reason) {
+    public synchronized void transitionTo(StreamStatus newStatus, String reason) {
         StreamStatus oldStatus = this.status;
         this.status = newStatus;
         this.errorMsg = reason;

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamStateHolder.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamStateHolder.java
@@ -1,0 +1,52 @@
+package com.independentid.signals;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class StreamStateHolder {
+
+    @JsonIgnore
+    private StreamStatus status = StreamStatus.ENABLED;
+
+    private String errorMsg;
+
+    @JsonIgnore
+    private final List<BiConsumer<StreamStatus, StreamStatus>> listeners = new ArrayList<>();
+
+    public StreamStatus getStatus() {
+        return status;
+    }
+
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    public void transitionTo(StreamStatus newStatus, String reason) {
+        StreamStatus oldStatus = this.status;
+        this.status = newStatus;
+        this.errorMsg = reason;
+        if (oldStatus != newStatus) {
+            for (BiConsumer<StreamStatus, StreamStatus> listener : listeners) {
+                listener.accept(oldStatus, newStatus);
+            }
+        }
+    }
+
+    public void addTransitionListener(BiConsumer<StreamStatus, StreamStatus> listener) {
+        listeners.add(listener);
+    }
+
+    @JsonProperty("status")
+    StreamStatus getPersistedStatus() {
+        return status == StreamStatus.PAUSED ? StreamStatus.ENABLED : status;
+    }
+
+    @JsonProperty("status")
+    void setStatusFromJson(StreamStatus s) {
+        this.status = s;
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamStatus.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamStatus.java
@@ -1,0 +1,7 @@
+package com.independentid.signals;
+
+public enum StreamStatus {
+    ENABLED,
+    PAUSED,
+    DISABLED
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/VerifyEventBuilder.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/VerifyEventBuilder.java
@@ -1,0 +1,30 @@
+package com.independentid.signals;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.independentid.scim.serializer.JsonUtil;
+import com.independentid.set.SecurityEventToken;
+import org.jose4j.jwt.NumericDate;
+
+import java.util.UUID;
+
+public final class VerifyEventBuilder {
+
+    public static final String VERIFICATION_EVENT_TYPE =
+            "https://schemas.openid.net/secevent/ssf/event-type/verification";
+
+    private VerifyEventBuilder() {
+    }
+
+    public static SecurityEventToken build(PushStream stream) {
+        SecurityEventToken event = new SecurityEventToken();
+        event.setIssuer(stream.iss);
+        if (stream.aud != null) {
+            event.setAud(stream.aud);
+        }
+        event.setJti(UUID.randomUUID().toString());
+        event.setIssuedAt(NumericDate.now());
+        ObjectNode payload = JsonUtil.getMapper().createObjectNode();
+        event.AddEventPayload(VERIFICATION_EVENT_TYPE, payload);
+        return event;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/set/SecurityEventTokenTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/set/SecurityEventTokenTest.java
@@ -1,0 +1,27 @@
+package com.independentid.scim.test.set;
+
+import com.independentid.set.SecurityEventToken;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurityEventTokenTest {
+
+    @Test
+    void getTxnReturnsNullWhenClaimAbsent() throws Exception {
+        // Per RFC 8417 §2.2, "txn" is OPTIONAL. A SET without txn (e.g. an SSF
+        // verification event) must not blow up the receiver.
+        SecurityEventToken event = new SecurityEventToken();
+        event.setJti("jti-1");
+
+        assertThat(event.getTxn()).isNull();
+    }
+
+    @Test
+    void getTxnReturnsValueWhenPresent() throws Exception {
+        SecurityEventToken event = new SecurityEventToken();
+        event.setTxn("tx-42");
+
+        assertThat(event.getTxn()).isEqualTo("tx-42");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PollFailureClassifierTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PollFailureClassifierTest.java
@@ -1,0 +1,60 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.FailureClassification;
+import com.independentid.signals.PollFailureClassifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PollFailureClassifierTest {
+
+    @Test
+    void classify2xxIsSuccess() {
+        FailureClassification result = PollFailureClassifier.classify(200, "OK", null, null);
+        assertThat(result).isInstanceOf(FailureClassification.Success.class);
+    }
+
+    @Test
+    void classify401IsUnauthorized() {
+        FailureClassification result = PollFailureClassifier.classify(401, "Unauthorized", null, null);
+        assertThat(result).isInstanceOf(FailureClassification.Unauthorized401.class);
+    }
+
+    @Test
+    void classify403IsForbidden() {
+        FailureClassification result = PollFailureClassifier.classify(403, "Forbidden", null, null);
+        assertThat(result).isInstanceOf(FailureClassification.Forbidden403.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 502, 503, 504})
+    void classify5xxIsServer5xx(int code) {
+        FailureClassification result = PollFailureClassifier.classify(code, "Server Error", null, null);
+        assertThat(result).isInstanceOf(FailureClassification.Server5xx.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 404, 410, 422})
+    void classifyOther4xxIsOtherClient4xx(int code) {
+        FailureClassification result = PollFailureClassifier.classify(code, "Bad", "body".getBytes(), null);
+        assertThat(result).isInstanceOf(FailureClassification.OtherClient4xx.class);
+    }
+
+    @Test
+    void classify429WithRetryAfterParsesDuration() {
+        FailureClassification result = PollFailureClassifier.classify(429, "Too Many", null, "30");
+        assertThat(result).isInstanceOf(FailureClassification.RateLimited429.class);
+        assertThat(((FailureClassification.RateLimited429) result).retryAfter()).contains(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void classifyIOExceptionIsTransport() {
+        FailureClassification result = PollFailureClassifier.classify(new IOException("refused"));
+        assertThat(result).isInstanceOf(FailureClassification.Transport.class);
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PollStreamFailureTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PollStreamFailureTest.java
@@ -1,0 +1,81 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.PollStream;
+import com.independentid.signals.StreamStatus;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PollStreamFailureTest {
+
+    @Test
+    void pollOn403TransitionsToDisabled() throws Exception {
+        PollStream stream = newStream();
+        stream.maxRetries = 1;
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getCode()).thenReturn(403);
+        when(mockResponse.getReasonPhrase()).thenReturn("Forbidden");
+        when(mockClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+        stream.client = mockClient;
+
+        stream.pollEvents(Collections.emptyList(), false, stream.maxRetries);
+
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("403");
+    }
+
+    @Test
+    void shutdownModeAckCallDoesNotTransitionStateOn5xx() throws Exception {
+        PollStream stream = newStream();
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getCode()).thenReturn(503);
+        when(mockResponse.getReasonPhrase()).thenReturn("Service Unavailable");
+        when(mockClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+        stream.client = mockClient;
+
+        // retries=0 signals shutdown-mode best-effort ack
+        stream.pollEvents(Collections.singletonList("jti-1"), true, 0);
+
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.ENABLED);
+    }
+
+    @Test
+    void shutdownModeAckCallDoesNotTransitionStateOn403() throws Exception {
+        PollStream stream = newStream();
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getCode()).thenReturn(403);
+        when(mockResponse.getReasonPhrase()).thenReturn("Forbidden");
+        when(mockClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+        stream.client = mockClient;
+
+        stream.pollEvents(Collections.singletonList("jti-1"), true, 0);
+
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.ENABLED);
+    }
+
+    private PollStream newStream() {
+        PollStream stream = new PollStream();
+        stream.endpointUrl = "https://example.com/poll";
+        stream.authorization = "NONE";
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        stream.maxRetries = 0;
+        stream.initialDelay = 0;
+        stream.maxDelay = 0;
+        return stream;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushFailureClassifierTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushFailureClassifierTest.java
@@ -1,0 +1,88 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.FailureClassification;
+import com.independentid.signals.PushFailureClassifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PushFailureClassifierTest {
+
+    @Test
+    void classify2xxIsSuccess() {
+        FailureClassification result = PushFailureClassifier.classify(202, "Accepted", null, null);
+
+        assertThat(result).isInstanceOf(FailureClassification.Success.class);
+    }
+
+    @Test
+    void classify403IsForbidden() {
+        FailureClassification result = PushFailureClassifier.classify(403, "Forbidden", null, null);
+
+        assertThat(result).isInstanceOf(FailureClassification.Forbidden403.class);
+        assertThat(((FailureClassification.Forbidden403) result).reason()).isEqualTo("403 Forbidden");
+    }
+
+    @Test
+    void classify401IsUnauthorized() {
+        FailureClassification result = PushFailureClassifier.classify(401, "Unauthorized", null, null);
+
+        assertThat(result).isInstanceOf(FailureClassification.Unauthorized401.class);
+        assertThat(((FailureClassification.Unauthorized401) result).reason()).isEqualTo("401 Unauthorized");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500, 502, 503, 504})
+    void classify5xxIsServer5xx(int code) {
+        FailureClassification result = PushFailureClassifier.classify(code, "Server Error", null, null);
+
+        assertThat(result).isInstanceOf(FailureClassification.Server5xx.class);
+        FailureClassification.Server5xx s = (FailureClassification.Server5xx) result;
+        assertThat(s.code()).isEqualTo(code);
+        assertThat(s.reason()).isEqualTo("Server Error");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 404, 410, 422})
+    void classifyOther4xxIsOtherClient4xxWithBody(int code) {
+        FailureClassification result = PushFailureClassifier.classify(code, "Bad", "details".getBytes(), null);
+
+        assertThat(result).isInstanceOf(FailureClassification.OtherClient4xx.class);
+        FailureClassification.OtherClient4xx c = (FailureClassification.OtherClient4xx) result;
+        assertThat(c.code()).isEqualTo(code);
+        assertThat(c.body()).isEqualTo("details");
+    }
+
+    @Test
+    void classify429WithNumericRetryAfterParsesDuration() {
+        FailureClassification result = PushFailureClassifier.classify(429, "Too Many Requests", null, "30");
+
+        assertThat(result).isInstanceOf(FailureClassification.RateLimited429.class);
+        FailureClassification.RateLimited429 r = (FailureClassification.RateLimited429) result;
+        assertThat(r.retryAfter()).contains(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void classify429WithoutRetryAfterReturnsEmptyOptional() {
+        FailureClassification result = PushFailureClassifier.classify(429, "Too Many Requests", null, null);
+
+        assertThat(result).isInstanceOf(FailureClassification.RateLimited429.class);
+        FailureClassification.RateLimited429 r = (FailureClassification.RateLimited429) result;
+        assertThat(r.retryAfter()).isEmpty();
+    }
+
+    @Test
+    void classifyIOExceptionIsTransport() {
+        IOException cause = new IOException("connection refused");
+
+        FailureClassification result = PushFailureClassifier.classify(cause);
+
+        assertThat(result).isInstanceOf(FailureClassification.Transport.class);
+        assertThat(((FailureClassification.Transport) result).cause()).isSameAs(cause);
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamFailureTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamFailureTest.java
@@ -1,0 +1,43 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.PushStream;
+import com.independentid.signals.StreamStatus;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PushStreamFailureTest {
+
+    @Test
+    void pushEventOn403TransitionsToDisabledWithReasonInErrorMsg() throws Exception {
+        PushStream stream = new PushStream();
+        stream.endpointUrl = "https://example.com/events";
+        stream.authorization = "NONE";
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        stream.issuerKey = null; // unsigned mode: JWS uses NONE algorithm
+        stream.maxRetries = 0;
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getCode()).thenReturn(403);
+        when(mockResponse.getReasonPhrase()).thenReturn("Forbidden");
+        when(mockClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+        stream.client = mockClient;
+
+        SecurityEventToken event = new SecurityEventToken();
+
+        boolean pushed = stream.pushEvent(event);
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("403").contains("Forbidden");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamFailureTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamFailureTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class PushStreamFailureTest {
@@ -39,5 +41,59 @@ class PushStreamFailureTest {
         assertThat(pushed).isFalse();
         assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
         assertThat(stream.state.getErrorMsg()).contains("403").contains("Forbidden");
+    }
+
+    @Test
+    void pushEventOn401ExhaustsUnauthorizedRetriesThenDisables() throws Exception {
+        PushStream stream = newStream();
+        stream.unauthorizedRetryMax = 2;
+        stream.unauthorizedRetryDelay = 0;
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getCode()).thenReturn(401);
+        when(mockResponse.getReasonPhrase()).thenReturn("Unauthorized");
+        when(mockClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+        stream.client = mockClient;
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("401").contains("exhausted");
+        verify(mockClient, times(stream.unauthorizedRetryMax + 1)).execute(any(HttpPost.class));
+    }
+
+    @Test
+    void pushEventOn5xxExhaustsTransportRetriesThenDisables() throws Exception {
+        PushStream stream = newStream();
+        stream.maxRetries = 2;
+        stream.initialDelay = 0;
+        stream.maxDelay = 0;
+
+        CloseableHttpClient mockClient = mock(CloseableHttpClient.class);
+        CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+        when(mockResponse.getCode()).thenReturn(503);
+        when(mockResponse.getReasonPhrase()).thenReturn("Service Unavailable");
+        when(mockClient.execute(any(HttpPost.class))).thenReturn(mockResponse);
+        stream.client = mockClient;
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("transport").contains("exceeded");
+        verify(mockClient, times(stream.maxRetries + 1)).execute(any(HttpPost.class));
+    }
+
+    private PushStream newStream() {
+        PushStream stream = new PushStream();
+        stream.endpointUrl = "https://example.com/events";
+        stream.authorization = "NONE";
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        stream.issuerKey = null;
+        stream.maxRetries = 0;
+        return stream;
     }
 }

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamIdleVerifyTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamIdleVerifyTest.java
@@ -1,0 +1,66 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.PushStream;
+import com.independentid.signals.VerifyEventBuilder;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PushStreamIdleVerifyTest {
+
+    @Test
+    void successfulPushUpdatesLastSuccessfulPushTimestamp() throws Exception {
+        PushStream stream = newStream();
+        Instant before = stream.getLastSuccessfulPush();
+        Thread.sleep(20);
+
+        stream.client = mockClientReturning(202);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isTrue();
+        assertThat(stream.getLastSuccessfulPush()).isAfter(before);
+    }
+
+    @Test
+    void verifyEventFlowsThroughPushEventAsRegularSet() throws Exception {
+        PushStream stream = newStream();
+        stream.client = mockClientReturning(202);
+
+        SecurityEventToken verify = VerifyEventBuilder.build(stream);
+        boolean pushed = stream.pushEvent(verify);
+
+        assertThat(pushed).isTrue();
+    }
+
+    private PushStream newStream() {
+        PushStream stream = new PushStream();
+        stream.endpointUrl = "https://recv.example.com/events";
+        stream.authorization = "NONE";
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        stream.issuerKey = null;
+        stream.maxRetries = 0;
+        stream.initialDelay = 0;
+        return stream;
+    }
+
+    private CloseableHttpClient mockClientReturning(int code) throws IOException {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        when(response.getCode()).thenReturn(code);
+        when(response.getReasonPhrase()).thenReturn("OK");
+        when(client.execute(any(HttpPost.class))).thenReturn(response);
+        return client;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamRfc8935Test.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamRfc8935Test.java
@@ -1,0 +1,133 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.PushStream;
+import com.independentid.signals.StreamStatus;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.Key;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PushStreamRfc8935Test {
+
+    @Test
+    void invalidAudienceDisablesWithStructuredErrorMsgIncludingJti() throws Exception {
+        PushStream stream = newStream();
+
+        String body = "{\"err\":\"invalid_audience\",\"description\":\"audience mismatch\",\"jti\":\"jti-1\"}";
+        stream.client = mockClient400With(body);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("RFC8935 invalid_audience");
+        assertThat(stream.state.getErrorMsg()).contains("audience mismatch");
+        assertThat(stream.state.getErrorMsg()).contains("jti=jti-1");
+    }
+
+    @Test
+    void jwsSignatureFailedWithSuccessfulReloadRetriesOnceAndSucceeds() throws Exception {
+        PushStream stream = newStream();
+        AtomicInteger reloadCount = new AtomicInteger();
+        stream.issuerKeyReloader = () -> {
+            reloadCount.incrementAndGet();
+            return null; // null is fine; signing path tolerates null (unsigned)
+        };
+
+        AtomicInteger pushCallCount = new AtomicInteger();
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        when(client.execute(any(HttpUriRequestBase.class))).thenAnswer(inv -> {
+            int calls = pushCallCount.incrementAndGet();
+            if (calls == 1) {
+                return jsonResponse(400, "{\"err\":\"jws_signature_failed\",\"description\":\"bad sig\",\"jti\":\"jti-1\"}");
+            }
+            CloseableHttpResponse ok = mock(CloseableHttpResponse.class);
+            when(ok.getCode()).thenReturn(202);
+            when(ok.getReasonPhrase()).thenReturn("Accepted");
+            return ok;
+        });
+        stream.client = client;
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isTrue();
+        assertThat(reloadCount.get()).isEqualTo(1);
+        assertThat(pushCallCount.get()).isEqualTo(2);
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.ENABLED);
+    }
+
+    @Test
+    void jwsSignatureFailedTwiceDisables() throws Exception {
+        PushStream stream = newStream();
+        stream.issuerKeyReloader = () -> null;
+
+        String body = "{\"err\":\"jws_signature_failed\",\"description\":\"bad sig\",\"jti\":\"jti-1\"}";
+        stream.client = mockClient400With(body);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("RFC8935 jws_signature_failed");
+    }
+
+    @Test
+    void jwsSignatureFailedOnUnencryptedStreamDisablesWithoutReload() throws Exception {
+        PushStream stream = newStream();
+        stream.isUnencrypted = true;
+        AtomicInteger reloadCount = new AtomicInteger();
+        stream.issuerKeyReloader = () -> {
+            reloadCount.incrementAndGet();
+            return null;
+        };
+
+        String body = "{\"err\":\"jws_signature_failed\",\"description\":\"bad sig\",\"jti\":\"jti-1\"}";
+        stream.client = mockClient400With(body);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(reloadCount.get()).isEqualTo(0);
+    }
+
+    private PushStream newStream() {
+        PushStream stream = new PushStream();
+        stream.endpointUrl = "https://recv.example.com/events";
+        stream.authorization = "NONE";
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        stream.issuerKey = null;
+        stream.maxRetries = 0;
+        stream.initialDelay = 0;
+        return stream;
+    }
+
+    private CloseableHttpClient mockClient400With(String body) throws IOException {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        when(client.execute(any(HttpUriRequestBase.class))).thenAnswer(inv -> jsonResponse(400, body));
+        return client;
+    }
+
+    private CloseableHttpResponse jsonResponse(int code, String body) throws IOException {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        HttpEntity entity = mock(HttpEntity.class);
+        when(response.getCode()).thenReturn(code);
+        when(response.getReasonPhrase()).thenReturn(code == 400 ? "Bad Request" : "OK");
+        when(response.getEntity()).thenReturn(entity);
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(body.getBytes()));
+        return response;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamStatusInterrogationTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamStatusInterrogationTest.java
@@ -84,6 +84,7 @@ class PushStreamStatusInterrogationTest {
 
     private PushStream newStream() {
         PushStream stream = new PushStream();
+        stream.streamId = "stream-1";
         stream.endpointUrl = "https://recv.example.com/events";
         stream.authorization = "NONE";
         stream.iss = "test-issuer";

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamStatusInterrogationTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamStatusInterrogationTest.java
@@ -1,0 +1,129 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.PushStream;
+import com.independentid.signals.StatusEndpointResolver;
+import com.independentid.signals.StreamStatus;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PushStreamStatusInterrogationTest {
+
+    @Test
+    void t1On5xxPlusRemotePausedTransitionsToPaused() throws Exception {
+        PushStream stream = newStream();
+        stream.maxRetries = 5;
+
+        CloseableHttpClient client = mockedRouting(503, "{\"status_endpoint\":\"https://recv.example.com/status\"}", "{\"status\":\"paused\"}");
+        stream.client = client;
+        stream.statusResolver = new StatusEndpointResolver(client);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.PAUSED);
+        assertThat(stream.state.getErrorMsg()).contains("paused");
+    }
+
+    @Test
+    void t1On5xxPlusRemoteDisabledTransitionsToDisabled() throws Exception {
+        PushStream stream = newStream();
+        stream.maxRetries = 5;
+
+        CloseableHttpClient client = mockedRouting(503, "{\"status_endpoint\":\"https://recv.example.com/status\"}", "{\"status\":\"disabled\"}");
+        stream.client = client;
+        stream.statusResolver = new StatusEndpointResolver(client);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(stream.state.getErrorMsg()).contains("disabled");
+    }
+
+    @Test
+    void t2PreFlightWithRemotePausedSkipsAttemptAndTransitionsToPaused() throws Exception {
+        PushStream stream = newStream();
+
+        CloseableHttpClient client = mockedRouting(202, "{\"status_endpoint\":\"https://recv.example.com/status\"}", "{\"status\":\"paused\"}");
+        stream.client = client;
+        stream.statusResolver = new StatusEndpointResolver(client);
+
+        boolean pushed = stream.pushEvent(new SecurityEventToken());
+
+        assertThat(pushed).isFalse();
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.PAUSED);
+        assertThat(stream.state.getErrorMsg()).contains("pre-flight");
+    }
+
+    @Test
+    void pausedRecheckTransitionsBackToEnabledWhenRemoteRecovers() throws Exception {
+        PushStream stream = newStream();
+
+        CloseableHttpClient client = mockedRouting(202, "{\"status_endpoint\":\"https://recv.example.com/status\"}", "{\"status\":\"enabled\"}");
+        stream.client = client;
+        stream.statusResolver = new StatusEndpointResolver(client);
+        // Simulate stream already being in PAUSED state
+        stream.state.transitionTo(StreamStatus.PAUSED, "test setup");
+
+        stream.pausedRecheck();
+
+        assertThat(stream.state.getStatus()).isEqualTo(StreamStatus.ENABLED);
+    }
+
+    private PushStream newStream() {
+        PushStream stream = new PushStream();
+        stream.endpointUrl = "https://recv.example.com/events";
+        stream.authorization = "NONE";
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        stream.issuerKey = null;
+        stream.maxRetries = 0;
+        stream.initialDelay = 0;
+        return stream;
+    }
+
+    /**
+     * Routes mock responses by URL path: push endpoint returns the configured pushCode;
+     * /.well-known/ssf-configuration returns wellKnownBody; status endpoint returns statusBody.
+     */
+    private CloseableHttpClient mockedRouting(int pushCode, String wellKnownBody, String statusBody) throws IOException {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        when(client.execute(any(HttpUriRequestBase.class))).thenAnswer(inv -> {
+            HttpUriRequestBase req = inv.getArgument(0);
+            String path = req.getRequestUri();
+            if (path.contains("/.well-known/ssf-configuration")) {
+                return jsonResponse(200, wellKnownBody);
+            }
+            if (path.contains("/status")) {
+                return jsonResponse(200, statusBody);
+            }
+            // push endpoint
+            CloseableHttpResponse pushResp = mock(CloseableHttpResponse.class);
+            when(pushResp.getCode()).thenReturn(pushCode);
+            when(pushResp.getReasonPhrase()).thenReturn(pushCode == 503 ? "Service Unavailable" : "OK");
+            return pushResp;
+        });
+        return client;
+    }
+
+    private CloseableHttpResponse jsonResponse(int code, String body) throws IOException {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        HttpEntity entity = mock(HttpEntity.class);
+        when(response.getCode()).thenReturn(code);
+        when(response.getEntity()).thenReturn(entity);
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(body.getBytes()));
+        return response;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/RemoteStatusProbeTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/RemoteStatusProbeTest.java
@@ -9,6 +9,7 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -17,6 +18,7 @@ import java.net.URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RemoteStatusProbeTest {
@@ -31,7 +33,7 @@ class RemoteStatusProbeTest {
     void probeReturnsParsedStatusFor200Response(String body, RemoteStatus expected) throws Exception {
         CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"" + body + "\"}");
 
-        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "stream-1", "NONE");
 
         assertThat(result).isEqualTo(expected);
     }
@@ -40,7 +42,7 @@ class RemoteStatusProbeTest {
     void probeReturnsUnknownOn500() throws Exception {
         CloseableHttpClient client = mockClientReturning(500, "{}");
 
-        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "stream-1", "NONE");
 
         assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
     }
@@ -49,7 +51,7 @@ class RemoteStatusProbeTest {
     void probeReturnsUnknownOnMalformedJson() throws Exception {
         CloseableHttpClient client = mockClientReturning(200, "not-json");
 
-        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "stream-1", "NONE");
 
         assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
     }
@@ -59,7 +61,7 @@ class RemoteStatusProbeTest {
         CloseableHttpClient client = mock(CloseableHttpClient.class);
         when(client.execute(any(HttpGet.class))).thenThrow(new IOException("connection refused"));
 
-        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "stream-1", "NONE");
 
         assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
     }
@@ -68,7 +70,49 @@ class RemoteStatusProbeTest {
     void probeReturnsUnknownOnUnknownStatusValue() throws Exception {
         CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"nonsense\"}");
 
-        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "stream-1", "NONE");
+
+        assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
+    }
+
+    @Test
+    void probeAppendsStreamIdQueryParamPerSsfSpec() throws Exception {
+        CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"enabled\"}");
+
+        RemoteStatusProbe.probe(client, URI.create("https://example.com/ssf/status"), "abc-123", "NONE");
+
+        ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+        verify(client).execute(captor.capture());
+        assertThat(captor.getValue().getUri().toString()).isEqualTo("https://example.com/ssf/status?stream_id=abc-123");
+    }
+
+    @Test
+    void probeAppendsStreamIdToExistingQueryParams() throws Exception {
+        CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"enabled\"}");
+
+        RemoteStatusProbe.probe(client, URI.create("https://example.com/status?other=1"), "s2", "NONE");
+
+        ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+        verify(client).execute(captor.capture());
+        assertThat(captor.getValue().getUri().toString()).isEqualTo("https://example.com/status?other=1&stream_id=s2");
+    }
+
+    @Test
+    void probeUrlEncodesStreamId() throws Exception {
+        CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"enabled\"}");
+
+        RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "id with space&amp", "NONE");
+
+        ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+        verify(client).execute(captor.capture());
+        assertThat(captor.getValue().getUri().toString()).isEqualTo("https://example.com/status?stream_id=id+with+space%26amp");
+    }
+
+    @Test
+    void probeReturnsUnknownWhenStreamIdIsMissing() {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), null, "NONE");
 
         assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
     }

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/RemoteStatusProbeTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/RemoteStatusProbeTest.java
@@ -1,0 +1,86 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.RemoteStatus;
+import com.independentid.signals.RemoteStatusProbe;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteStatusProbeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "enabled, ENABLED",
+            "ENABLED, ENABLED",
+            "paused, PAUSED",
+            "disabled, DISABLED"
+    })
+    void probeReturnsParsedStatusFor200Response(String body, RemoteStatus expected) throws Exception {
+        CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"" + body + "\"}");
+
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void probeReturnsUnknownOn500() throws Exception {
+        CloseableHttpClient client = mockClientReturning(500, "{}");
+
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+
+        assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
+    }
+
+    @Test
+    void probeReturnsUnknownOnMalformedJson() throws Exception {
+        CloseableHttpClient client = mockClientReturning(200, "not-json");
+
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+
+        assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
+    }
+
+    @Test
+    void probeReturnsUnknownOnIOException() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        when(client.execute(any(HttpGet.class))).thenThrow(new IOException("connection refused"));
+
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+
+        assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
+    }
+
+    @Test
+    void probeReturnsUnknownOnUnknownStatusValue() throws Exception {
+        CloseableHttpClient client = mockClientReturning(200, "{\"status\":\"nonsense\"}");
+
+        RemoteStatus result = RemoteStatusProbe.probe(client, URI.create("https://example.com/status"), "NONE");
+
+        assertThat(result).isEqualTo(RemoteStatus.UNKNOWN);
+    }
+
+    private CloseableHttpClient mockClientReturning(int code, String body) throws IOException {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        HttpEntity entity = mock(HttpEntity.class);
+        when(response.getCode()).thenReturn(code);
+        when(response.getEntity()).thenReturn(entity);
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(body.getBytes()));
+        when(client.execute(any(HttpGet.class))).thenReturn(response);
+        return client;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/RetryStrategyTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/RetryStrategyTest.java
@@ -1,0 +1,137 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.FailureClassification;
+import com.independentid.signals.RetryDecision;
+import com.independentid.signals.RetryStrategy;
+import com.independentid.signals.RetryStrategyConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RetryStrategyTest {
+
+    private final RetryStrategyConfig config = new RetryStrategyConfig(
+            10,                          // transportRetryMax
+            Duration.ofSeconds(2),       // transportInitialDelay
+            Duration.ofMinutes(5),       // transportMaxDelay
+            10,                          // unauthorizedRetryMax
+            Duration.ofSeconds(15)       // unauthorizedDelay
+    );
+
+    @Test
+    void forbidden403DisablesImmediately() {
+        FailureClassification c = new FailureClassification.Forbidden403("403 Forbidden");
+
+        RetryDecision d = RetryStrategy.decide(c, 0, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.Disable.class);
+        assertThat(((RetryDecision.Disable) d).reason()).isEqualTo("403 Forbidden");
+    }
+
+    @Test
+    void otherClient4xxDisablesImmediately() {
+        FailureClassification c = new FailureClassification.OtherClient4xx(404, "not found");
+
+        RetryDecision d = RetryStrategy.decide(c, 0, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.Disable.class);
+        assertThat(((RetryDecision.Disable) d).reason()).contains("404").contains("not found");
+    }
+
+    @Test
+    void unauthorized401UnderCapSleepsForUnauthorizedDelay() {
+        FailureClassification c = new FailureClassification.Unauthorized401("401 Unauthorized");
+
+        RetryDecision d = RetryStrategy.decide(c, 5, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.SleepThenRetry.class);
+        assertThat(((RetryDecision.SleepThenRetry) d).delay()).isEqualTo(Duration.ofSeconds(15));
+    }
+
+    @Test
+    void unauthorized401AtCapDisables() {
+        FailureClassification c = new FailureClassification.Unauthorized401("401 Unauthorized");
+
+        RetryDecision d = RetryStrategy.decide(c, 10, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.Disable.class);
+        assertThat(((RetryDecision.Disable) d).reason()).contains("401").contains("exhausted");
+    }
+
+    @Test
+    void server5xxExpBackoffGrowsWithAttempts() {
+        FailureClassification c = new FailureClassification.Server5xx(503, "Service Unavailable");
+
+        Duration d0 = ((RetryDecision.SleepThenRetry) RetryStrategy.decide(c, 0, config)).delay();
+        Duration d1 = ((RetryDecision.SleepThenRetry) RetryStrategy.decide(c, 1, config)).delay();
+        Duration d2 = ((RetryDecision.SleepThenRetry) RetryStrategy.decide(c, 2, config)).delay();
+
+        assertThat(d0).isEqualTo(Duration.ofSeconds(2));
+        assertThat(d1).isEqualTo(Duration.ofSeconds(4));
+        assertThat(d2).isEqualTo(Duration.ofSeconds(8));
+    }
+
+    @Test
+    void server5xxExpBackoffCapsAtMaxDelay() {
+        FailureClassification c = new FailureClassification.Server5xx(503, "Service Unavailable");
+
+        RetryDecision d = RetryStrategy.decide(c, 8, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.SleepThenRetry.class);
+        assertThat(((RetryDecision.SleepThenRetry) d).delay()).isEqualTo(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void server5xxAboveAttemptCapDisables() {
+        FailureClassification c = new FailureClassification.Server5xx(503, "Service Unavailable");
+
+        RetryDecision d = RetryStrategy.decide(c, 10, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.Disable.class);
+        assertThat(((RetryDecision.Disable) d).reason()).contains("transport").contains("exceeded");
+    }
+
+    @Test
+    void transportFailureBackoffMirrorsServer5xx() {
+        FailureClassification c = new FailureClassification.Transport(new IOException("connection refused"));
+
+        Duration d0 = ((RetryDecision.SleepThenRetry) RetryStrategy.decide(c, 0, config)).delay();
+        RetryDecision dCap = RetryStrategy.decide(c, 10, config);
+
+        assertThat(d0).isEqualTo(Duration.ofSeconds(2));
+        assertThat(dCap).isInstanceOf(RetryDecision.Disable.class);
+    }
+
+    @Test
+    void rateLimited429WithRetryAfterReturnsNoCap() {
+        FailureClassification c = new FailureClassification.RateLimited429(429, "Too Many", Optional.of(Duration.ofSeconds(45)));
+
+        RetryDecision d = RetryStrategy.decide(c, 0, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.RetryNoCap.class);
+        assertThat(((RetryDecision.RetryNoCap) d).delay()).isEqualTo(Duration.ofSeconds(45));
+    }
+
+    @Test
+    void rateLimited429WithoutRetryAfterUsesTransportInitialDelay() {
+        FailureClassification c = new FailureClassification.RateLimited429(429, "Too Many", Optional.empty());
+
+        RetryDecision d = RetryStrategy.decide(c, 0, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.RetryNoCap.class);
+        assertThat(((RetryDecision.RetryNoCap) d).delay()).isEqualTo(Duration.ofSeconds(2));
+    }
+
+    @Test
+    void rateLimited429NeverDisablesEvenAtHighAttemptCount() {
+        FailureClassification c = new FailureClassification.RateLimited429(429, "Too Many", Optional.empty());
+
+        RetryDecision d = RetryStrategy.decide(c, 10000, config);
+
+        assertThat(d).isInstanceOf(RetryDecision.RetryNoCap.class);
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/Rfc8935ErrorParserTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/Rfc8935ErrorParserTest.java
@@ -1,0 +1,91 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.Rfc8935Error;
+import com.independentid.signals.Rfc8935ErrorParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Rfc8935ErrorParserTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "authentication_failed",
+            "invalid_request",
+            "invalid_audience",
+            "invalid_issuer",
+            "invalid_key",
+            "jws_signature_failed",
+            "jwe_decryption_failed"
+    })
+    void parsesAllKnownCodes(String code) {
+        String body = "{\"err\":\"" + code + "\",\"description\":\"why\"}";
+
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse(body.getBytes());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().code()).isEqualTo(code);
+        assertThat(result.get().description()).isEqualTo("why");
+    }
+
+    @Test
+    void parsesJtiWhenPresent() {
+        String body = "{\"err\":\"invalid_audience\",\"description\":\"d\",\"jti\":\"abc-123\"}";
+
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse(body.getBytes());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().jti()).contains("abc-123");
+    }
+
+    @Test
+    void missingDescriptionStillParses() {
+        String body = "{\"err\":\"invalid_audience\"}";
+
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse(body.getBytes());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().description()).isNull();
+    }
+
+    @Test
+    void unknownErrCodeReturnsEmpty() {
+        String body = "{\"err\":\"some_new_code\"}";
+
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse(body.getBytes());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void nonJsonBodyReturnsEmpty() {
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse("not-json".getBytes());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void jsonWithoutErrFieldReturnsEmpty() {
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse("{\"foo\":\"bar\"}".getBytes());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void nullBodyReturnsEmpty() {
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse(null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void emptyBodyReturnsEmpty() {
+        Optional<Rfc8935Error> result = Rfc8935ErrorParser.parse(new byte[0]);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/SignalsGoSignalsIT.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/SignalsGoSignalsIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * End-to-end integration test exercising PRD-A's operational vocabulary
+ * against a real goSignals instance launched via docker-compose-signals.yml.
+ *
+ * Disabled by default (and excluded from the surefire default run) because it
+ * requires:
+ *   - docker compose -f docker-compose-signals.yml up (running)
+ *   - The i2gosignals:latest image built locally (see goSignals build instructions)
+ *
+ * To run manually:
+ *   docker compose -f docker-compose-signals.yml up -d
+ *   mvn -pl i2scim-server test -Dtest=SignalsGoSignalsIT
+ */
+
+package com.independentid.scim.test.signals;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestProfile(SignalsGoSignalsITProfile.class)
+@Disabled("Requires goSignals + Mongo replica set running via docker-compose-signals.yml; enable manually")
+public class SignalsGoSignalsIT {
+
+    @Test
+    void scenario1_healthyPushEndToEnd() {
+        // Healthy push: SCIM operation triggers a SET, posted to goSignals,
+        // returns 202; assert local PushStream.state.getStatus() == ENABLED
+        // throughout, and the event arrives at goSignals (visible via its
+        // poll endpoint or stream state).
+    }
+
+    @Test
+    void scenario2_revokedStreamReturns403AndDisablesImmediately() {
+        // Configure the stream against a goSignals stream that has been
+        // revoked (DELETE on goSignals stream config); attempt push;
+        // assert local Status=DISABLED immediately with structured errorMsg
+        // containing "403" / "Forbidden".
+    }
+
+    @Test
+    void scenario3_pausedMirrorWithAutoRecovery() {
+        // Pause the goSignals stream from goSignals' side (PATCH stream
+        // config); push attempt fails; T1 detects remote PAUSED; local
+        // transitions to PAUSED. Then re-enable goSignals' stream; the
+        // paused-recheck loop detects remote ENABLED; local auto-recovers
+        // to ENABLED. No operator intervention from i2scim side.
+    }
+
+    @Test
+    void scenario4_invalidAudienceDisablesWithStructuredErrorMsg() {
+        // Misconfigure the stream's aud so goSignals rejects with
+        // RFC8935 invalid_audience; push; assert local Status=DISABLED
+        // with errorMsg="RFC8935 invalid_audience: ...; jti=...".
+    }
+
+    @Test
+    void scenario5_jwsSignatureFailedReloadAndRetryOnce() {
+        // Force goSignals' JWKS cache to drop our key; push; assert §2.4
+        // carve-out fires (PEM reload + retry-once). If goSignals' JWKS
+        // refreshed in-between, local returns to ENABLED on retry; if
+        // still failing, local DISABLED.
+    }
+
+    @Test
+    void scenario6_idleVerifyEventObservedAtGoSignals() {
+        // Leave the push stream idle for idle.verify.interval + slack;
+        // assert a verify event (event type = SSF verification) is
+        // observed at goSignals (in its event log or poll output);
+        // assert local Status=ENABLED is retained.
+    }
+
+    @Test
+    void scenario7_shutdownAckBypassesStateTransition() {
+        // Trigger Quarkus shutdown while acks are in flight; assert the
+        // final pollEvents(acks, ackOnly=true, retries=0) call does NOT
+        // transition Status=DISABLED even if goSignals is unreachable
+        // at the shutdown moment.
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/SignalsGoSignalsITProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/SignalsGoSignalsITProfile.java
@@ -1,0 +1,36 @@
+/*
+ * Test profile for SignalsGoSignalsIT. Points i2scim at a goSignals
+ * instance launched via docker-compose-signals.yml.
+ */
+
+package com.independentid.scim.test.signals;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class SignalsGoSignalsITProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.ofEntries(
+                Map.entry("scim.signals.enable", "true"),
+                Map.entry("scim.event.enable", "true"),
+                Map.entry("scim.signals.test", "true"),
+                Map.entry("scim.signals.ssf.serverUrl", "http://localhost:8888"),
+                Map.entry("scim.signals.pub.iss", "i2scim-it"),
+                Map.entry("scim.signals.pub.aud", "goSignals1"),
+                Map.entry("scim.signals.rcv.iss", "goSignals1"),
+                Map.entry("scim.signals.rcv.aud", "i2scim-it"),
+                Map.entry("scim.signals.pub.unauthorized.retry.max", "2"),
+                Map.entry("scim.signals.pub.unauthorized.retry.delay", "100"),
+                Map.entry("scim.signals.pub.status.check.interval", "500"),
+                Map.entry("scim.signals.pub.idle.verify.interval", "2000"),
+                Map.entry("scim.signals.rcv.unauthorized.retry.max", "2"),
+                Map.entry("scim.signals.rcv.unauthorized.retry.delay", "100"),
+                Map.entry("scim.signals.rcv.status.check.interval", "500"),
+                Map.entry("scim.prov.providerClass", "com.independentid.scim.backend.memory.MemoryProvider"),
+                Map.entry("scim.security.enable", "false")
+        );
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/SsfConfigJsonMigratorTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/SsfConfigJsonMigratorTest.java
@@ -1,0 +1,66 @@
+package com.independentid.scim.test.signals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.independentid.signals.SsfConfigJsonMigrator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SsfConfigJsonMigratorTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void legacyErrorStateTrueBecomesDisabledWithMigrationErrorMsg() throws Exception {
+        JsonNode legacy = mapper.readTree(
+                "{\"pushStream\":{\"errorState\":true,\"endpointUrl\":\"https://example.com/events\"}}");
+
+        JsonNode migrated = SsfConfigJsonMigrator.migrate(legacy);
+
+        JsonNode pushStream = migrated.get("pushStream");
+        assertThat(pushStream.get("status").asText()).isEqualTo("DISABLED");
+        assertThat(pushStream.get("errorMsg").asText()).isEqualTo("migrated from legacy errorState");
+        assertThat(pushStream.has("errorState")).isFalse();
+        assertThat(pushStream.get("endpointUrl").asText()).isEqualTo("https://example.com/events");
+    }
+
+    @Test
+    void legacyErrorStateFalseBecomesEnabledWithNoErrorMsg() throws Exception {
+        JsonNode legacy = mapper.readTree(
+                "{\"pollStream\":{\"errorState\":false,\"endpointUrl\":\"https://example.com/poll\"}}");
+
+        JsonNode migrated = SsfConfigJsonMigrator.migrate(legacy);
+
+        JsonNode pollStream = migrated.get("pollStream");
+        assertThat(pollStream.get("status").asText()).isEqualTo("ENABLED");
+        assertThat(pollStream.has("errorMsg")).isFalse();
+        assertThat(pollStream.has("errorState")).isFalse();
+    }
+
+    @Test
+    void newShapeJsonPassesThroughUnchanged() throws Exception {
+        JsonNode original = mapper.readTree(
+                "{\"pushStream\":{\"status\":\"DISABLED\",\"errorMsg\":\"403 Forbidden\",\"endpointUrl\":\"https://example.com/events\"}," +
+                "\"pollStream\":{\"status\":\"ENABLED\",\"endpointUrl\":\"https://example.com/poll\"}}");
+
+        JsonNode migrated = SsfConfigJsonMigrator.migrate(original);
+
+        assertThat(migrated.get("pushStream").get("status").asText()).isEqualTo("DISABLED");
+        assertThat(migrated.get("pushStream").get("errorMsg").asText()).isEqualTo("403 Forbidden");
+        assertThat(migrated.get("pollStream").get("status").asText()).isEqualTo("ENABLED");
+    }
+
+    @Test
+    void missingBothFieldsLeavesStreamUntouched() throws Exception {
+        JsonNode original = mapper.readTree(
+                "{\"pushStream\":{\"endpointUrl\":\"https://example.com/events\"}}");
+
+        JsonNode migrated = SsfConfigJsonMigrator.migrate(original);
+
+        JsonNode pushStream = migrated.get("pushStream");
+        assertThat(pushStream.has("status")).isFalse();
+        assertThat(pushStream.has("errorState")).isFalse();
+        assertThat(pushStream.get("endpointUrl").asText()).isEqualTo("https://example.com/events");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/StatusEndpointResolverTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/StatusEndpointResolverTest.java
@@ -1,0 +1,120 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.StatusEndpointResolver;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StatusEndpointResolverTest {
+
+    @Test
+    void wellKnownAdvertisesStatusEndpointReturnsThatUrl() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        stubResponse(client, 200, "{\"status_endpoint\":\"https://recv.example.com/ssf/status\"}");
+
+        StatusEndpointResolver resolver = new StatusEndpointResolver(client);
+
+        Optional<URI> result = resolver.resolve(URI.create("https://recv.example.com"),
+                URI.create("https://recv.example.com/ssf/events"));
+
+        assertThat(result).contains(URI.create("https://recv.example.com/ssf/status"));
+    }
+
+    @Test
+    void wellKnownReachableWithoutStatusEndpointMarksUnsupportedAndReturnsEmpty() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        stubResponse(client, 200, "{\"issuer\":\"foo\"}");
+
+        StatusEndpointResolver resolver = new StatusEndpointResolver(client);
+
+        Optional<URI> result = resolver.resolve(URI.create("https://recv.example.com"),
+                URI.create("https://recv.example.com/ssf/events"));
+
+        assertThat(result).isEmpty();
+        assertThat(resolver.isMarkedUnsupported(URI.create("https://recv.example.com"))).isTrue();
+    }
+
+    @Test
+    void wellKnownUnreachableFallsBackToDerivedUrl() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        when(client.execute(any(HttpGet.class))).thenThrow(new IOException("connection refused"));
+
+        StatusEndpointResolver resolver = new StatusEndpointResolver(client);
+
+        Optional<URI> result = resolver.resolve(URI.create("https://recv.example.com"),
+                URI.create("https://recv.example.com/ssf/events"));
+
+        assertThat(result).contains(URI.create("https://recv.example.com/ssf/status"));
+        assertThat(resolver.isMarkedUnsupported(URI.create("https://recv.example.com"))).isFalse();
+    }
+
+    @Test
+    void resolveCachesSuccessfulLookup() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        stubResponse(client, 200, "{\"status_endpoint\":\"https://recv.example.com/ssf/status\"}");
+
+        StatusEndpointResolver resolver = new StatusEndpointResolver(client);
+        URI host = URI.create("https://recv.example.com");
+        URI endpoint = URI.create("https://recv.example.com/ssf/events");
+
+        resolver.resolve(host, endpoint);
+        resolver.resolve(host, endpoint);
+
+        verify(client, times(1)).execute(any(HttpGet.class));
+    }
+
+    @Test
+    void invalidateForcesFreshLookup() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        stubResponse(client, 200, "{\"status_endpoint\":\"https://recv.example.com/ssf/status\"}");
+
+        StatusEndpointResolver resolver = new StatusEndpointResolver(client);
+        URI host = URI.create("https://recv.example.com");
+        URI endpoint = URI.create("https://recv.example.com/ssf/events");
+
+        resolver.resolve(host, endpoint);
+        resolver.invalidate(host);
+        resolver.resolve(host, endpoint);
+
+        verify(client, times(2)).execute(any(HttpGet.class));
+    }
+
+    @Test
+    void unsupportedMarkSticksAcrossSubsequentResolves() throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        stubResponse(client, 200, "{\"issuer\":\"foo\"}");
+
+        StatusEndpointResolver resolver = new StatusEndpointResolver(client);
+        URI host = URI.create("https://recv.example.com");
+        URI endpoint = URI.create("https://recv.example.com/ssf/events");
+
+        resolver.resolve(host, endpoint);
+        resolver.resolve(host, endpoint);
+
+        // Once unsupported, no further well-known fetches
+        verify(client, times(1)).execute(any(HttpGet.class));
+    }
+
+    private static void stubResponse(CloseableHttpClient client, int code, String body) throws IOException {
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+        HttpEntity entity = mock(HttpEntity.class);
+        when(response.getCode()).thenReturn(code);
+        when(response.getEntity()).thenReturn(entity);
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(body.getBytes()));
+        when(client.execute(any(HttpGet.class))).thenReturn(response);
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/StreamMaintenanceSchedulerTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/StreamMaintenanceSchedulerTest.java
@@ -1,0 +1,94 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.signals.StreamMaintenanceScheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class StreamMaintenanceSchedulerTest {
+
+    private StreamMaintenanceScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new StreamMaintenanceScheduler();
+    }
+
+    @AfterEach
+    void tearDown() {
+        scheduler.shutdown();
+    }
+
+    @Test
+    void scheduledTaskRunsAtTheConfiguredCadence() throws Exception {
+        CountDownLatch ranAtLeastTwice = new CountDownLatch(2);
+
+        scheduler.schedulePausedRecheck("stream-a", ranAtLeastTwice::countDown, Duration.ofMillis(50));
+
+        assertThat(ranAtLeastTwice.await(2, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void cancelStopsScheduledTask() throws Exception {
+        AtomicInteger counter = new AtomicInteger();
+
+        scheduler.schedulePausedRecheck("stream-a", counter::incrementAndGet, Duration.ofMillis(50));
+        Thread.sleep(120);
+        scheduler.cancelPausedRecheck("stream-a");
+        int countAtCancel = counter.get();
+        Thread.sleep(200);
+
+        assertThat(counter.get()).isCloseTo(countAtCancel, org.assertj.core.data.Offset.offset(1));
+    }
+
+    @Test
+    void multipleStreamsHaveIndependentTasks() throws Exception {
+        CountDownLatch streamA = new CountDownLatch(1);
+        CountDownLatch streamB = new CountDownLatch(1);
+
+        scheduler.schedulePausedRecheck("stream-a", streamA::countDown, Duration.ofMillis(50));
+        scheduler.schedulePausedRecheck("stream-b", streamB::countDown, Duration.ofMillis(50));
+
+        assertThat(streamA.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(streamB.await(2, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void cancelIsIdempotentForUnscheduledKey() {
+        assertThatCode(() -> scheduler.cancelPausedRecheck("never-scheduled"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void reschedulingSameKeyReplacesPriorTask() throws Exception {
+        AtomicInteger originalRunCount = new AtomicInteger();
+        CountDownLatch replacementRan = new CountDownLatch(1);
+
+        scheduler.schedulePausedRecheck("stream-a", originalRunCount::incrementAndGet, Duration.ofMillis(50));
+        Thread.sleep(80);
+        scheduler.schedulePausedRecheck("stream-a", replacementRan::countDown, Duration.ofMillis(50));
+
+        assertThat(replacementRan.await(2, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void shutdownStopsAllScheduledWork() throws Exception {
+        AtomicInteger counter = new AtomicInteger();
+        scheduler.schedulePausedRecheck("stream-a", counter::incrementAndGet, Duration.ofMillis(50));
+        Thread.sleep(120);
+
+        scheduler.shutdown();
+        int countAtShutdown = counter.get();
+        Thread.sleep(200);
+
+        assertThat(counter.get()).isEqualTo(countAtShutdown);
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/StreamStateHolderTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/StreamStateHolderTest.java
@@ -1,0 +1,68 @@
+package com.independentid.scim.test.signals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.independentid.signals.StreamStateHolder;
+import com.independentid.signals.StreamStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StreamStateHolderTest {
+
+    @Test
+    void newHolderIsEnabledWithNoErrorMsg() {
+        StreamStateHolder holder = new StreamStateHolder();
+
+        assertThat(holder.getStatus()).isEqualTo(StreamStatus.ENABLED);
+        assertThat(holder.getErrorMsg()).isNull();
+    }
+
+    @Test
+    void transitionToDisabledUpdatesStatusAndErrorMsg() {
+        StreamStateHolder holder = new StreamStateHolder();
+
+        holder.transitionTo(StreamStatus.DISABLED, "403 Forbidden");
+
+        assertThat(holder.getStatus()).isEqualTo(StreamStatus.DISABLED);
+        assertThat(holder.getErrorMsg()).isEqualTo("403 Forbidden");
+    }
+
+    @Test
+    void sameStateTransitionDoesNotFireListener() {
+        StreamStateHolder holder = new StreamStateHolder();
+        List<String> events = new ArrayList<>();
+        holder.addTransitionListener((oldS, newS) -> events.add(oldS + "->" + newS));
+
+        holder.transitionTo(StreamStatus.ENABLED, "still enabled");
+
+        assertThat(events).isEmpty();
+        assertThat(holder.getStatus()).isEqualTo(StreamStatus.ENABLED);
+    }
+
+    @Test
+    void pausedStatusSerializesAsEnabledButRuntimeFieldUnchanged() throws Exception {
+        StreamStateHolder holder = new StreamStateHolder();
+        holder.transitionTo(StreamStatus.PAUSED, "remote paused");
+
+        String json = new ObjectMapper().writeValueAsString(holder);
+
+        assertThat(json).contains("\"status\":\"ENABLED\"");
+        assertThat(json).doesNotContain("PAUSED");
+        assertThat(holder.getStatus()).isEqualTo(StreamStatus.PAUSED);
+    }
+
+    @Test
+    void differentStateTransitionFiresListenerWithOldAndNew() {
+        StreamStateHolder holder = new StreamStateHolder();
+        List<String> events = new ArrayList<>();
+        holder.addTransitionListener((oldS, newS) -> events.add(oldS + "->" + newS));
+
+        holder.transitionTo(StreamStatus.PAUSED, "remote paused");
+        holder.transitionTo(StreamStatus.ENABLED, "remote re-enabled");
+
+        assertThat(events).containsExactly("ENABLED->PAUSED", "PAUSED->ENABLED");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/VerifyEventBuilderTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/VerifyEventBuilderTest.java
@@ -1,0 +1,66 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.PushStream;
+import com.independentid.signals.VerifyEventBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VerifyEventBuilderTest {
+
+    @Test
+    void buildProducesEventWithSsfVerificationEventType() throws Exception {
+        PushStream stream = newStream();
+
+        SecurityEventToken event = VerifyEventBuilder.build(stream);
+
+        String json = event.toJsonString();
+        assertThat(json).contains("https://schemas.openid.net/secevent/ssf/event-type/verification");
+    }
+
+    @Test
+    void buildPopulatesIssuerFromStream() throws Exception {
+        PushStream stream = newStream();
+
+        SecurityEventToken event = VerifyEventBuilder.build(stream);
+
+        assertThat(event.getIssuer()).isEqualTo("test-issuer");
+    }
+
+    @Test
+    void buildPopulatesAudienceFromStream() throws Exception {
+        PushStream stream = newStream();
+
+        SecurityEventToken event = VerifyEventBuilder.build(stream);
+
+        assertThat(event.getAud()).contains("test-audience");
+    }
+
+    @Test
+    void buildPopulatesJtiAndIat() throws Exception {
+        PushStream stream = newStream();
+
+        SecurityEventToken event = VerifyEventBuilder.build(stream);
+
+        assertThat(event.getJti()).isNotBlank();
+        assertThat(event.getIssuedAt()).isNotNull();
+    }
+
+    @Test
+    void buildProducesUniqueJtiPerCall() throws Exception {
+        PushStream stream = newStream();
+
+        SecurityEventToken first = VerifyEventBuilder.build(stream);
+        SecurityEventToken second = VerifyEventBuilder.build(stream);
+
+        assertThat(first.getJti()).isNotEqualTo(second.getJti());
+    }
+
+    private PushStream newStream() {
+        PushStream stream = new PushStream();
+        stream.iss = "test-issuer";
+        stream.aud = "test-audience";
+        return stream;
+    }
+}


### PR DESCRIPTION
Closes #66, #67, #68, #69, #70, #71

Implements PRD-A (#63) — operational vocabulary parity between i2scim's signals client and goSignals, as documented in `i2goSignals/docs/operations.md`.

## Summary

Six tracer-bullet slices, one PR. Each slice is independently green and the build stays green between commits.

| Slice | What |
|---|---|
| #66 | Tri-state `StreamStatus` enum + `StreamStateHolder` + `SsfConfigJsonMigrator` |
| #67 | `PushFailureClassifier` / `PollFailureClassifier` + `RetryStrategy` |
| #68 | `StatusEndpointResolver` (M4) + `RemoteStatusProbe` (M5) + `StreamMaintenanceScheduler` (M7) + T1/T2 + paused recheck |
| #69 | `VerifyEventBuilder` (M8) + idle keepalive (T3) + `lastSuccessfulPush` |
| #70 | `Rfc8935ErrorParser` + §2.4 handling + `jws_signature_failed` PEM-reload retry-once |
| #71 | End-to-end goSignals integration test skeleton (`@Disabled`, surefire-excluded) |

## Post-slice fixes on this branch

Surfaced during integration testing against goSignals; landed on this branch since they belong with PRD-A's vocabulary work:

- **`74a7390` — Documentation.** Operational vocabulary section added to `docs/Signals.md` (lifecycle table, failure classification, T1/T2/T3, RFC8935 §2.4, ssfConfig.json migration).
- **`5bab9b2` — SSF §7.1.2 stream_id query param.** `RemoteStatusProbe` now appends `?stream_id=<id>` to status-endpoint GETs as required by the SSF spec; goSignals' status endpoint returned 400 without it. URL-encodes the id and preserves any pre-existing query string. Skips the probe and returns `UNKNOWN` if streamId is missing. Audit of every other SSF endpoint call in the signals package found no further compliance gaps.
- **`ece1ef2` — Verify-event NPE.** `SecurityEventToken.getTxn()` returned NPE when the `txn` claim was absent — but per RFC 8417 §2.2 `txn` is OPTIONAL, and SSF verification events do not carry one. Now returns null when absent. `SignalsEventHandler.consume()` also detects `op == null` (verification event or unsubscribed event type) and acks-and-skips before reaching the worker pool, so verify events no longer trigger redelivery loops.

## What's verified

- 102 unit + mock-orchestration tests across 15 test files, all green.
- `mvn install -DskipTests` clean.
- Slice 1 lift-and-shifts every existing `errorState=true` path to `Status=DISABLED` with derived `errorMsg`; subsequent slices refine the classification and add T1/T2/T3.
- `StreamStateHolder.transitionTo` is synchronized; listener list is `CopyOnWriteArrayList` so the scheduler thread can transition state independently of the producer.
- 429 with `Retry-After` is honored and never auto-disables (peer back-pressure invariant).
- Shutdown-mode poll ack (`retries=0`) bypasses state transitions; verified in `PollStreamFailureTest`.
- `ssfConfig.json` migrates legacy `errorState` on read; new code writes only the new shape. Soft roll-back incompatibility documented in PRD-A.

## What's not verified

- The seven scenarios in `SignalsGoSignalsIT.java` (slice 6 / #71) are stubbed and `@Disabled` because they require `docker compose -f docker-compose-signals.yml up` running. The class compiles and is excluded from default surefire. Operators flip `@Disabled` off and fill in assertions during HITL QA.
- Existing `SignalsEventHandlerTest` and `SignalsEventMapperTest` are `@QuarkusTest` requiring MongoDB; out of scope for the unit-test acceptance criteria of slices 1–5. Compile-clean against the new code.

## Out of scope (covered in PRD-B and PRD-C)

- Durable `pendingPushes` / `pendingAcks` collections; restart survival of in-flight retries; elapsed-time retry caps; pro-active PEM-change watcher → PRD-B (#64).
- `ResetDate` / `ResetJti` operator levers; persistent SCIM-op→SET audit log; `Operational=true` event tagging → PRD-C (#65).
- Per-event ack-error reporting (RFC8936 §3.1).

## Test plan

- [ ] `mvn install -DskipTests` succeeds (verified).
- [ ] All 102 unit tests pass (verified).
- [ ] Run `docker compose -f docker-compose-signals.yml up -d`, remove `@Disabled` from `SignalsGoSignalsIT`, fill scenario assertions, verify each scenario passes.
- [ ] Existing `@QuarkusTest` signals tests (`SignalsEventHandlerTest`, `SignalsEventMapperTest`) pass against MongoDB.
- [ ] Manual upgrade smoke test: load a pre-A `ssfConfig.json` with `errorState: true` on `pushStream`; confirm migration to `status=DISABLED` with `errorMsg="migrated from legacy errorState"`.
- [ ] Live-fire verification event round-trip against goSignals: confirm verify event is acked and no NPE on the receiver.

## New configuration

Seven new properties (see slice issues for detail). Existing retry/cadence properties unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)