### PR TITLE
PRD #82: observability stack — JSON logs (#83) + /q/metrics (#84)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,33 @@ adapted to act as a gateway to internal proprietary identity APIs by implementin
 
 ## Recent Updates
 
+# Release 0.10.2
+
+This release wires i2scim into the i2goSignals observability stack
+(Loki + Prometheus) so dev operators get unified logs and metrics for
+SCIM peers alongside goSignals services. JSON logging is env-gated; the
+prod default (text format on stdout) is unchanged.
+
+* **Env-gated JSON console logging** — Set `QUARKUS_LOG_CONSOLE_JSON=true`
+  to emit JSON records whose keys match the i2goSignals Loki schema:
+  `time`, `level`, `msg`, `component`, plus the static fields `service`
+  (`"i2scim"`) and `version`. Default off; prod stdout stays text.
+* **Per-container identity** — `NODE_ID` and `CLUSTER_NAME` env vars are
+  appended to every JSON record so `{node_id="..."}` and
+  `{cluster_name="..."}` Loki/LogQL queries select individual peers.
+  Unset → `"unknown"` sentinel (SmallRye Config rejects an empty
+  `additional-field.value`).
+* **Prometheus metrics at `/q/metrics`** — The Micrometer endpoint moves
+  from `/metrics` to `/q/metrics` so it sits under Quarkus's
+  non-application root and is reachable anonymously (matching the
+  `/q/health` posture). Use `Accept: text/plain;version=0.0.4` for the
+  legacy Prometheus text format; the default Accept negotiation returns
+  OpenMetrics 1.0.0. K8s manifests updated to point
+  `prometheus.io/path` at the new path.
+* **Startup banner** — The server logs `i2scim server v<version>` on
+  startup so the version is visible in the unified log stream without
+  needing to inspect the image tag.
+
 # Release 0.10.1
 
 This release makes i2scim's Signals client behave the way operators of

--- a/i2scim-client/pom.xml
+++ b/i2scim-client/pom.xml
@@ -39,7 +39,7 @@
     <parent>
         <groupId>com.independentid</groupId>
         <artifactId>i2scim-root</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
     </parent>
     <scm>
         <connection>scm:git:https://github.com/i2-open/i2scim.git</connection>

--- a/i2scim-core/pom.xml
+++ b/i2scim-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.independentid</groupId>
         <artifactId>i2scim-root</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
     </parent>
 
     <artifactId>i2scim-core</artifactId>

--- a/i2scim-server/k8s/README.md
+++ b/i2scim-server/k8s/README.md
@@ -52,7 +52,7 @@ For a fault-tolerant deployment, run an external MongoDB replica set or sharded 
 
 ## Health and observability
 
-The image exposes the standard Quarkus health endpoints (`/q/health/live`, `/q/health/ready`) and a Prometheus-format metrics endpoint at `/metrics` (configured via `quarkus.micrometer.export.prometheus.path`). Both deployment files set the standard `prometheus.io/*` annotations for scrape discovery.
+The image exposes the standard Quarkus health endpoints (`/q/health/live`, `/q/health/ready`) and a Prometheus-format metrics endpoint at `/q/metrics` on port 8080 (configured via `quarkus.micrometer.export.prometheus.path`). The endpoint is anonymous (it sits under Quarkus's non-application root, outside the SCIM auth filter) so dev/cluster Prometheus instances can scrape it without credentials. Prometheus selects the 0.0.4 text format with `Accept: text/plain;version=0.0.4`; the default Accept negotiation returns OpenMetrics 1.0.0, which Prometheus also handles. Both deployment files set the standard `prometheus.io/*` annotations for scrape discovery — point the scrape path at `/q/metrics`.
 
 ## See also
 

--- a/i2scim-server/k8s/memory/4-i2scim-memory-deploy.yml
+++ b/i2scim-server/k8s/memory/4-i2scim-memory-deploy.yml
@@ -6,7 +6,7 @@ metadata:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
     prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+    prometheus.io/path: /q/metrics
   labels:
     app.kubernetes.io/name: i2scim-mem
     app.kubernetes.io/version: 0.7.0-Alpha
@@ -20,7 +20,7 @@ metadata:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
     prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+    prometheus.io/path: /q/metrics
   labels:
     app.kubernetes.io/name: i2scim-mem
     app.kubernetes.io/version: 0.7.0-Alpha
@@ -56,7 +56,7 @@ metadata:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
     prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+    prometheus.io/path: /q/metrics
   labels:
     app.kubernetes.io/name: i2scim-mem
     app.kubernetes.io/version: 0.7.0-Alpha
@@ -74,7 +74,7 @@ spec:
         prometheus.io/port: "8080"
         prometheus.io/scheme: http
         prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
+        prometheus.io/path: /q/metrics
       labels:
         app.kubernetes.io/name: i2scim-mem
         app.kubernetes.io/version: 0.7.0-Alpha

--- a/i2scim-server/k8s/mongo/4-i2scim-mongo-set.yml
+++ b/i2scim-server/k8s/mongo/4-i2scim-mongo-set.yml
@@ -9,7 +9,7 @@ metadata:
     app.quarkus.io/vcs-url: https://github.com/independentid/i2scim.git
     app.quarkus.io/build-timestamp: 2021-06-29 - 17:36:09 +0000
     prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+    prometheus.io/path: /q/metrics
   labels:
     app.kubernetes.io/name: i2scim-mongo
     app.kubernetes.io/version: 0.6.1
@@ -26,7 +26,7 @@ metadata:
     app.quarkus.io/vcs-url: https://github.com/independentid/i2scim.git
     app.quarkus.io/build-timestamp: 2021-06-29 - 17:36:09 +0000
     prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+    prometheus.io/path: /q/metrics
   labels:
     app.kubernetes.io/name: i2scim-mongo
     app.kubernetes.io/version: 0.6.1
@@ -62,7 +62,7 @@ metadata:
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
     prometheus.io/scrape: "true"
-    prometheus.io/path: /metrics
+    prometheus.io/path: /q/metrics
   labels:
     app.kubernetes.io/name: i2scim-mongo
     app.kubernetes.io/version: 0.6.1
@@ -81,7 +81,7 @@ spec:
         prometheus.io/port: "8080"
         prometheus.io/scheme: http
         prometheus.io/scrape: "true"
-        prometheus.io/path: /metrics
+        prometheus.io/path: /q/metrics
       labels:
         app.kubernetes.io/name: i2scim-mongo
         app.kubernetes.io/version: 0.6.1

--- a/i2scim-server/pom.xml
+++ b/i2scim-server/pom.xml
@@ -77,6 +77,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-logging-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
         <dependency>

--- a/i2scim-server/pom.xml
+++ b/i2scim-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.independentid</groupId>
         <artifactId>i2scim-root</artifactId>
-        <version>0.10.1</version>
+        <version>0.10.2</version>
     </parent>
 
     <artifactId>i2scim-server</artifactId>

--- a/i2scim-server/src/main/java/com/independentid/scim/server/StartupBanner.java
+++ b/i2scim-server/src/main/java/com/independentid/scim/server/StartupBanner.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.server;
+
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ApplicationScoped
+public class StartupBanner {
+
+    private static final Logger logger = LoggerFactory.getLogger(StartupBanner.class);
+
+    @ConfigProperty(name = "quarkus.application.version")
+    String version;
+
+    void onStart(@Observes StartupEvent ev) {
+        logger.info("i2scim server v{}", version);
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -339,7 +339,7 @@ public class SsfHandler {
         try {
             gen = JsonUtil.getGenerator(stringWriter, true);
             gen.writeStartObject();
-            gen.writeStringField("description", "i2scim.io v0.9.3");
+            gen.writeStringField("description", "i2scim.io v0.10.2");
             gen.writeArrayFieldStart("scopes");
             gen.writeString("admin");
             gen.writeString("stream");

--- a/i2scim-server/src/main/resources/application.properties
+++ b/i2scim-server/src/main/resources/application.properties
@@ -138,9 +138,13 @@ mp.jwt.verify.audiences=aud.test.i2scim.io
 #mp.jwt.verify.publickey={"keys":[{"kty":"RSA","kid":"i2scim","use":"Key used for i2scim testing purposes ONLY!","n":"taCP35lFs85YNnjpKqbCASaosD7QdZjGnDqWoZs93wbYHbqGRMEVQ4YInNd5MsZKcF3gGtHqo0DVM_CDiRIZxcZZuwZ3BBtRmBuQafytOCkNZKjfoOE6ptnHO9oTkyhKiNJIs-lKRldP-SDUHZ_Oux8dAnD-kJhjijInRJJkqsaO-gH26sv95O7k5S0Jm-ERr0Tqfostf0k_YM9elYXXzh7CQi3rGZ9h-ccckkcs8i-J4BVVsBDruO5Rxvtt5KVEUp0PuCrLLuqmCuhjL-JdE4EiuomdJDbAqmmQZ6Ef6g_nUH_4WcCtDtN_LerTgEzIz9D7i8NV_0Ho311R9Lt4GQ","e":"AQAB"}]}
 
 #DEVOPS and Monitoring
-#quarkus.micrometer.export.prometheus.path=
-
-quarkus.micrometer.export.prometheus.path=/metrics
+# Prometheus metrics are served at /q/metrics (Quarkus non-application root
+# prefix `/q/` + the Micrometer registry path). Keeping the endpoint under
+# `/q/*` puts it outside the SCIM servlet's auth filter — matching the
+# `/q/health` anonymous posture and what the i2goSignals dev Prometheus
+# instance expects to scrape (issue #84). Do not move it back to the
+# application root unless you also wire it through the auth allowlist.
+quarkus.micrometer.export.prometheus.path=/q/metrics
 quarkus.micrometer.binder.http-server.enabled=true
 
 

--- a/i2scim-server/src/main/resources/application.properties
+++ b/i2scim-server/src/main/resources/application.properties
@@ -53,6 +53,35 @@ scim.root.dir=/scim
 quarkus.log.min-level=FINE
 #quarkus.log.category."com.independentid.scim".min-level=DEBUG
 
+# JSON console logging — env-gated. Default off so prod stdout stays in human-readable
+# text format; flip QUARKUS_LOG_CONSOLE_JSON=true (i2goSignals dev compose) to emit
+# structured records that match the i2goSignals Loki schema.
+# Note: the parent property `quarkus.log.console.json` is deprecated in Quarkus 3.19+;
+# we wire the new `quarkus.log.console.json.enabled` key from the original env var via a
+# property expression so operators keep the documented QUARKUS_LOG_CONSOLE_JSON contract
+# without the deprecation warning at boot.
+quarkus.log.console.json.enabled=${QUARKUS_LOG_CONSOLE_JSON:false}
+# Rename Quarkus default JSON keys to the i2goSignals schema:
+#   timestamp -> time, message -> msg, loggerName (enum LOGGER_NAME) -> component.
+# Property keys must match the JBoss StructuredFormatter.Key enum name (uppercased
+# after parsing), so "logger_name" is required here instead of camelCase "loggerName".
+quarkus.log.console.json.key-overrides=timestamp=time,message=msg,logger_name=component
+# Static identity fields appended to every JSON record. `service` is a constant
+# identifier so a single Loki query (`{service="i2scim"}`) selects all SCIM peers;
+# `version` carries the Maven artifact version so deployments are distinguishable
+# without re-tagging containers.
+quarkus.log.console.json.additional-field.service.value=i2scim
+quarkus.log.console.json.additional-field.version.value=${quarkus.application.version}
+# Per-container identity supplied by the deployment environment. Operators set
+# NODE_ID / CLUSTER_NAME via compose / k8s env. The "unknown" default is required
+# because SmallRye Config rejects an empty string for additional-field.value
+# (the built-in String converter treats "" as null and fails @ConfigMapping
+# validation, see SRCFG00040). "unknown" is a deliberate, clearly non-id sentinel
+# so an operator missing the env in a deployment sees the gap explicitly in Loki
+# instead of an unresolved literal "${NODE_ID}".
+quarkus.log.console.json.additional-field.node_id.value=${NODE_ID:unknown}
+quarkus.log.console.json.additional-field.cluster_name.value=${CLUSTER_NAME:unknown}
+
 # HTTP Logging
 quarkus.http.access-log.enabled=true
 quarkus.http.access-log.log-to-file=true

--- a/i2scim-server/src/test/java/com/independentid/scim/test/devops/PrometheusMetricsEndpointTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/devops/PrometheusMetricsEndpointTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.devops;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the i2goSignals scrape contract for issue #84: Prometheus-format
+ * application metrics must be reachable at {@code /q/metrics} on the
+ * application port with no authentication required, even when SCIM security
+ * is enabled. The endpoint is what the i2goSignals dev Prometheus instance
+ * scrapes — moving it back under {@code /q/*} keeps it outside the SCIM
+ * servlet's auth filter (matching the {@code /q/health} anonymous posture).
+ */
+@QuarkusTest
+@TestProfile(PrometheusMetricsTestProfile.class)
+class PrometheusMetricsEndpointTest {
+
+    @TestHTTPResource("/")
+    URL baseUrl;
+
+    @Test
+    void metricsEndpointReturns200WithoutAuth() throws Exception {
+        URL rUrl = new URL(baseUrl, "/q/metrics");
+        HttpGet get = new HttpGet(rUrl.toString());
+        // Deliberately omit Authorization header — endpoint must be anonymous
+        // because Prometheus dev-stack scrape does not present credentials.
+
+        try (ClassicHttpResponse resp = com.independentid.scim.test.misc.TestUtils.executeRequest(get)) {
+            assertThat(resp.getCode())
+                    .as("GET /q/metrics with no auth must return 200")
+                    .isEqualTo(200);
+        }
+    }
+
+    @Test
+    void metricsBodyContainsMicrometerDefaultSeries() throws Exception {
+        // Seed the http-server timer with one observed request so the
+        // http_server_requests_seconds_count series materialises in the
+        // export (Micrometer omits zero-observation timers).
+        HttpGet seed = new HttpGet(new URL(baseUrl, "/q/health").toString());
+        try (ClassicHttpResponse seeded = com.independentid.scim.test.misc.TestUtils.executeRequest(seed)) {
+            assertThat(seeded.getCode()).isEqualTo(200);
+            EntityUtils.consumeQuietly(seeded.getEntity());
+        }
+
+        HttpGet get = new HttpGet(new URL(baseUrl, "/q/metrics").toString());
+        // Request the Prometheus 0.0.4 text format (Quarkus would otherwise
+        // negotiate OpenMetrics by default; both work for Prometheus scrape
+        // but the legacy 0.0.4 names are what the acceptance criterion lists).
+        get.addHeader("Accept", "text/plain;version=0.0.4");
+
+        try (ClassicHttpResponse resp = com.independentid.scim.test.misc.TestUtils.executeRequest(get)) {
+            HttpEntity entity = resp.getEntity();
+            String body = EntityUtils.toString(entity);
+
+            assertThat(resp.getCode()).isEqualTo(200);
+            assertThat(body)
+                    .as("JVM memory binder must be active")
+                    .contains("jvm_memory_used_bytes");
+            // i2scim runs on Quarkus + Undertow (not Vert.x HTTP), so the
+            // HTTP server binder exposes request-level metrics as
+            // `http_server_active_requests` (a gauge) and per-request byte
+            // counters rather than the Vert.x-only
+            // `http_server_requests_seconds_count` timer. The substance the
+            // acceptance criterion for #84 cares about — that HTTP request
+            // observability is on — is proved by either.
+            assertThat(body)
+                    .as("HTTP request observability must be active (http-server.enabled=true)")
+                    .contains("http_server_active_requests")
+                    .contains("http_server_bytes_read_count");
+            assertThat(body)
+                    .as("Process uptime binder must be active")
+                    .contains("process_uptime_seconds");
+        }
+    }
+
+    @Test
+    void metricsContentTypeIsPrometheusTextFormat() throws Exception {
+        URL rUrl = new URL(baseUrl, "/q/metrics");
+        HttpGet get = new HttpGet(rUrl.toString());
+        // Explicit Prometheus 0.0.4 Accept — what real Prometheus instances
+        // present when they want the legacy text format and what the
+        // acceptance criterion for issue #84 calls out.
+        get.addHeader("Accept", "text/plain;version=0.0.4");
+
+        try (ClassicHttpResponse resp = com.independentid.scim.test.misc.TestUtils.executeRequest(get)) {
+            assertThat(resp.getCode()).isEqualTo(200);
+
+            Header[] cts = resp.getHeaders("Content-Type");
+            assertThat(cts).as("Content-Type header present").isNotEmpty();
+            String ct = cts[0].getValue();
+            assertThat(ct)
+                    .as("Prometheus text format (RFC: text/plain; version=0.0.4)")
+                    .startsWith("text/plain")
+                    .contains("version=0.0.4");
+        }
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/devops/PrometheusMetricsTestProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/devops/PrometheusMetricsTestProfile.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.devops;
+
+import com.independentid.scim.backend.memory.MemoryProvider;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+/**
+ * Profile for {@link PrometheusMetricsEndpointTest}. Security is left
+ * <em>enabled</em> (the prod posture) precisely so the test can prove that
+ * {@code /q/metrics} is reachable without an Authorization header — moving
+ * the endpoint under {@code /q/*} must take it outside the SCIM auth filter.
+ * Memory provider keeps the test self-contained (no Mongo dependency).
+ */
+public class PrometheusMetricsTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "scim.prov.providerClass", MemoryProvider.class.getName(),
+                "scim.security.enable", "true",
+                "scim.event.enable", "false",
+                "scim.root.dir", "."
+        );
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "PrometheusMetricsTestProfile";
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/devops/ScimHealthTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/devops/ScimHealthTest.java
@@ -235,16 +235,19 @@ public class ScimHealthTest {
 
     @Test
     public void d_metricsCheckJwt() throws Exception {
-        URL rUrl = new URL(baseUrl, "/metrics");
+        // Endpoint moved from /metrics to /q/metrics (issue #84) so the dev
+        // Prometheus scrape can reach it without going through the SCIM auth
+        // filter. The JWT header is left in to prove that supplying one
+        // doesn't break the endpoint — `/q/metrics` is anonymous either way.
+        URL rUrl = new URL(baseUrl, "/q/metrics");
         HttpGet get = new HttpGet(rUrl.toString());
         get.addHeader(HttpHeaders.AUTHORIZATION, bearer);
-        get.addHeader(HttpHeaders.ACCEPT, "text/plain");
+        get.addHeader(HttpHeaders.ACCEPT, "text/plain;version=0.0.4");
         ClassicHttpResponse resp = TestUtils.executeRequest(get);
         HttpEntity entity = resp.getEntity();
 
         String body = EntityUtils.toString(entity);
-        System.out.println("METRICS BODY:\n" + body);
-        logger.info("/metrics\n" + body);
+        logger.info("/q/metrics\n" + body);
 
         assertThat(resp.getCode())
                 .as("Check metrics response received ok")

--- a/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogDisabledProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogDisabledProfile.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.logging;
+
+import com.independentid.scim.backend.memory.MemoryProvider;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+/**
+ * JSON logging *disabled* — matches prod default. Used to verify that when an
+ * operator does not set {@code QUARKUS_LOG_CONSOLE_JSON=true} the console
+ * handler still uses the human-readable PatternFormatter (no regression).
+ */
+public class JsonLogDisabledProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.log.console.json.enabled", "false",
+                "scim.prov.providerClass", MemoryProvider.class.getName(),
+                "scim.security.enable", "false",
+                "scim.event.enable", "false",
+                "scim.root.dir", "."
+        );
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "JsonLogDisabledProfile";
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogDisabledTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogDisabledTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.logging;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression guard for the env-gated rollout: when JSON logging is disabled
+ * (the prod default and the path operators get when they don't set
+ * QUARKUS_LOG_CONSOLE_JSON), the console handler must emit human-readable text,
+ * not JSON. A failure here means we shipped JSON-by-default and broke every
+ * existing log consumer that expects the text format.
+ */
+@QuarkusTest
+@TestProfile(JsonLogDisabledProfile.class)
+class JsonLogDisabledTest {
+
+    @Test
+    void defaultFormatterIsTextNotJson() throws Exception {
+        Formatter formatter = JsonLogFormatTest.consoleFormatter();
+        LogRecord record = new LogRecord(Level.INFO, "hello text-mode");
+        record.setLoggerName("com.example.Demo");
+
+        String line = formatter.format(record);
+
+        assertThat(line)
+                .as("text formatter must not emit JSON-looking output")
+                .doesNotStartWith("{");
+        // The PatternFormatter renders the message verbatim somewhere in the line;
+        // JsonFormatter would have quoted it.
+        assertThat(line).contains("hello text-mode");
+        assertThat(line).doesNotContain("\"msg\"");
+        assertThat(line).doesNotContain("\"time\"");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogFormatTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogFormatTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that with {@code quarkus.log.console.json=true} the root console
+ * handler emits records whose JSON keys match the i2goSignals schema:
+ * {@code time}, {@code level}, {@code msg}, {@code component}.
+ */
+@QuarkusTest
+@TestProfile(JsonLoggingEnabledProfile.class)
+class JsonLogFormatTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void formatterProducesJsonWithRenamedKeys() throws Exception {
+        Formatter formatter = consoleFormatter();
+        LogRecord record = new LogRecord(Level.INFO, "hello world");
+        record.setLoggerName("com.example.Demo");
+        record.setMillis(System.currentTimeMillis());
+
+        String line = formatter.format(record).trim();
+
+        JsonNode json = MAPPER.readTree(line);
+        assertThat(json.has("time")).as("renamed timestamp -> time").isTrue();
+        assertThat(json.has("level")).as("level retained").isTrue();
+        assertThat(json.has("msg")).as("renamed message -> msg").isTrue();
+        assertThat(json.has("component")).as("renamed loggerName -> component").isTrue();
+
+        assertThat(json.get("msg").asText()).isEqualTo("hello world");
+        assertThat(json.get("component").asText()).isEqualTo("com.example.Demo");
+        assertThat(json.get("level").asText()).isEqualTo("INFO");
+
+        // None of the legacy Quarkus default keys should leak through.
+        assertThat(json.has("timestamp")).as("default timestamp must be renamed").isFalse();
+        assertThat(json.has("message")).as("default message must be renamed").isFalse();
+        assertThat(json.has("loggerName")).as("default loggerName must be renamed").isFalse();
+    }
+
+    @Test
+    void unsetNodeIdAndClusterNameYieldUnknownNotLiteralPlaceholder() throws Exception {
+        Formatter formatter = consoleFormatter();
+        LogRecord record = new LogRecord(Level.INFO, "identity probe");
+        record.setLoggerName("com.example.Demo");
+
+        JsonNode json = MAPPER.readTree(formatter.format(record).trim());
+
+        // When NODE_ID / CLUSTER_NAME aren't supplied the property-expression
+        // default (`${NODE_ID:unknown}`) must resolve to the sentinel "unknown" —
+        // never to the unresolved literal "${NODE_ID}", which would poison any
+        // downstream Loki label and silently mask deployment misconfiguration.
+        assertThat(json.has("node_id")).isTrue();
+        assertThat(json.get("node_id").asText())
+                .as("node_id must not be a literal placeholder when env is unset")
+                .doesNotContain("${")
+                .isEqualTo("unknown");
+
+        assertThat(json.has("cluster_name")).isTrue();
+        assertThat(json.get("cluster_name").asText())
+                .as("cluster_name must not be a literal placeholder when env is unset")
+                .doesNotContain("${")
+                .isEqualTo("unknown");
+    }
+
+    @Test
+    void formatterIncludesStaticServiceAndVersion() throws Exception {
+        Formatter formatter = consoleFormatter();
+        LogRecord record = new LogRecord(Level.INFO, "static-fields probe");
+        record.setLoggerName("com.example.Demo");
+
+        JsonNode json = MAPPER.readTree(formatter.format(record).trim());
+
+        assertThat(json.has("service")).as("static service field present").isTrue();
+        assertThat(json.get("service").asText()).isEqualTo("i2scim");
+
+        assertThat(json.has("version")).as("static version field present").isTrue();
+        // Built artifact version (e.g. "0.10.1"); non-empty is sufficient — we don't
+        // want this test to break on every version bump.
+        assertThat(json.get("version").asText()).isNotBlank();
+    }
+
+    /**
+     * Returns the formatter Quarkus has wired onto the root console handler.
+     * Quarkus runs on JBoss LogManager, so we walk that context (not the JUL
+     * LogManager) to find the active ConsoleHandler. With JSON logging enabled
+     * the formatter is the Quarkus JsonFormatter; with it disabled it is a
+     * PatternFormatter.
+     */
+    static Formatter consoleFormatter() {
+        org.jboss.logmanager.Logger root = org.jboss.logmanager.LogContext.getLogContext().getLogger("");
+        for (Handler h : root.getHandlers()) {
+            // ConsoleHandler may be wrapped in an AsyncHandler; recurse.
+            Formatter f = unwrapFormatter(h);
+            if (f != null) {
+                return f;
+            }
+        }
+        throw new AssertionError("no console handler with a formatter is registered on the JBoss root logger");
+    }
+
+    private static Formatter unwrapFormatter(Handler h) {
+        Formatter f = h.getFormatter();
+        if (f != null) {
+            return f;
+        }
+        // QuarkusDelayedHandler, AsyncHandler, and most JBoss handlers extend
+        // ExtHandler, which exposes nested handlers.
+        if (h instanceof org.jboss.logmanager.ExtHandler ext) {
+            for (Handler inner : ext.getHandlers()) {
+                Formatter inner_f = unwrapFormatter(inner);
+                if (inner_f != null) {
+                    return inner_f;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogIdentityTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLogIdentityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Formatter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code NODE_ID} / {@code CLUSTER_NAME} supplied at startup
+ * appear verbatim as {@code node_id} / {@code cluster_name} in every JSON
+ * record — the per-container identity i2goSignals relies on for label-based
+ * Loki queries.
+ */
+@QuarkusTest
+@TestProfile(JsonLoggingWithIdentityProfile.class)
+class JsonLogIdentityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void nodeIdAndClusterNameAreInjectedFromEnvironment() throws Exception {
+        Formatter formatter = JsonLogFormatTest.consoleFormatter();
+        LogRecord record = new LogRecord(Level.INFO, "identity check");
+        record.setLoggerName("com.example.Demo");
+
+        JsonNode json = MAPPER.readTree(formatter.format(record).trim());
+
+        assertThat(json.has("node_id")).as("node_id field present").isTrue();
+        assertThat(json.get("node_id").asText()).isEqualTo("test-node-1");
+
+        assertThat(json.has("cluster_name")).as("cluster_name field present").isTrue();
+        assertThat(json.get("cluster_name").asText()).isEqualTo("test-cluster");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLoggingEnabledProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLoggingEnabledProfile.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.logging;
+
+import com.independentid.scim.backend.memory.MemoryProvider;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class JsonLoggingEnabledProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.log.console.json.enabled", "true",
+                "scim.prov.providerClass", MemoryProvider.class.getName(),
+                "scim.security.enable", "false",
+                "scim.event.enable", "false",
+                "scim.root.dir", "."
+        );
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "JsonLoggingEnabledProfile";
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLoggingWithIdentityProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/logging/JsonLoggingWithIdentityProfile.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026.  Independent Identity Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package com.independentid.scim.test.logging;
+
+import com.independentid.scim.backend.memory.MemoryProvider;
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+/**
+ * JSON logging enabled with NODE_ID / CLUSTER_NAME populated, simulating the
+ * i2goSignals compose deployment where each SCIM peer container is given a
+ * distinct identity via environment variables.
+ */
+public class JsonLoggingWithIdentityProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.log.console.json.enabled", "true",
+                "NODE_ID", "test-node-1",
+                "CLUSTER_NAME", "test-cluster",
+                "scim.prov.providerClass", MemoryProvider.class.getName(),
+                "scim.security.enable", "false",
+                "scim.event.enable", "false",
+                "scim.root.dir", "."
+        );
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "JsonLoggingWithIdentityProfile";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.independentid</groupId>
     <artifactId>i2scim-root</artifactId>
-    <version>0.10.1</version>
+    <version>0.10.2</version>
     <packaging>pom</packaging>
     <name>i2scim-root</name>
     <description>i2scim.io SCIM v2 Server on Quarkus - Root Project</description>


### PR DESCRIPTION
## Summary

[PRD #82](https://github.com/i2-open/i2scim/issues/82): make i2scim a first-class peer in the i2goSignals observability stack (Loki + Prometheus) so a single Grafana view covers SCIM and Signals together. Three slices on this branch.

### Slice 1 — JSON console logging (closes #83)

- Adds `quarkus-logging-json` to `i2scim-server`.
- **Env-gated**: prod stdout stays human-readable text; `QUARKUS_LOG_CONSOLE_JSON=true` (the i2goSignals dev-compose contract) flips to JSON.
- Renames keys (`timestamp→time`, `message→msg`, `logger_name→component`) and injects static fields: `service=i2scim`, `version=${quarkus.application.version}`, `node_id`/`cluster_name` from `NODE_ID`/`CLUSTER_NAME` env.
- Wired through `quarkus.log.console.json.enabled` (non-deprecated) so the documented `QUARKUS_LOG_CONSOLE_JSON` env survives Quarkus 3.19's deprecation of the parent property.

**Design note — `unknown` sentinel**: SmallRye Config rejects empty string for `additional-field.value` (built-in String converter treats `""` as null, fails `@ConfigMapping` validation — `SRCFG00040`). Issue #83 said "absent or empty strings". Since empty is rejected by the platform, defaults resolve to `"unknown"` — clearly non-id, makes misconfiguration explicit in Loki, never leaks the literal `${NODE_ID}`.

### Slice 2 — Prometheus `/q/metrics`, anonymous (closes #84)

- Moves `quarkus.micrometer.export.prometheus.path` from `/metrics` (under the SCIM servlet's auth filter) to `/q/metrics` (Quarkus non-application root, outside the auth filter). Matches the `/q/health` anonymous posture and what dev-stack Prometheus scrapes.
- K8s manifests' `prometheus.io/path` annotations bumped to `/q/metrics`.
- `i2scim-server/k8s/README.md` documents the new endpoint, port, anonymity, and Accept negotiation.
- Legacy `ScimHealthTest.d_metricsCheckJwt` updated to the new path (JWT header left in to prove it doesn't break the anonymous endpoint).

**Acceptance-criterion divergence (honest)**: #84 listed `http_server_requests_seconds_count` as a required series. That metric is produced by Quarkus's Vert.x HTTP server binder; i2scim runs on **Undertow**, which exposes equivalent request observability as `http_server_active_requests` (gauge) plus `http_server_bytes_read_count` / `http_server_bytes_written_count` (per-request counters). The test asserts what's actually emitted. Prometheus + Grafana can graph request activity from either set; if i2goSignals dashboards literally PromQL `http_server_requests_seconds_count`, follow-up = add `quarkus-micrometer-binder-vertx`.

### Slice 3 — Version bump to 0.10.2 + startup banner

- Bumps root + 3 module poms `0.10.1` → `0.10.2`.
- Fixes `SsfHandler` client-registration description (was stale at `v0.9.3`) → `v0.10.2`.
- New `StartupBanner` CDI bean (`i2scim-server/src/main/java/com/independentid/scim/server/StartupBanner.java`) observes Quarkus `StartupEvent` and logs `i2scim server v<version>` so the running version is visible in the unified log stream without inspecting the image tag.
- Adds 0.10.2 release notes to `docs/README.md`.

## Test plan

- [x] `mvn -pl i2scim-server test -Dtest='JsonLog*Test'` — 5 tests, all green
- [x] `mvn -pl i2scim-server test -Dtest=PrometheusMetricsEndpointTest` — 3 tests, all green (200 anonymous, default series present, Prometheus 0.0.4 Content-Type)
- [x] `mvn -pl i2scim-server test -Dtest=ScimHealthTest` — 6 tests, all green (`/q/metrics` path with bearer still works)
- [x] **Full suite**: `mvn -pl i2scim-server test` — **378/379 pass**. Single failure (`PemReloadWatcherTest.close_stopsFurtherFires`) is a pre-existing filesystem-watcher timing flake unrelated to this branch; passes 8/8 when re-run in isolation.
- [x] Startup banner verified at runtime: `INFO [com.independentid.scim.server.StartupBanner] (main) i2scim server v0.10.2`.
- [ ] Manual e2e (post-merge, paired with i2goSignals compose change):
  - `curl loki:3100/loki/api/v1/labels` shows `service`/`node_id`/`cluster_name`/`component` populated for both `scim_cluster*` peers.
  - `curl prometheus:9090/api/v1/targets` shows the `i2scim` job with both peers `up=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)