### PR TITLE
PRD #86: RISC events derived from SCIM User state changes

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -110,11 +110,13 @@ i2scim can additionally derive **OpenID RISC** events (OpenID RISC Profile 1.0) 
 
 **scim.signals.risc.identifier.addRemoveIsChange** - When `true` (the DEFAULT), a pure add or removal of an identifier value (one side absent) counts as an Identifier Changed event. When `false`, only a value-to-value change emits.
 
+**scim.signals.risc.subject.format** - The subject identifier format carried by all RISC events: one of `scim` (the DEFAULT), `email`, `username`, or `phone`. With `scim` the subject is the stable `id`/`uri` of the `User`. With `email`/`username`/`phone` the subject carries the primary value of the corresponding `User` attribute (`emails`, `userName`, `phoneNumbers`); for Identifier Changed this is the *prior* (pre-image) value, with the new value still conveyed in the payload. When the configured format cannot be satisfied for a given `User` (e.g. `email` format but the `User` has no email), the event falls back to the `scim` subject so it is still emitted.
+
 RISC events are derived as follows:
 
 - **account-purged** — a `User` DELETE.
 - **account-enabled** / **account-disabled** — a change to a `User`'s `active` attribute (an absent `active` is treated as enabled). A CREATE always emits, reflecting the resulting state. A PATCH that `add`s/`replace`s `active` (including a path-less `value` object) emits the new value — even when unchanged — and a PATCH that `remove`s `active` emits `account-enabled`. A PUT emits only when `active` actually changes versus the prior state.
-- **identifier-changed** — a change to the primary value of a configured identifier attribute (`scim.signals.risc.identifier.attrs`) on a `User` PUT or PATCH; CREATE and DELETE never emit it. Each changed identifier attribute yields its own SET. With the default `scim` subject format the SET carries the stable `id`/`uri` subject and conveys the new identifier value in the event payload as `new-value`.
+- **identifier-changed** — a change to the primary value of a configured identifier attribute (`scim.signals.risc.identifier.attrs`) on a `User` PUT or PATCH; CREATE and DELETE never emit it. Each changed identifier attribute yields its own SET. With the default `scim` subject format the SET carries the stable `id`/`uri` subject and conveys the new identifier value in the event payload as `new-value`. Under a non-`scim` `scim.signals.risc.subject.format` the subject instead carries the prior identifier value and the payload still conveys the new value.
 
 #### Operator re-enable after DISABLED (PRD-B)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -106,6 +106,11 @@ i2scim can additionally derive **OpenID RISC** events (OpenID RISC Profile 1.0) 
 
 **scim.signals.risc.types** - Comma-separated list of RISC event types to emit, by short name: `account-purged`, `account-disabled`, `account-enabled`, `identifier-changed`. A single `*` (the DEFAULT) emits all supported types.
 
+RISC events are derived as follows:
+
+- **account-purged** — a `User` DELETE.
+- **account-enabled** / **account-disabled** — a change to a `User`'s `active` attribute (an absent `active` is treated as enabled). A CREATE always emits, reflecting the resulting state. A PATCH that `add`s/`replace`s `active` (including a path-less `value` object) emits the new value — even when unchanged — and a PATCH that `remove`s `active` emits `account-enabled`. A PUT emits only when `active` actually changes versus the prior state.
+
 #### Operator re-enable after DISABLED (PRD-B)
 
 A stream transitioned to `DISABLED` by the elapsed-time cap retains all pending JTIs in `pendingPushes` (Mongo) or `events/pending/<streamId>/` (memory). Re-enable is done through the existing PRD-A control surface — programmatically calling `pushStream.state.transitionTo(StreamStatus.ENABLED, null)` on the active `SsfHandler.getPushStream()`. The per-stream `PushRetryWorker` registers a transition listener that wakes the idle-sleeping worker thread on `DISABLED → ENABLED`, so the queue resumes draining (in `queuedAt` order) within milliseconds rather than after the next idle window. The first 2xx response is the operational marker that the stream is healthy again; if the receiver is still failing, the elapsed-time cap fires again and the stream is re-DISABLED. Pending JTIs are never deleted by a DISABLE — only by a successful 2xx delivery.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -106,10 +106,15 @@ i2scim can additionally derive **OpenID RISC** events (OpenID RISC Profile 1.0) 
 
 **scim.signals.risc.types** - Comma-separated list of RISC event types to emit, by short name: `account-purged`, `account-disabled`, `account-enabled`, `identifier-changed`. A single `*` (the DEFAULT) emits all supported types.
 
+**scim.signals.risc.identifier.attrs** - Comma-separated list of `User` attributes whose primary value is treated as a login identifier for `identifier-changed` derivation (DEFAULT: `userName,emails`). A singular attribute (e.g. `userName`) uses its scalar value; a multi-valued attribute (e.g. `emails`, `phoneNumbers`) uses the `value` of the entry flagged `primary`, treating a lone value as primary when no `primary` flag is set.
+
+**scim.signals.risc.identifier.addRemoveIsChange** - When `true` (the DEFAULT), a pure add or removal of an identifier value (one side absent) counts as an Identifier Changed event. When `false`, only a value-to-value change emits.
+
 RISC events are derived as follows:
 
 - **account-purged** — a `User` DELETE.
 - **account-enabled** / **account-disabled** — a change to a `User`'s `active` attribute (an absent `active` is treated as enabled). A CREATE always emits, reflecting the resulting state. A PATCH that `add`s/`replace`s `active` (including a path-less `value` object) emits the new value — even when unchanged — and a PATCH that `remove`s `active` emits `account-enabled`. A PUT emits only when `active` actually changes versus the prior state.
+- **identifier-changed** — a change to the primary value of a configured identifier attribute (`scim.signals.risc.identifier.attrs`) on a `User` PUT or PATCH; CREATE and DELETE never emit it. Each changed identifier attribute yields its own SET. With the default `scim` subject format the SET carries the stable `id`/`uri` subject and conveys the new identifier value in the event payload as `new-value`.
 
 #### Operator re-enable after DISABLED (PRD-B)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -98,6 +98,14 @@ These properties allow the SSF client to trust custom CA roots (e.g., for self-s
 
 **scim.signals.pub.pem.watch** - PRD-B slice #79. When `true` (default), an out-of-band rotation of `scim.signals.pub.pem.path` is detected proactively via `java.nio.file.WatchService` (with a 5s mtime-poll fallback) and the cached issuer key on the active `PushStream` is refreshed before the next push. Set to `false` to disable the watcher and rely solely on the reactive `jws_signature_failed` reload path. Has no effect when `scim.signals.pub.pem.value` is set (env-value mode requires a restart to roll the key anyway).
 
+#### RISC events (PRD #86)
+
+i2scim can additionally derive **OpenID RISC** events (OpenID RISC Profile 1.0) from SCIM `User` state changes and emit them as their own Security Event Tokens on the existing SET push stream. RISC emission is opt-in and additive to — and gated by — `scim.signals.enable` / `scim.signals.pub.enable`; it does not bypass them. Each RISC event is delivered as its own SET with a distinct `jti`, sharing the `txn` and `toe` of the SCIM events derived from the same operation so a receiver can correlate them. RISC events are emitted only for `User` resources.
+
+**scim.signals.risc.enable** - Master switch for RISC event emission (DEFAULT: `false`). When `false`, upgrading i2scim never changes what existing receivers receive.
+
+**scim.signals.risc.types** - Comma-separated list of RISC event types to emit, by short name: `account-purged`, `account-disabled`, `account-enabled`, `identifier-changed`. A single `*` (the DEFAULT) emits all supported types.
+
 #### Operator re-enable after DISABLED (PRD-B)
 
 A stream transitioned to `DISABLED` by the elapsed-time cap retains all pending JTIs in `pendingPushes` (Mongo) or `events/pending/<streamId>/` (memory). Re-enable is done through the existing PRD-A control surface — programmatically calling `pushStream.state.transitionTo(StreamStatus.ENABLED, null)` on the active `SsfHandler.getPushStream()`. The per-stream `PushRetryWorker` registers a transition listener that wakes the idle-sleeping worker thread on `DISABLED → ENABLED`, so the queue resumes draining (in `queuedAt` order) within milliseconds rather than after the next idle window. The first 2xx response is the operational marker that the stream is healthy again; if the receiver is still failing, the elapsed-time cap fires again and the stream is re-DISABLED. Pending JTIs are never deleted by a DISABLE — only by a successful 2xx delivery.

--- a/docs/adr/0001-pre-image-on-requestctx-for-event-derivation.md
+++ b/docs/adr/0001-pre-image-on-requestctx-for-event-derivation.md
@@ -1,0 +1,32 @@
+# Pre-image carried on RequestCtx for event derivation
+
+To derive RISC events (Account Enabled/Disabled, Identifier Changed) from SCIM
+state changes, the event mapper needs the resource's state *before* the
+operation. The backend providers already load that pre-image for free during
+`patch`/`put`/`delete`, so each provider stashes it on the per-request
+`RequestCtx` (`setPreImageResource`), and the mapper reads it via
+`op.getRequestCtx()`. This adds zero backend round-trips and therefore zero
+latency to the SCIM operation itself.
+
+## Status
+
+accepted
+
+## Considered Options
+
+- **Pre-image field on `Operation`** — domain-cleaner, but the provider SPI
+  (`IScimProvider.patch/put/delete`) does not receive the `Operation`. Wiring it
+  through would mean either widening the SPI or having the op class issue its
+  own pre-read — an extra backend round-trip on the SCIM critical path.
+- **Plugin pre-op hook** (`IScimPlugin`) snapshotting the resource — also an
+  extra read, and more moving parts.
+
+## Consequences
+
+`RequestCtx`, a protocol-layer object, now carries a domain `ScimResource`
+snapshot — a deliberate layering compromise accepted because `RequestCtx`
+already accumulates per-request state and is the only object the provider can
+reach that also flows to the event publication path. `delete()` must now retain
+the removed resource (previously discarded) so the pre-image is available for
+Account Purged. Event publication remains fully asynchronous and non-blocking:
+the SCIM response returns before any event mapping runs.

--- a/docs/event-specs/openid-risc-1_0-final.txt
+++ b/docs/event-specs/openid-risc-1_0-final.txt
@@ -1,0 +1,672 @@
+
+
+
+
+Shared Signals                                              M. Scurtescu
+                                                                Coinbase
+                                                              A. Backman
+                                                                  Amazon
+                                                                 P. Hunt
+                                                                  Oracle
+                                                              J. Bradley
+                                                                  Yubico
+                                                               S. Bounev
+                                                              VeriClouds
+                                                        A. Tulshibagwale
+                                                                    SGNL
+                                                          29 August 2025
+
+
+                 OpenID RISC Profile Specification 1.0
+                 openid-risc-profile-specification-1_0
+
+Abstract
+
+   This document defines the Risk Incident Sharing and Coordination
+   (RISC) Event Types based on the Shared Signals Framework (SSF)
+   [SHARED-SIGNALS-FRAMEWORK].  Event Types are introduced and defined
+   in Security Event Token (SET) [SET].
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+     1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   2
+   2.  Event Types . . . . . . . . . . . . . . . . . . . . . . . . .   2
+     2.1.  Account Credential Change Required  . . . . . . . . . . .   2
+     2.2.  Account Purged  . . . . . . . . . . . . . . . . . . . . .   3
+     2.3.  Account Disabled  . . . . . . . . . . . . . . . . . . . .   3
+     2.4.  Account Enabled . . . . . . . . . . . . . . . . . . . . .   4
+     2.5.  Identifier Changed  . . . . . . . . . . . . . . . . . . .   4
+     2.6.  Identifier Recycled . . . . . . . . . . . . . . . . . . .   5
+     2.7.  Credential Compromise . . . . . . . . . . . . . . . . . .   6
+     2.8.  Opt Out . . . . . . . . . . . . . . . . . . . . . . . . .   7
+       2.8.1.  Opt In  . . . . . . . . . . . . . . . . . . . . . . .   8
+       2.8.2.  Opt Out Initiated . . . . . . . . . . . . . . . . . .   8
+       2.8.3.  Opt Out Cancelled . . . . . . . . . . . . . . . . . .   8
+       2.8.4.  Opt Out Effective . . . . . . . . . . . . . . . . . .   9
+     2.9.  Recovery Activated  . . . . . . . . . . . . . . . . . . .   9
+     2.10. Recovery Information Changed  . . . . . . . . . . . . . .   9
+     2.11. Sessions Revoked  . . . . . . . . . . . . . . . . . . . .   9
+   3.  Compatibility . . . . . . . . . . . . . . . . . . . . . . . .  10
+     3.1.  Google Subject Type Value . . . . . . . . . . . . . . . .  10
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .  10
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 1]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   5.  Normative References  . . . . . . . . . . . . . . . . . . . .  10
+   Appendix A.  Acknowledgements . . . . . . . . . . . . . . . . . .  11
+   Appendix B.  Notices  . . . . . . . . . . . . . . . . . . . . . .  11
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  12
+
+1.  Introduction
+
+   This specification defines event types and their contents based on
+   the Shared Signals Framework [SHARED-SIGNALS-FRAMEWORK] that are
+   required to implement Risk Incident Sharing and Coordination.
+
+1.1.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+2.  Event Types
+
+   The base URI for RISC event types is:
+   https://schemas.openid.net/secevent/risc/event-type/
+
+2.1.  Account Credential Change Required
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   account-credential-change-required
+
+   Account Credential Change Required signals that the account
+   identified by the subject was required to change a credential.  For
+   example the user was required to go through a password change.
+
+   Attributes: none
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 2]
+
+                    openid-risc-profile-specification        August 2025
+
+
+{
+  "iss": "https://idp.example.com/",
+  "jti": "756E69717565206964656E746966696572",
+  "iat": 1508184845,
+  "aud": "636C69656E745F6964",
+  "sub_id": {
+    "format": "iss_sub",
+    "iss": "https://idp.example.com/",
+    "sub": "7375626A656374"
+  },
+  "events": {
+    "https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required": {}
+  }
+}
+
+        Figure 1: Example: Account Credential Change Required
+
+2.2.  Account Purged
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   account-purged
+
+   Account Purged signals that the account identified by the subject has
+   been permanently deleted.
+
+   Attributes: none
+
+2.3.  Account Disabled
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   account-disabled
+
+   Account Disabled signals that the account identified by the subject
+   has been disabled.  The actual reason why the account was disabled
+   might be specified with the nested reason attribute described below.
+   The account may be enabled (Section 2.4) in the future.
+
+   Attributes:
+
+   *  reason - optional, describes why was the account disabled.
+      Possible values:
+
+      -  hijacking
+
+      -  bulk-account
+
+
+
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 3]
+
+                    openid-risc-profile-specification        August 2025
+
+
+{
+  "iss": "https://idp.example.com/",
+  "jti": "756E69717565206964656E746966696572",
+  "iat": 1508184845,
+  "aud": "636C69656E745F6964",
+  "sub_id": {
+    "format": "iss_sub",
+    "iss": "https://idp.example.com/",
+    "sub": "7375626A656374",
+  },
+  "events": {
+    "https://schemas.openid.net/secevent/risc/event-type/account-disabled": {
+      "reason": "hijacking"
+    }
+  }
+}
+
+                 Figure 2: Example: Account Disabled
+
+2.4.  Account Enabled
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   account-enabled
+
+   Account Enabled signals that the account identified by the subject
+   has been enabled.
+
+   Attributes: none
+
+2.5.  Identifier Changed
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   identifier-changed
+
+   Identifier Changed signals that the identifier specified in the
+   subject has changed.  The subject type MUST be either email or phone
+   and it MUST specify the old value.
+
+   This event SHOULD be issued only by the provider that is
+   authoritative over the identifier.  For example, if the person that
+   owns john.doe@example.com goes through a name change and wants the
+   new john.roe@example.com email then *only* the email provider
+   example.com SHOULD issue an Identifier Changed event as shown in the
+   example below.
+
+   If an identifier used as a username or recovery option is changed, at
+   a provider that is not authoritative over that identifier, then
+   Recovery Information Changed (Section 2.10) SHOULD be used instead.
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 4]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   Attributes:
+
+   *  new-value - optional, the new value of the identifier.
+
+{
+  "iss": "https://idp.example.com/",
+  "jti": "756E69717565206964656E746966696572",
+  "iat": 1508184845,
+  "aud": "636C69656E745F6964",
+  "sub_id": {
+    "format": "email",
+    "email": "john.doe@example.com"
+  },
+  "events": {
+    "https://schemas.openid.net/secevent/risc/event-type/identifier-changed": {
+      "new-value": "john.roe@example.com"
+    }
+  }
+}
+
+                Figure 3: Example: Identifier Changed
+
+   The john.doe@example.com email changed to john.roe@example.com.
+
+2.6.  Identifier Recycled
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   identifier-recycled
+
+   Identifier Recycled signals that the identifier specified in the
+   subject was recycled and now it belongs to a new user.  The subject
+   type MUST be either email or phone.
+
+   Attributes: none
+
+{
+  "iss": "https://idp.example.com/",
+  "jti": "756E69717565206964656E746966696572",
+  "iat": 1508184845,
+  "aud": "636C69656E745F6964",
+  "sub_id": {
+    "format": "email",
+    "email": "foo@example.com"
+  },
+  "events": {
+    "https://schemas.openid.net/secevent/risc/event-type/identifier-recycled": {}
+  }
+}
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 5]
+
+                    openid-risc-profile-specification        August 2025
+
+
+                Figure 4: Example: Identifier Recycled
+
+   The foo@example.com email address was recycled.
+
+2.7.  Credential Compromise
+
+   Event Type URI:
+
+   https://schemas.openid.net/secevent/risc/event-type/credential-
+   compromise
+
+   A Credential Compromise event signals that the identifier specified
+   in the subject was found to be compromised.
+
+   Attributes:
+
+   *  credential_type - REQUIRED.  The type of credential that is
+      compromised.  The value of this attribute must be one of the
+      values specified for the similarly named field in the Credential
+      Change event defined in the CAEP Specification
+      [CAEP-SPECIFICATION].
+
+   *  event_timestamp - OPTIONAL.  JSON number: the time at which the
+      event described by this SET was discovered by the Transmitter.
+      Its value is a JSON number representing the number of seconds from
+      1970-01-01T0:0:0Z as measured in UTC until the date/time.
+
+   *  reason_admin - OPTIONAL.  The reason why the credential
+      compromised event was generated, intended for administrators
+
+   *  reason_user - OPTIONAL.  The reason why the credential compromised
+      event was generated, intended for end-users
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 6]
+
+                    openid-risc-profile-specification        August 2025
+
+
+{
+  "iss": "https://idp.example.com/3456790/",
+  "jti": "756E69717565206964656E746966696572",
+  "iat": 1508184845,
+  "aud": "https://sp.example2.net/caep",
+  "sub_id": {
+    "format": "iss_sub",
+    "iss": "https://idp.example.com/3456790/",
+    "sub": "joe.smith@example.com"
+  },
+  "events": {
+    "https://schemas.openid.net/secevent/risc/event-type/credential-compromise": {
+      "credential_type": "password"
+    }
+  }
+}
+
+
+           Figure 5: Example: Compromised credential found
+
+2.8.  Opt Out
+
+   Users SHOULD be allowed to opt-in and out of RISC events being sent
+   for their accounts.  With regards to opt-out, an account can be in
+   one of these three states:
+
+   1.  opt-in - the account is participating in RISC event exchange.
+
+   2.  opt-out-initiated - the user requested to be excluded from RISC
+       event exchanges, but for practical security reasons for a period
+       of time RISC events are still exchanged.  The main reason for
+       this state is to prevent a hijacker from immediately opting out
+       of RISC.
+
+   3.  opt-out - the account is NOT participating in RISC event
+       exchange.
+
+   State changes trigger Opt-Out Events as represented below:
+
+
+
+
+
+
+
+
+
+
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 7]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   +--------+  opt-out-initiated  +-------------------+
+   |        +--------------------->                   |
+   | opt-in |                     | opt-out-initiated |
+   |        |  opt-out-cancelled  |                   |
+   |        <---------------------+                   |
+   +---^----+                     +----------+--------+
+       |                                     |
+       | opt-in                              | opt-out-effective
+       |                                     |
+       |                          +----------V--------+
+       |                          |                   |
+       +--------------------------| opt-out           |
+                                  |                   |
+                                  +-------------------+
+
+                Figure 6: Opt-Out States and Opt-Out Events
+
+   Both Transmitters and Receivers SHOULD manage Opt-Out state for
+   users.  Transmitters should send the events defined in this section
+   when the Opt-Out state changes.
+
+2.8.1.  Opt In
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   opt-in
+
+   Opt In signals that the account identified by the subject opted into
+   RISC event exchanges.  The account is in the opt-in state.
+
+   Attributes: none
+
+2.8.2.  Opt Out Initiated
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   opt-out-initiated
+
+   Opt Out Initiated signals that the account identified by the subject
+   initiated to opt out from RISC event exchanges.  The account is in
+   the opt-out-initiated state.
+
+   Attributes: none
+
+2.8.3.  Opt Out Cancelled
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   opt-out-cancelled
+
+
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 8]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   Opt Out Cancelled signals that the account identified by the subject
+   cancelled the opt out from RISC event exchanges.  The account is in
+   the opt-in state.
+
+   Attributes: none
+
+2.8.4.  Opt Out Effective
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   opt-out-effective
+
+   Opt Out Effective signals that the account identified by the subject
+   was effectively opted out from RISC event exchanges.  The account is
+   in the opt-out state.
+
+   Attributes: none
+
+2.9.  Recovery Activated
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   recovery-activated
+
+   Recovery Activated signals that the account identified by the subject
+   activated a recovery flow.
+
+   Attributes: none
+
+2.10.  Recovery Information Changed
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   recovery-information-changed
+
+   Recovery Information Changed signals that the account identified by
+   the subject has changed some of its recovery information.  For
+   example a recovery email address was added or removed.
+
+   Attributes: none
+
+2.11.  Sessions Revoked
+
+   Note: This event type is now deprecated.  New implementations MUST
+   use the session-revoked event defined in the CAEP Specification
+   [CAEP-SPECIFICATION].
+
+   Event Type URI: https://schemas.openid.net/secevent/risc/event-type/
+   sessions-revoked
+
+
+
+
+
+Scurtescu, et al.            Standards Track                    [Page 9]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   Sessions Revoked signals that all the sessions for the account
+   identified by the subject have been revoked.
+
+   Attributes: none
+
+3.  Compatibility
+
+3.1.  Google Subject Type Value
+
+   Implementers are hereby made aware that the existing RISC
+   implementation by Google uses the field name subject_type instead of
+   the field name format to indicate the format of the subject
+   identifier.  The usage of the field name subject_type is deprecated
+   and new services MUST NOT use this field name.
+
+   Relying parties wishing to receive events from the Google RISC
+   transmitter therefore need to have code to work around this, until
+   such time as their implementation is updated.  Any such workaround
+   should be written in a manner that does not break if Google updates
+   their implementation to conform to this specification.
+
+4.  Security Considerations
+
+   Any implementations of events described in this document SHOULD
+   comply with the Shared Signals Framework [SHARED-SIGNALS-FRAMEWORK].
+   Exchanging events described herein without complying with the Shared
+   Signals Framework [SHARED-SIGNALS-FRAMEWORK] may result in security
+   issues.
+
+5.  Normative References
+
+   [CAEP-SPECIFICATION]
+              Cappalli, T. and A. Tulshibagwale, "OpenID Continuous
+              Access Evaluation Profile 1.0", 29 August 2025,
+              <https://openid.net/specs/openid-caep-1_0.html>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+
+
+
+
+
+
+Scurtescu, et al.            Standards Track                   [Page 10]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   [SET]      Hunt, P., Ed., Jones, M.B., Denniss, W., and M.A. Ansari,
+              "Security Event Token (SET)", April 2018,
+              <https://tools.ietf.org/html/draft-ietf-secevent-token-
+              09>.
+
+   [SHARED-SIGNALS-FRAMEWORK]
+              Tulshibagwale, A., Cappalli, T., Scurtescu, M., Backman,
+              A., Bradley, J., and S. Miel, "OpenID Shared Signals
+              Framework Specification 1.0", 29 August 2025,
+              <https://openid.net/specs/openid-sharedsignals-framework-
+              1_0.html>.
+
+Appendix A.  Acknowledgements
+
+   The authors wish to thank all members of the OpenID Foundation Shared
+   Signals Working Group who contributed to the development of this
+   specification.
+
+Appendix B.  Notices
+
+   Copyright (c) 2025 The OpenID Foundation.
+
+   The OpenID Foundation (OIDF) grants to any Contributor, developer,
+   implementer, or other interested party a non-exclusive, royalty free,
+   worldwide copyright license to reproduce, prepare derivative works
+   from, distribute, perform and display, this Implementers Draft, Final
+   Specification, or Final Specification Incorporating Errata
+   Corrections solely for the purposes of (i) developing specifications,
+   and (ii) implementing Implementers Drafts, Final Specifications, and
+   Final Specification Incorporating Errata Corrections based on such
+   documents, provided that attribution be made to the OIDF as the
+   source of the material, but that such attribution does not indicate
+   an endorsement by the OIDF.
+
+   The technology described in this specification was made available
+   from contributions from various sources, including members of the
+   OpenID Foundation and others.  Although the OpenID Foundation has
+   taken steps to help ensure that the technology is available for
+   distribution, it takes no position regarding the validity or scope of
+   any intellectual property or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this specification or the extent to which any license under such
+   rights might or might not be available; neither does it represent
+   that it has made any independent effort to identify any such rights.
+   The OpenID Foundation and the contributors to this specification make
+   no (and hereby expressly disclaim any) warranties (express, implied,
+   or otherwise), including implied warranties of merchantability, non-
+   infringement, fitness for a particular purpose, or title, related to
+
+
+
+Scurtescu, et al.            Standards Track                   [Page 11]
+
+                    openid-risc-profile-specification        August 2025
+
+
+   this specification, and the entire risk as to implementing this
+   specification is assumed by the implementer.  The OpenID Intellectual
+   Property Rights policy (found at openid.net) requires contributors to
+   offer a patent promise not to assert certain patent claims against
+   other contributors and against implementers.  OpenID invites any
+   interested party to bring to its attention any copyrights, patents,
+   patent applications, or other proprietary rights that may cover
+   technology that may be required to practice this specification.
+
+Authors' Addresses
+
+   Marius Scurtescu
+   Coinbase
+   Email: marius.scurtescu@coinbase.com
+
+
+   Annabelle Backman
+   Amazon
+   Email: richanna@amazon.com
+
+
+   Phil Hunt
+   Oracle Corporation
+   Email: phil.hunt@yahoo.com
+
+
+   John Bradley
+   Yubico
+   Email: secevemt@ve7jtb.com
+
+
+   Stan Bounev
+   VeriClouds
+   Email: stanb@vericlouds.com
+
+
+   Atul Tulshibagwale
+   SGNL
+   Email: atul@sgnl.ai
+
+
+
+
+
+
+
+
+
+
+
+
+Scurtescu, et al.            Standards Track                   [Page 12]

--- a/docs/event-specs/rfc7643.txt
+++ b/docs/event-specs/rfc7643.txt
@@ -1,0 +1,5827 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                      P. Hunt, Ed.
+Request for Comments: 7643                                        Oracle
+Category: Standards Track                                     K. Grizzle
+ISSN: 2070-1721                                                SailPoint
+                                                           E. Wahlstroem
+                                                        Nexus Technology
+                                                            C. Mortimore
+                                                              Salesforce
+                                                          September 2015
+
+
+        System for Cross-domain Identity Management: Core Schema
+
+Abstract
+
+   The System for Cross-domain Identity Management (SCIM) specifications
+   are designed to make identity management in cloud-based applications
+   and services easier.  The specification suite builds upon experience
+   with existing schemas and deployments, placing specific emphasis on
+   simplicity of development and integration, while applying existing
+   authentication, authorization, and privacy models.  Its intent is to
+   reduce the cost and complexity of user management operations by
+   providing a common user schema and extension model as well as binding
+   documents to provide patterns for exchanging this schema using HTTP.
+
+   This document provides a platform-neutral schema and extension model
+   for representing users and groups and other resource types in JSON
+   format.  This schema is intended for exchange and use with cloud
+   service providers.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7643.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 1]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction and Overview .......................................3
+      1.1. Requirements Notation and Conventions ......................4
+      1.2. Definitions ................................................5
+   2. SCIM Schema .....................................................6
+      2.1. Attributes .................................................7
+      2.2. Attribute Characteristics ..................................8
+      2.3. Attribute Data Types .......................................8
+           2.3.1. String ..............................................9
+           2.3.2. Boolean .............................................9
+           2.3.3. Decimal ............................................10
+           2.3.4. Integer ............................................10
+           2.3.5. DateTime ...........................................10
+           2.3.6. Binary .............................................10
+           2.3.7. Reference ..........................................10
+           2.3.8. Complex ............................................11
+      2.4. Multi-Valued Attributes ...................................11
+      2.5. Unassigned and Null Values ................................13
+   3. SCIM Resources .................................................13
+      3.1. Common Attributes .........................................16
+      3.2. Defining New Resource Types ...............................18
+      3.3. Attribute Extensions to Resources .........................18
+   4. SCIM Core Resources and Extensions .............................19
+      4.1. "User" Resource Schema ....................................19
+           4.1.1. Singular Attributes ................................19
+           4.1.2. Multi-Valued Attributes ............................23
+      4.2. "Group" Resource Schema ...................................25
+      4.3. Enterprise User Schema Extension ..........................26
+   5. Service Provider Configuration Schema ..........................27
+   6. ResourceType Schema ............................................29
+   7. Schema Definition ..............................................30
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 2]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   8. JSON Representation ............................................34
+      8.1. Minimal User Representation ...............................34
+      8.2. Full User Representation ..................................35
+      8.3. Enterprise User Extension Representation ..................39
+      8.4. Group Representation ......................................43
+      8.5. Service Provider Configuration Representation .............44
+      8.6. Resource Type Representation ..............................46
+      8.7. Schema Representation .....................................47
+           8.7.1. Resource Schema Representation .....................47
+           8.7.2. Service Provider Schema Representation .............74
+   9. Security Considerations ........................................92
+      9.1. Protocol ..................................................92
+      9.2. Passwords and Other Sensitive Security Data ...............92
+      9.3. Privacy ...................................................92
+   10. IANA Considerations ...........................................94
+      10.1. Registration of SCIM URN Sub-namespace and SCIM
+            Registry .................................................94
+      10.2. URN Sub-namespace for SCIM ...............................94
+           10.2.1. Specification Template ............................95
+      10.3. Registering SCIM Schemas .................................97
+           10.3.1. Registration Procedure ............................97
+           10.3.2. Schema Registration Template ......................98
+      10.4. Initial SCIM Schema Registry .............................99
+   11. References ...................................................100
+      11.1. Normative References ....................................100
+      11.2. Informative References ..................................101
+   Acknowledgements .................................................103
+   Authors' Addresses ...............................................104
+
+1.  Introduction and Overview
+
+   While there are existing standards for describing and exchanging user
+   information, many of these standards can be difficult to implement
+   and/or use; e.g., their wire protocols do not easily traverse
+   firewalls and/or are not easily layered onto existing web protocols.
+   As a result, many cloud providers implement non-standardized
+   protocols for managing users within their services.  This increases
+   both the cost and complexity associated with organizations adopting
+   products and services from multiple cloud providers, as they must
+   perform redundant integration development.  Similarly, cloud service
+   providers seeking to interoperate with multiple application
+   marketplaces or cloud identity providers would require pairwise
+   integration.
+
+   SCIM seeks to simplify this problem through an easily implemented
+   specification suite that provides a common user schema and extension
+   model, as well as a SCIM protocol document that defines exchanging
+   this schema via an HTTP-based protocol [RFC7644].  The SCIM
+
+
+
+Hunt, et al.                 Standards Track                    [Page 3]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   specifications draw design input and feedback from existing
+   identity-related protocols and schemas from a wide variety of sources
+   including, but not limited to, existing services exposed by cloud
+   providers, PortableContacts [PortableContacts], vCards [RFC6350], and
+   Lightweight Directory Access Protocol (LDAP) directory services
+   [RFC4512].
+
+   The SCIM protocol is an application-level protocol for provisioning
+   and managing identity data specified through SCIM schemas.  The
+   protocol supports creation, modification, retrieval, and discovery of
+   core identity resources such as Users and Groups, using a subset of
+   the HTTP methods (GET for retrieval of resources; POST for creation,
+   searching, and bulk modification; PUT for attribute replacement
+   within resources; PATCH for partial update of attributes; and DELETE
+   for removing resources).
+
+   While the SCIM protocol and core schema specifications are intended
+   to cover point-to-point scenarios, implementers and deployers should
+   consider multi-hop and multi-party scenarios such as a service
+   provider acting as a general profile service for in-domain
+   applications (e.g., a directory), as well as scenarios where a
+   service provider in turn passes information to a third-party service
+   provider by acting as either a SCIM client or a SCIM service
+   provider.  Implementers and deployers should carefully consider their
+   service level agreements and privacy agreements when distributing or
+   propagating personal information (see Section 9.3).
+
+   This document provides a JSON-based schema and extension model for
+   representing users and groups, as well as service provider
+   configuration.  This schema is intended for exchange and use with
+   cloud service providers and other cross-domain scenarios.
+
+1.1.  Requirements Notation and Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   The key words "REQUIRED" and "OPTIONAL" are used throughout this
+   document to indicate whether an attribute or schema element is
+   required or optional.  These key words may be used alone (e.g.,
+   "REQUIRED.") or in a sentence.  If not specified, an attribute is
+   considered to be optional.
+
+   The word "DEFAULT" as used in Section 7 indicates that a "keyword"
+   value for an attribute characteristic is the default behavior.
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 4]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Throughout this document, values are quoted to indicate that they are
+   to be taken literally.  When using these values in protocol messages,
+   the quotes MUST NOT be used as part of the value.
+
+   Throughout this document, figures may contain spaces and extra line
+   wrapping to improve readability and accommodate space limitations.
+   Similarly, some URIs contained within examples have been shortened
+   for space and readability reasons.
+
+1.2.  Definitions
+
+   Service Provider
+      An HTTP web application that provides identity information via the
+      SCIM protocol.
+
+   Client
+      A website or application that uses the SCIM protocol to manage
+      identity data maintained by the service provider.  The client
+      initiates SCIM HTTP requests to a target service provider.
+
+   Provisioning Domain
+      A provisioning domain is an administrative domain external to the
+      domain of a service provider for legal or technical reasons.  For
+      example, a SCIM client in an enterprise (provisioning client)
+      communicates with a SCIM service provider that is owned or
+      controlled by a different legal entity.
+
+   Resource Type
+      A type of a resource that is managed by a service provider.  The
+      resource type defines the resource name, endpoint URL, schemas,
+      and other metadata that indicate where a resource is managed and
+      how it is composed, e.g., "User" or "Group".
+
+   Resource
+      An artifact that is managed by a service provider and that
+      contains one or more attributes, e.g., "User" or "Group".
+
+   Endpoint
+      An endpoint for a service provider is a defined base path relative
+      to the service provider's Base URI (see Section 1.3 of [RFC7644]),
+      over which SCIM operations may be performed against SCIM
+      resources.  For example, assuming that the service provider's Base
+      URI is "https://example.com/", "User" resources may be accessed at
+      the "https://example.com/Users" or "https://example.com/v2/Users"
+      endpoint (see Section 3.13 of [RFC7644] for details regarding
+      protocol versioning, e.g., 'v2').  Service provider schemas MAY be
+      returned from the "/Schemas" endpoint.
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 5]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Schema
+      A collection of attribute definitions that describe the contents
+      of an entire or partial resource, e.g.,
+      "urn:ietf:params:scim:schemas:core:2.0:User".  The attribute
+      definitions specify the name of the attribute, and metadata such
+      as type (e.g., string, binary), cardinality (singular, multi,
+      complex), mutability, and returnability.
+
+   Singular Attribute
+      A resource attribute that contains 0..1 values, e.g.,
+      "displayName".
+
+   Multi-valued Attribute
+      A resource attribute that contains 0..n values, e.g., "emails".
+
+   Simple Attribute
+      A singular or multi-valued attribute whose value is a primitive,
+      e.g., "String".  A simple attribute MUST NOT contain
+      sub-attributes.
+
+   Complex Attribute
+      A singular or multi-valued attribute whose value is a composition
+      of one or more simple attributes; e.g., "addresses" has the
+      sub-attributes "streetAddress", "locality", "postalCode", and
+      "country".
+
+   Sub-Attribute
+      A simple attribute that is contained within a complex attribute.
+
+2.  SCIM Schema
+
+   A SCIM server provides a set of resources, the allowable contents of
+   which are defined by a set of schema URIs and a resource type.
+   SCIM's schema is not a document-centric one such as with
+   [XML-Schema].  Instead, SCIM's support of schema is attribute based,
+   where each attribute may have different type, mutability,
+   cardinality, or returnability.  Validation of documents and messages
+   is always performed by an intended receiver, as specified by the SCIM
+   specifications.  Validation is performed by the receiver in the
+   context of a SCIM protocol request (see [RFC7644]).  For example, a
+   SCIM service provider, upon receiving a request to replace an
+   existing resource with a replacement JSON object, evaluates each
+   asserted attribute based on its characteristics as defined in the
+   relevant schema (e.g., mutability) and decides which attributes may
+   be replaced or ignored.
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 6]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   This specification provides a minimal core schema for representing
+   users and groups (resources), encompassing common attributes found in
+   many existing deployments and schemas.  In addition to the minimal
+   core schema, this document also specifies a standardized means by
+   which service providers may extend schemas to define new resources
+   and attributes in both standardized and service-provider-specific
+   cases.
+
+   Resources are categorized into common resource types such as "User"
+   or "Group".  Collections of resources of the same type are usually
+   contained within the same "container" ("folder") endpoint.
+
+2.1.  Attributes
+
+   A resource is a collection of attributes identified by one or more
+   schemas.  Minimally, an attribute consists of the attribute name and
+   at least one simple or complex value, either of which may be
+   multi-valued.  For each attribute, a SCIM schema defines the data
+   type, plurality, mutability, and other distinguishing features of an
+   attribute.
+
+   Attribute names are case insensitive and are often "camel-cased"
+   (e.g., "camelCase").  SCIM resources are represented in JSON
+   [RFC7159] format and MUST specify schema via the "schemas" attribute
+   per Section 3.
+
+   Attribute names MUST conform to the following ABNF rules:
+
+               ATTRNAME   = ALPHA *(nameChar)
+               nameChar   = "$" / "-" / "_" / DIGIT / ALPHA
+
+                    Figure 1: ABNF for Attribute Names
+
+   The above rules (and other rules in this specification) use the "Core
+   Rules" from ABNF; see Appendix B of [RFC5234].  Unless otherwise
+   specified in this document, all ABNF strings are case insensitive and
+   the character set for these strings is US-ASCII.  For example, all
+   attribute names defined by the above rule are case insensitive.
+
+   When defining attribute names, it should be noted that the hyphen
+   ("-") is not permitted in JavaScript attribute names (or in attribute
+   names for some other languages).  While there are no known issues
+   within HTTP protocol and JSON notation, attribute names containing
+   hyphens may need to be escaped when declaring corresponding names of
+   JavaScript attributes.
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 7]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+2.2.  Attribute Characteristics
+
+   All attributes have a set of characteristics that describe their type
+   and handling by a service provider; full definitions may be found in
+   Section 7.  The characteristics include:
+
+   o  "required",
+
+   o  "canonicalValues",
+
+   o  "caseExact",
+
+   o  "mutability",
+
+   o  "returned",
+
+   o  "uniqueness", and
+
+   o  "referenceTypes".
+
+   If not otherwise stated in Section 7, SCIM attributes have the
+   following characteristics:
+
+   o  "required" is "false" (i.e., not REQUIRED),
+
+   o  "canonicalValues": none assigned (for example, the "type"
+      sub-attribute as described in Section 2.4),
+
+   o  "caseExact" is "false" (i.e., case-insensitive),
+
+   o  "mutability" is "readWrite" (i.e., modifiable),
+
+   o  "returned" is "default" (the attribute value is returned by
+      default),
+
+   o  "uniqueness" is "none" (has no uniqueness enforced), and
+
+   o  "type" is "string" (Section 2.3.1).
+
+2.3.  Attribute Data Types
+
+   Attribute data types are derived from JSON [RFC7159].  The JSON
+   format defines a limited set of data types; hence, where appropriate,
+   alternate JSON representations derived from XML Schema [XML-Schema]
+   are defined below.  SCIM extensions SHOULD NOT introduce new data
+   types.
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 8]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Table 1 maps the following SCIM data types to their corresponding
+   SCIM schema type and underlying JSON data type:
+
+   +-----------+-------------+-----------------------------------------+
+   | SCIM Data | SCIM Schema | JSON Type                               |
+   | Type      | "type"      |                                         |
+   +-----------+-------------+-----------------------------------------+
+   | String    | "string"    | String per Section 7 of [RFC7159]       |
+   |           |             |                                         |
+   | Boolean   | "boolean"   | Value per Section 3 of [RFC7159]        |
+   |           |             |                                         |
+   | Decimal   | "decimal"   | Number per Section 6 of [RFC7159]       |
+   |           |             |                                         |
+   | Integer   | "integer"   | Number per Section 6 of [RFC7159]       |
+   |           |             |                                         |
+   | DateTime  | "dateTime"  | String per Section 7 of [RFC7159]       |
+   |           |             |                                         |
+   | Binary    | "binary"    | Binary value base64 encoded per Section |
+   |           |             | 4 of [RFC4648], or with URL and         |
+   |           |             | filename safe alphabet URL per Section  |
+   |           |             | 5 of [RFC4648] that is passed as a JSON |
+   |           |             | string per Section 7 of [RFC7159]       |
+   |           |             |                                         |
+   | Reference | "reference" | String per Section 7 of [RFC7159]       |
+   |           |             |                                         |
+   | Complex   | "complex"   | Object per Section 4 of [RFC7159]       |
+   +-----------+-------------+-----------------------------------------+
+
+              Table 1: SCIM Data Type to JSON Representation
+
+2.3.1.  String
+
+   A sequence of zero or more Unicode characters encoded using UTF-8 as
+   per [RFC2277] and [RFC3629].  The JSON format is defined in Section 7
+   of [RFC7159].  An attribute with SCIM schema type "string" MAY
+   specify a required data format.  Additionally, when "canonicalValues"
+   is specified, service providers MAY restrict accepted values to the
+   specified values.
+
+2.3.2.  Boolean
+
+   The literal "true" or "false".  The JSON format is defined in
+   Section 3 of [RFC7159].  A boolean has no case sensitivity or
+   uniqueness.
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 9]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+2.3.3.  Decimal
+
+   A real number with at least one digit to the left and right of the
+   period.  The JSON format is defined in Section 6 of [RFC7159].  A
+   decimal has no case sensitivity.
+
+2.3.4.  Integer
+
+   A whole number with no fractional digits or decimal.  The JSON format
+   is defined in Section 6 of [RFC7159], with the additional constraint
+   that the value MUST NOT contain fractional or exponent parts.  An
+   integer has no case sensitivity.
+
+2.3.5.  DateTime
+
+   A DateTime value (e.g., 2008-01-23T04:56:22Z).  The attribute value
+   MUST be encoded as a valid xsd:dateTime as specified in Section 3.3.7
+   of [XML-Schema] and MUST include both a date and a time.  A date time
+   format has no case sensitivity or uniqueness.
+
+   Values represented in JSON format MUST conform to the XML constraints
+   above and are represented as a JSON string per Section 7 of
+   [RFC7159].
+
+2.3.6.  Binary
+
+   Arbitrary binary data.  The attribute value MUST be base64 encoded as
+   specified in Section 4 of [RFC4648].  In cases where a URL-safe
+   encoding is required, the attribute definition MAY specify that
+   base64 URL encoding be used as per Section 5 of [RFC4648].  Unless
+   otherwise specified in the attribute definition, trailing padding
+   characters MAY be omitted ("=").
+
+   In JSON representation, the encoded values are represented as a JSON
+   string per Section 7 of [RFC7159].  A binary is case exact and has no
+   uniqueness.
+
+2.3.7.  Reference
+
+   A URI for a resource.  A resource MAY be a SCIM resource, an external
+   link to a resource (e.g., a photo), or an identifier such as a URN.
+   The value MUST be the absolute or relative URI of the target
+   resource.  Relative URIs should be resolved as specified in
+   Section 5.2 of [RFC3986].  However, the base URI for relative URI
+   resolution MUST include all URI components and path segments up to,
+   but not including, the Endpoint URI (the SCIM service provider root
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 10]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   endpoint); e.g., the base URI for a request to
+   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646"
+   would be "https://example.com/v2/", and the relative URI for this
+   resource would be "Users/2819c223-7f76-453a-919d-413861904646".
+
+   In JSON representation, the URI value is represented as a JSON string
+   per Section 7 of [RFC7159].  A reference is case exact.  A reference
+   has a "referenceTypes" attribute that indicates what types of
+   resources may be linked, as per Section 7 of this document.
+
+   A reference URI MUST be to an HTTP-addressable resource.  An HTTP
+   client performing a GET operation on a reference URI MUST receive the
+   target resource or an appropriate HTTP response code.  A SCIM service
+   provider MAY choose to enforce referential integrity for reference
+   types referring to SCIM resources.
+
+   By convention, a reference is commonly represented as a "$ref"
+   sub-attribute in complex or multi-valued attributes; however, this is
+   OPTIONAL.
+
+2.3.8.  Complex
+
+   A singular or multi-valued attribute whose value is a composition of
+   one or more simple attributes.  The JSON format is defined in
+   Section 4 of [RFC7159].  The order of the component attributes is not
+   significant.  Servers and clients MUST NOT require or expect
+   attributes to be in any specific order when an object is either
+   generated or analyzed.  A complex attribute has no uniqueness or case
+   sensitivity.  A complex attribute MUST NOT contain sub-attributes
+   that have sub-attributes (i.e., that are complex).
+
+2.4.  Multi-Valued Attributes
+
+   Multi-valued attributes contain a list of elements using the JSON
+   array format defined in Section 5 of [RFC7159].  Elements can be
+   either of the following:
+
+   o  primitive values, or
+
+   o  objects with a set of sub-attributes and values, using the JSON
+      object format defined in Section 4 of [RFC7159], in which case
+      they SHALL be considered to be complex attributes.  As with
+      complex attributes, the order of sub-attributes is not
+      significant.  The predefined sub-attributes listed in this section
+      can be used with multi-valued attribute objects, but these
+      sub-attributes MUST be used with the meanings defined here.
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 11]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   If not otherwise defined, the default set of sub-attributes for a
+   multi-valued attribute is as follows:
+
+   type
+      A label indicating the attribute's function, e.g., "work" or
+      "home".
+
+   primary
+      A Boolean value indicating the 'primary' or preferred attribute
+      value for this attribute, e.g., the preferred mailing address or
+      the primary email address.  The primary attribute value "true"
+      MUST appear no more than once.  If not specified, the value of
+      "primary" SHALL be assumed to be "false".
+
+   display
+      A human-readable name, primarily used for display purposes and
+      having a mutability of "immutable".
+
+   value
+      The attribute's significant value, e.g., email address, phone
+      number.
+
+   $ref
+      The reference URI of a target resource, if the attribute is a
+      reference.  URIs are canonicalized per Section 6.2 of [RFC3986].
+      While the representation of a resource may vary in different SCIM
+      protocol API versions (see Section 3.13 of [RFC7644]), URIs for
+      SCIM resources with an API version SHALL be considered comparable
+      to URIs without a version or with a different version.  For
+      example, "https://example.com/Users/12345" is equivalent to
+      "https://example.com/v2/Users/12345".
+
+   When returning multi-valued attributes, service providers SHOULD
+   canonicalize the value returned (e.g., by returning a value for the
+   sub-attribute "type", such as "home" or "work") when appropriate
+   (e.g., for email addresses and URLs).
+
+   Service providers MAY return element objects with the same "value"
+   sub-attribute more than once with a different "type" sub-attribute
+   (e.g., the same email address may be used for work and home) but
+   SHOULD NOT return the same (type, value) combination more than once
+   per attribute, as this complicates processing by the client.
+
+   When defining schema for multi-valued attributes, it is considered a
+   good practice to provide a type attribute that MAY be used for the
+   purpose of canonicalization of values.  In the schema definition for
+   an attribute, the service provider MAY define the recommended
+   canonical values (see Section 7).
+
+
+
+Hunt, et al.                 Standards Track                   [Page 12]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+2.5.  Unassigned and Null Values
+
+   Unassigned attributes, the null value, or an empty array (in the case
+   of a multi-valued attribute) SHALL be considered to be equivalent in
+   "state".  Assigning an attribute with the value "null" or an empty
+   array (in the case of multi-valued attributes) has the effect of
+   making the attribute "unassigned".  When a resource is expressed in
+   JSON format, unassigned attributes, although they are defined in
+   schema, MAY be omitted for compactness.
+
+3.  SCIM Resources
+
+   Each SCIM resource is a JSON object that has the following
+   components:
+
+   Resource Type
+      Each resource (or JSON object) in SCIM has a resource type
+      ("meta.resourceType"; see Section 3.1) that defines the resource's
+      core attribute schema and any attribute extension schema, as well
+      as the endpoint where objects of the same type may be found.  More
+      information about a resource MAY be found in its resource type
+      definition (see Section 6).
+
+   "Schemas" Attribute
+      The "schemas" attribute is a REQUIRED attribute and is an array of
+      Strings containing URIs that are used to indicate the namespaces
+      of the SCIM schemas that define the attributes present in the
+      current JSON structure.  This attribute may be used by parsers to
+      define the attributes present in the JSON structure that is the
+      body to an HTTP request or response.  Each String value must be a
+      unique URI.  All representations of SCIM schemas MUST include a
+      non-empty array with value(s) of the URIs supported by that
+      representation.  The "schemas" attribute for a resource MUST only
+      contain values defined as "schema" and "schemaExtensions" for the
+      resource's defined "resourceType".  Duplicate values MUST NOT be
+      included.  Value order is not specified and MUST NOT impact
+      behavior.
+
+   Common Attributes
+      A resource's common attributes are those attributes that are part
+      of every SCIM resource, regardless of the value of the "schemas"
+      attribute present in a JSON body.  These attributes are not
+      defined in any particular schema but SHALL be assumed to be
+      present in every resource, regardless of the value of the
+      "schemas" attribute.  See Section 3.1.
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 13]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Core Attributes
+      A resource's core attributes are those attributes that sit at the
+      top level of the JSON object together with the common attributes
+      (such as the resource "id").  The list of valid attributes is
+      specified by the resource's resource type "schema" attribute (see
+      Section 6).  This same value is also present in the resource's
+      "schemas" attribute.
+
+   Extended Attributes
+      Extended schema attributes are specified by the resource's
+      resource type "schemaExtensions" attribute (see Section 6).
+      Unlike core attributes, extended attributes are kept in their own
+      sub-attribute namespace identified by the schema extension URI.
+      This avoids attribute name conflicts that may arise due to
+      conflicts from separate schema extensions.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 14]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   The following example "User" contains the common attributes "id" and
+   "externalId", as well as the complex attribute "meta", which contains
+   the sub-attribute "resourceType".  The resource also contains core
+   attributes "userName" and "name", as well as extended enterprise User
+   attributes "employeeNumber" and "costCenter", which are contained in
+   their own JSON substructure identified by their schema URI.  Some
+   values have been omitted (...), shortened, or spaced out for clarity.
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:schemas:core:2.0:User",
+         "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
+
+     "id": "2819c223-7f76-453a-413861904646",
+     "externalId": "701984",
+
+     "userName": "bjensen@example.com",
+     "name": {
+       "formatted": "Ms. Barbara J Jensen, III",
+       "familyName": "Jensen",
+       "givenName": "Barbara",
+       "middleName": "Jane",
+       "honorificPrefix": "Ms.",
+       "honorificSuffix": "III"
+     },
+    ...
+
+     "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+       "employeeNumber": "701984",
+       "costCenter": "4130",
+       ...
+     },
+
+     "meta": {
+       "resourceType": "User",
+       "created": "2010-01-23T04:56:22Z",
+       "lastModified": "2011-05-13T04:42:34Z",
+       "version": "W\/\"3694e05e9dff591\"",
+       "location":
+         "https://example.com/v2/Users/2819c223-7f76-453a-413861904646"
+     }
+   }
+
+                 Figure 2: Example JSON Resource Structure
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 15]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+3.1.  Common Attributes
+
+   Each SCIM resource (Users, Groups, etc.) includes the following
+   common attributes.  With the exception of the "ServiceProviderConfig"
+   and "ResourceType" server discovery endpoints and their associated
+   resources, these attributes MUST be defined for all resources,
+   including any extended resource types.  When accepted by a service
+   provider (e.g., after a SCIM create), the attributes "id" and "meta"
+   (and its associated sub-attributes) MUST be assigned values by the
+   service provider.  Common attributes are considered to be part of
+   every base resource schema and do not use their own "schemas" URI.
+
+   For backward compatibility, some existing schema definitions MAY list
+   common attributes as part of the schema.  The attribute
+   characteristics (see Section 2.2) listed here SHALL take precedence
+   over older definitions that may be included in existing schemas.
+
+   id
+      A unique identifier for a SCIM resource as defined by the service
+      provider.  Each representation of the resource MUST include a
+      non-empty "id" value.  This identifier MUST be unique across the
+      SCIM service provider's entire set of resources.  It MUST be a
+      stable, non-reassignable identifier that does not change when the
+      same resource is returned in subsequent requests.  The value of
+      the "id" attribute is always issued by the service provider and
+      MUST NOT be specified by the client.  The string "bulkId" is a
+      reserved keyword and MUST NOT be used within any unique identifier
+      value.  The attribute characteristics are "caseExact" as "true", a
+      mutability of "readOnly", and a "returned" characteristic of
+      "always".  See Section 9 for additional considerations regarding
+      privacy.
+
+   externalId
+      A String that is an identifier for the resource as defined by the
+      provisioning client.  The "externalId" may simplify identification
+      of a resource between the provisioning client and the service
+      provider by allowing the client to use a filter to locate the
+      resource with an identifier from the provisioning domain,
+      obviating the need to store a local mapping between the
+      provisioning domain's identifier of the resource and the
+      identifier used by the service provider.  Each resource MAY
+      include a non-empty "externalId" value.  The value of the
+      "externalId" attribute is always issued by the provisioning client
+      and MUST NOT be specified by the service provider.  The service
+      provider MUST always interpret the externalId as scoped to the
+      provisioning domain.  While the server does not enforce
+      uniqueness, it is assumed that the value's uniqueness is
+      controlled by the client setting the value.  See Section 9 for
+
+
+
+Hunt, et al.                 Standards Track                   [Page 16]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      additional considerations regarding privacy.  This attribute has
+      "caseExact" as "true" and a mutability of "readWrite".  This
+      attribute is OPTIONAL.
+
+   meta
+      A complex attribute containing resource metadata.  All "meta"
+      sub-attributes are assigned by the service provider (have a
+      "mutability" of "readOnly"), and all of these sub-attributes have
+      a "returned" characteristic of "default".  This attribute SHALL be
+      ignored when provided by clients.  "meta" contains the following
+      sub-attributes:
+
+      resourceType  The name of the resource type of the resource.  This
+         attribute has a mutability of "readOnly" and "caseExact" as
+         "true".
+
+      created  The "DateTime" that the resource was added to the service
+         provider.  This attribute MUST be a DateTime.
+
+      lastModified  The most recent DateTime that the details of this
+         resource were updated at the service provider.  If this
+         resource has never been modified since its initial creation,
+         the value MUST be the same as the value of "created".
+
+      location  The URI of the resource being returned.  This value MUST
+         be the same as the "Content-Location" HTTP response header (see
+         Section 3.1.4.2 of [RFC7231]).
+
+      version  The version of the resource being returned.  This value
+         must be the same as the entity-tag (ETag) HTTP response header
+         (see Sections 2.1 and 2.3 of [RFC7232]).  This attribute has
+         "caseExact" as "true".  Service provider support for this
+         attribute is optional and subject to the service provider's
+         support for versioning (see Section 3.14 of [RFC7644]).  If a
+         service provider provides "version" (entity-tag) for a
+         representation and the generation of that entity-tag does not
+         satisfy all of the characteristics of a strong validator (see
+         Section 2.1 of [RFC7232]), then the origin server MUST mark the
+         "version" (entity-tag) as weak by prefixing its opaque value
+         with "W/" (case sensitive).
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 17]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+3.2.  Defining New Resource Types
+
+   SCIM may be extended to define new classes of resources by defining a
+   resource type.  Each resource type defines the name, endpoint, base
+   schema (the attributes), and any schema extensions registered for use
+   with the resource type.  In order to offer new types of resources, a
+   service provider defines the new resource type as specified in
+   Section 6 and defines a schema representation (see Section 8.7).
+
+3.3.  Attribute Extensions to Resources
+
+   SCIM allows resource types to have extensions in addition to their
+   core schema.  This is similar to how "objectClasses" are used in LDAP
+   [RFC4512].  However, unlike LDAP, there is no inheritance model; all
+   extensions are additive (similar to the LDAP auxiliary object class).
+   Each value in the "schemas" attribute indicates additive schema that
+   MAY exist in a SCIM resource representation.  The "schemas" attribute
+   MUST contain at least one value, which SHALL be the base schema for
+   the resource.  The "schemas" attribute MAY contain additional values
+   indicating extended schemas that are in use.  Schema extensions
+   SHOULD avoid redefining any attributes defined in this specification
+   and SHOULD follow conventions defined in this specification.  Except
+   for the base object schema, the schema extension URI SHALL be used as
+   a JSON container to distinguish attributes belonging to the extension
+   namespace from base schema attributes.  See Figure 5, which is an
+   example of the JSON representation of an enterprise User and is also
+   an example of a User with extended schema.
+
+   In order to determine which URI value in the "schemas" attribute is
+   the base schema and which is an extended schema for any given
+   resource, the resource's "resourceType" attribute value MAY be used
+   to retrieve the resource's "ResourceType" schema (see Section 6).
+   See the "ResourceType" representation in Figure 8 for an example.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 18]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+4.  SCIM Core Resources and Extensions
+
+   This section defines the default resource schemas present in a SCIM
+   server.  SCIM is not exclusive to these resources and may be extended
+   to support other resource types (see Section 3.2).
+
+4.1.  "User" Resource Schema
+
+   SCIM provides a resource type for "User" resources.  The core schema
+   for "User" is identified using the following schema URI:
+   "urn:ietf:params:scim:schemas:core:2.0:User".  The following
+   attributes are defined in addition to the core schema attributes:
+
+4.1.1.  Singular Attributes
+
+   userName
+      A service provider's unique identifier for the user, typically
+      used by the user to directly authenticate to the service provider.
+      Often displayed to the user as their unique identifier within the
+      system (as opposed to "id" or "externalId", which are generally
+      opaque and not user-friendly identifiers).  Each User MUST include
+      a non-empty userName value.  This identifier MUST be unique across
+      the service provider's entire set of Users.  This attribute is
+      REQUIRED and is case insensitive.
+
+   name
+      The components of the user's name.  Service providers MAY return
+      just the full name as a single string in the formatted
+      sub-attribute, or they MAY return just the individual component
+      attributes using the other sub-attributes, or they MAY return
+      both.  If both variants are returned, they SHOULD be describing
+      the same name, with the formatted name indicating how the
+      component attributes should be combined.
+
+      formatted  The full name, including all middle names, titles, and
+         suffixes as appropriate, formatted for display (e.g.,
+         "Ms. Barbara Jane Jensen, III").
+
+      familyName  The family name of the User, or last name in most
+         Western languages (e.g., "Jensen" given the full name
+         "Ms. Barbara Jane Jensen, III").
+
+      givenName  The given name of the User, or first name in most
+         Western languages (e.g., "Barbara" given the full name
+         "Ms. Barbara Jane Jensen, III").
+
+      middleName  The middle name(s) of the User (e.g., "Jane" given the
+         full name "Ms. Barbara Jane Jensen, III").
+
+
+
+Hunt, et al.                 Standards Track                   [Page 19]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      honorificPrefix  The honorific prefix(es) of the User, or title in
+         most Western languages (e.g., "Ms." given the full name
+         "Ms. Barbara Jane Jensen, III").
+
+      honorificSuffix  The honorific suffix(es) of the User, or suffix
+         in most Western languages (e.g., "III" given the full name
+         "Ms. Barbara Jane Jensen, III").
+
+   displayName
+      The name of the user, suitable for display to end-users.  Each
+      user returned MAY include a non-empty displayName value.  The name
+      SHOULD be the full name of the User being described, if known
+      (e.g., "Babs Jensen" or "Ms. Barbara J Jensen, III") but MAY be a
+      username or handle, if that is all that is available (e.g.,
+      "bjensen").  The value provided SHOULD be the primary textual
+      label by which this User is normally displayed by the service
+      provider when presenting it to end-users.
+
+   nickName
+      The casual way to address the user in real life, e.g., "Bob" or
+      "Bobby" instead of "Robert".  This attribute SHOULD NOT be used to
+      represent a User's username (e.g., bjensen or mpepperidge).
+
+   profileUrl
+      A URI that is a uniform resource locator (as defined in
+      Section 1.1.3 of [RFC3986]) and that points to a location
+      representing the user's online profile (e.g., a web page).  URIs
+      are canonicalized per Section 6.2 of [RFC3986].
+
+   title
+      The user's title, such as "Vice President".
+
+   userType
+      Used to identify the relationship between the organization and the
+      user.  Typical values used might be "Contractor", "Employee",
+      "Intern", "Temp", "External", and "Unknown", but any value may be
+      used.
+
+   preferredLanguage
+      Indicates the user's preferred written or spoken languages and is
+      generally used for selecting a localized user interface.  The
+      value indicates the set of natural languages that are preferred.
+      The format of the value is the same as the HTTP Accept-Language
+      header field (not including "Accept-Language:") and is specified
+      in Section 5.3.5 of [RFC7231].  The intent of this value is to
+      enable cloud applications to perform matching of language tags
+      [RFC4647] to the user's language preferences, regardless of what
+      may be indicated by a user agent (which might be shared), or in an
+
+
+
+Hunt, et al.                 Standards Track                   [Page 20]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      interaction that does not involve a user (such as in a delegated
+      OAuth 2.0 [RFC6749] style interaction) where normal HTTP
+      Accept-Language header negotiation cannot take place.
+
+   locale
+      Used to indicate the User's default location for purposes of
+      localizing such items as currency, date time format, or numerical
+      representations.  A valid value is a language tag as defined in
+      [RFC5646].  Computer languages are explicitly excluded.
+
+      A language tag is a sequence of one or more case-insensitive
+      sub-tags, each separated by a hyphen character ("-", %x2D).  For
+      backward compatibility, servers MAY accept tags separated by an
+      underscore character ("_", %x5F).  In most cases, a language tag
+      consists of a primary language sub-tag that identifies a broad
+      family of related languages (e.g., "en" = English) and that is
+      optionally followed by a series of sub-tags that refine or narrow
+      that language's range (e.g., "en-CA" = the variety of English as
+      communicated in Canada).  Whitespace is not allowed within a
+      language tag.  Example tags include:
+
+           fr, en-US, es-419, az-Arab, x-pig-latin, man-Nkoo-GN
+
+      See [RFC5646] for further information.
+
+   timezone
+      The User's time zone, in IANA Time Zone database format [RFC6557],
+      also known as the "Olson" time zone database format [Olson-TZ]
+      (e.g., "America/Los_Angeles").
+
+   active
+      A Boolean value indicating the user's administrative status.  The
+      definitive meaning of this attribute is determined by the service
+      provider.  As a typical example, a value of true implies that the
+      user is able to log in, while a value of false implies that the
+      user's account has been suspended.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 21]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   password
+      This attribute is intended to be used as a means to set, replace,
+      or compare (i.e., filter for equality) a password.  The cleartext
+      value or the hashed value of a password SHALL NOT be returnable by
+      a service provider.  If a service provider holds the value
+      locally, the value SHOULD be hashed.  When a password is set or
+      changed by the client, the cleartext password SHOULD be processed
+      by the service provider as follows:
+
+      *  Prepare the cleartext value for international language
+         comparison.  See Section 7.8 of [RFC7644].
+
+      *  Validate the value against server password policy.  Note: The
+         definition and enforcement of password policy are beyond the
+         scope of this document.
+
+      *  Ensure that the value is encrypted (e.g., hashed).  See
+         Section 9.2 for acceptable hashing and encryption handling when
+         storing or persisting for provisioning workflow reasons.
+
+      A service provider that immediately passes the cleartext value on
+      to another system or programming interface MUST pass the value
+      directly over a secured connection (e.g., Transport Layer Security
+      (TLS)).  If the value needs to be temporarily persisted for a
+      period of time (e.g., because of a workflow) before provisioning,
+      then the value MUST be protected by some method, such as
+      encryption.
+
+      Testing for an equality match MAY be supported if there is an
+      existing stored hashed value.  When testing for equality, the
+      service provider:
+
+      *  Prepares the filter value for international language
+         comparison.  See Section 7.8 of [RFC7644].
+
+      *  Generates the salted hash of the filter value and tests for a
+         match with the locally held value.
+
+      The mutability of the password attribute is "writeOnly",
+      indicating that the value MUST NOT be returned by a service
+      provider in any form (the attribute characteristic "returned" is
+      "never").
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 22]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+4.1.2.  Multi-Valued Attributes
+
+   The following multi-valued attributes are defined.
+
+   emails
+      Email addresses for the User.  The value SHOULD be specified
+      according to [RFC5321].  Service providers SHOULD canonicalize the
+      value according to [RFC5321], e.g., "bjensen@example.com" instead
+      of "bjensen@EXAMPLE.COM".  The "display" sub-attribute MAY be used
+      to return the canonicalized representation of the email value.
+      The "type" sub-attribute is used to provide a classification
+      meaningful to the (human) user.  The user interface should
+      encourage the use of basic values of "work", "home", and "other"
+      and MAY allow additional type values to be used at the discretion
+      of SCIM clients.
+
+   phoneNumbers
+      Phone numbers for the user.  The value SHOULD be specified
+      according to the format defined in [RFC3966], e.g.,
+      'tel:+1-201-555-0123'.  Service providers SHOULD canonicalize the
+      value according to [RFC3966] format, when appropriate.  The
+      "display" sub-attribute MAY be used to return the canonicalized
+      representation of the phone number value.  The sub-attribute
+      "type" often has typical values of "work", "home", "mobile",
+      "fax", "pager", and "other" and MAY allow more types to be defined
+      by the SCIM clients.
+
+   ims
+      Instant messaging address for the user.  No official
+      canonicalization rules exist for all instant messaging addresses,
+      but service providers SHOULD, when appropriate, remove all
+      whitespace and convert the address to lowercase.  The "type"
+      sub-attribute SHOULD take one of the following values: "aim",
+      "gtalk", "icq", "xmpp", "msn", "skype", "qq", "yahoo", or "other"
+      (representing currently popular IM services at the time of this
+      writing).  Service providers MAY add further values if new IM
+      services are introduced and MAY specify more detailed
+      canonicalization rules for each possible value.
+
+   photos
+      A URI that is a uniform resource locator (as defined in
+      Section 1.1.3 of [RFC3986]) that points to a resource location
+      representing the user's image.  The resource MUST be a file (e.g.,
+      a GIF, JPEG, or PNG image file) rather than a web page containing
+      an image.  Service providers MAY return the same image in
+      different sizes, although it is recognized that no standard for
+      describing images of various sizes currently exists.  Note that
+      this attribute SHOULD NOT be used to send down arbitrary photos
+
+
+
+Hunt, et al.                 Standards Track                   [Page 23]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      taken by this user; instead, profile photos of the user that are
+      suitable for display when describing the user should be sent.
+      Instead of the standard canonical values for type, this attribute
+      defines the following canonical values to represent popular photo
+      sizes: "photo" and "thumbnail".
+
+   addresses
+      A physical mailing address for this user.  Canonical type values
+      of "work", "home", and "other".  This attribute is a complex type
+      with the following sub-attributes.  All sub-attributes are
+      OPTIONAL.
+
+      formatted  The full mailing address, formatted for display or use
+         with a mailing label.  This attribute MAY contain newlines.
+
+      streetAddress  The full street address component, which may
+         include house number, street name, P.O. box, and multi-line
+         extended street address information.  This attribute MAY
+         contain newlines.
+
+      locality  The city or locality component.
+
+      region  The state or region component.
+
+      postalCode  The zip code or postal code component.
+
+      country  The country name component.  When specified, the value
+         MUST be in ISO 3166-1 "alpha-2" code format [ISO3166]; e.g.,
+         the United States and Sweden are "US" and "SE", respectively.
+
+   groups
+      A list of groups to which the user belongs, either through direct
+      membership, through nested groups, or dynamically calculated.  The
+      values are meant to enable expression of common group-based or
+      role-based access control models, although no explicit
+      authorization model is defined.  It is intended that the semantics
+      of group membership and any behavior or authorization granted as a
+      result of membership are defined by the service provider.  The
+      canonical types "direct" and "indirect" are defined to describe
+      how the group membership was derived.  Direct group membership
+      indicates that the user is directly associated with the group and
+      SHOULD indicate that clients may modify membership through the
+      "Group" resource.  Indirect membership indicates that user
+      membership is transitive or dynamic and implies that clients
+      cannot modify indirect group membership through the "Group"
+      resource but MAY modify direct group membership through the
+      "Group" resource, which may influence indirect memberships.  If
+      the SCIM service provider exposes a "Group" resource, the "value"
+
+
+
+Hunt, et al.                 Standards Track                   [Page 24]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      sub-attribute MUST be the "id", and the "$ref" sub-attribute must
+      be the URI of the corresponding "Group" resources to which the
+      user belongs.  Since this attribute has a mutability of
+      "readOnly", group membership changes MUST be applied via the
+      "Group" Resource (Section 4.2).  This attribute has a mutability
+      of "readOnly".
+
+   entitlements
+      A list of entitlements for the user that represent a thing the
+      user has.  An entitlement may be an additional right to a thing,
+      object, or service.  No vocabulary or syntax is specified; service
+      providers and clients are expected to encode sufficient
+      information in the value so as to accurately and without ambiguity
+      determine what the user has access to.  This value has no
+      canonical types, although a type may be useful as a means to scope
+      entitlements.
+
+   roles
+      A list of roles for the user that collectively represent who the
+      user is, e.g., "Student", "Faculty".  No vocabulary or syntax is
+      specified, although it is expected that a role value is a String
+      or label representing a collection of entitlements.  This value
+      has no canonical types.
+
+   x509Certificates
+      A list of certificates associated with the resource (e.g., a
+      User).  Each value contains exactly one DER-encoded X.509
+      certificate (see Section 4 of [RFC5280]), which MUST be base64
+      encoded per Section 4 of [RFC4648].  A single value MUST NOT
+      contain multiple certificates and so does not contain the encoding
+      "SEQUENCE OF Certificate" in any guise.
+
+4.2.  "Group" Resource Schema
+
+   SCIM provides a schema for representing groups, identified using the
+   following schema URI: "urn:ietf:params:scim:schemas:core:2.0:Group".
+
+   "Group" resources are meant to enable expression of common
+   group-based or role-based access control models, although no explicit
+   authorization model is defined.  It is intended that the semantics of
+   group membership, and any behavior or authorization granted as a
+   result of membership, are defined by the service provider; these are
+   considered out of scope for this specification.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 25]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   The following singular attribute is defined in addition to the common
+   attributes defined in the SCIM core schema:
+
+   displayName
+      A human-readable name for the Group.  REQUIRED.
+
+   The following multi-valued attribute is defined in addition to the
+   common attributes defined in the SCIM core schema:
+
+   members
+      A list of members of the Group.  While values MAY be added or
+      removed, sub-attributes of members are "immutable".  The "value"
+      sub-attribute contains the value of an "id" attribute of a SCIM
+      resource, and the "$ref" sub-attribute must be the URI of a SCIM
+      resource such as a "User", or a "Group".  The intention of the
+      "Group" type is to allow the service provider to support nested
+      groups.  Service providers MAY require clients to provide a
+      non-empty value by setting the "required" attribute characteristic
+      of a sub-attribute of the "members" attribute in the "Group"
+      resource schema.
+
+4.3.  Enterprise User Schema Extension
+
+   The following SCIM extension defines attributes commonly used in
+   representing users that belong to, or act on behalf of, a business or
+   enterprise.  The enterprise User extension is identified using the
+   following schema URI:
+   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User".
+
+   The following singular attributes are defined:
+
+   employeeNumber
+      A string identifier, typically numeric or alphanumeric, assigned
+      to a person, typically based on order of hire or association with
+      an organization.
+
+   costCenter
+      Identifies the name of a cost center.
+
+   organization
+      Identifies the name of an organization.
+
+   division
+      Identifies the name of a division.
+
+   department
+      Identifies the name of a department.
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 26]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   manager
+      The user's manager.  A complex type that optionally allows service
+      providers to represent organizational hierarchy by referencing the
+      "id" attribute of another User.
+
+      value  The "id" of the SCIM resource representing the user's
+         manager.  RECOMMENDED.
+
+      $ref  The URI of the SCIM resource representing the User's
+         manager.  RECOMMENDED.
+
+      displayName  The displayName of the user's manager.  This
+         attribute is OPTIONAL, and mutability is "readOnly".
+
+5.  Service Provider Configuration Schema
+
+   SCIM provides a schema for representing the service provider's
+   configuration, identified using the following schema URI:
+   "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig".
+
+   The service provider configuration resource enables a service
+   provider to discover SCIM specification features in a standardized
+   form as well as provide additional implementation details to clients.
+   All attributes have a mutability of "readOnly".  Unlike other core
+   resources, the "id" attribute is not required for the service
+   provider configuration resource.
+
+   The following singular attributes are defined in addition to the
+   common attributes defined in the core schema:
+
+   documentationUri
+      An HTTP-addressable URL pointing to the service provider's
+      human-consumable help documentation.  OPTIONAL.
+
+   patch
+      A complex type that specifies PATCH configuration options.
+      REQUIRED.  See Section 3.5.2 of [RFC7644].
+
+      supported  A Boolean value specifying whether or not the operation
+         is supported.  REQUIRED.
+
+   bulk
+      A complex type that specifies bulk configuration options.  See
+      Section 3.7 of [RFC7644].  REQUIRED.
+
+      supported  A Boolean value specifying whether or not the operation
+         is supported.  REQUIRED.
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 27]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      maxOperations  An integer value specifying the maximum number of
+         operations.  REQUIRED.
+
+      maxPayloadSize  An integer value specifying the maximum payload
+         size in bytes.  REQUIRED.
+
+   filter
+      A complex type that specifies FILTER options.  REQUIRED.  See
+      Section 3.4.2.2 of [RFC7644].
+
+      supported  A Boolean value specifying whether or not the operation
+         is supported.  REQUIRED.
+
+      maxResults  An integer value specifying the maximum number of
+         resources returned in a response.  REQUIRED.
+
+   changePassword
+      A complex type that specifies configuration options related to
+      changing a password.  REQUIRED.
+
+      supported  A Boolean value specifying whether or not the operation
+         is supported.  REQUIRED.
+
+   sort
+      A complex type that specifies Sort configuration options.
+      REQUIRED.
+
+      supported  A Boolean value specifying whether or not sorting is
+         supported.  REQUIRED.
+
+   etag
+      A complex type that specifies ETag configuration options.
+      REQUIRED.
+
+      supported  A Boolean value specifying whether or not the operation
+         is supported.  REQUIRED.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 28]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   The following multi-valued attribute is defined in addition to the
+   common attributes defined in the core schema:
+
+   authenticationSchemes
+      A multi-valued complex type that specifies supported
+      authentication scheme properties.  To enable seamless discovery of
+      configurations, the service provider SHOULD, with the appropriate
+      security considerations, make the authenticationSchemes attribute
+      publicly accessible without prior authentication.  REQUIRED.  The
+      following sub-attributes are defined:
+
+      type  The authentication scheme.  This specification defines the
+         values "oauth", "oauth2", "oauthbearertoken", "httpbasic", and
+         "httpdigest".  REQUIRED.
+
+      name  The common authentication scheme name, e.g., HTTP Basic.
+         REQUIRED.
+
+      description  A description of the authentication scheme.
+         REQUIRED.
+
+      specUri  An HTTP-addressable URL pointing to the authentication
+         scheme's specification.  OPTIONAL.
+
+      documentationUri  An HTTP-addressable URL pointing to the
+         authentication scheme's usage documentation.  OPTIONAL.
+
+6.  ResourceType Schema
+
+   The "ResourceType" schema specifies the metadata about a resource
+   type.  Resource type resources are READ-ONLY and identified using the
+   following schema URI:
+   "urn:ietf:params:scim:schemas:core:2.0:ResourceType".  Unlike other
+   core resources, all attributes are REQUIRED unless otherwise
+   specified.  The "id" attribute is not required for the resource type
+   resource.
+
+   The following singular attributes are defined:
+
+   id
+      The resource type's server unique id.  This is often the same
+      value as the "name" attribute.  OPTIONAL.
+
+   name
+      The resource type name.  When applicable, service providers MUST
+      specify the name, e.g., "User" or "Group".  This name is
+      referenced by the "meta.resourceType" attribute in all resources.
+      REQUIRED.
+
+
+
+Hunt, et al.                 Standards Track                   [Page 29]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   description
+      The resource type's human-readable description.  When applicable,
+      service providers MUST specify the description.  OPTIONAL.
+
+   endpoint
+      The resource type's HTTP-addressable endpoint relative to the Base
+      URL of the service provider, e.g., "Users".  REQUIRED.
+
+   schema
+      The resource type's primary/base schema URI, e.g.,
+      "urn:ietf:params:scim:schemas:core:2.0:User".  This MUST be equal
+      to the "id" attribute of the associated "Schema" resource.
+      REQUIRED.
+
+   schemaExtensions
+      A list of URIs of the resource type's schema extensions.
+      OPTIONAL.
+
+      schema  The URI of an extended schema, e.g., "urn:edu:2.0:Staff".
+         This MUST be equal to the "id" attribute of a "Schema"
+         resource.  REQUIRED.
+
+      required  A Boolean value that specifies whether or not the schema
+         extension is required for the resource type.  If true, a
+         resource of this type MUST include this schema extension and
+         also include any attributes declared as required in this schema
+         extension.  If false, a resource of this type MAY omit this
+         schema extension.  REQUIRED.
+
+7.  Schema Definition
+
+   This section defines a way to specify the schema in use by resources
+   available and accepted by a SCIM service provider.  For each
+   "schemas" URI value, this schema specifies the defined attribute(s)
+   and their characteristics (mutability, returnability, etc).  For
+   every schema URI used in a resource object, there is a corresponding
+   "Schema" resource.  "Schema" resources are not modifiable, and their
+   associated attributes have a mutability of "readOnly".  Except for
+   "id" (which is always returned), all attributes have a "returned"
+   characteristic of "default".  Unless otherwise specified, all schema
+   attributes are case insensitive.  These resources have a "schemas"
+   attribute with the following schema URI:
+
+   urn:ietf:params:scim:schemas:core:2.0:Schema
+
+   Unlike other core resources, the "Schema" resource MAY contain a
+   complex object within a sub-attribute, and all attributes are
+   REQUIRED unless otherwise specified.
+
+
+
+Hunt, et al.                 Standards Track                   [Page 30]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   The following singular attributes are defined:
+
+   id
+      The unique URI of the schema.  When applicable, service providers
+      MUST specify the URI, e.g.,
+      "urn:ietf:params:scim:schemas:core:2.0:User".  Unlike most other
+      schemas, which use some sort of Globally Unique Identifier (GUID)
+      for the "id", the schema "id" is a URI so that it can be
+      registered and is portable between different service providers and
+      clients.  REQUIRED.
+
+   name
+      The schema's human-readable name.  When applicable, service
+      providers MUST specify the name, e.g., "User" or "Group".
+      OPTIONAL.
+
+   description
+      The schema's human-readable description.  When applicable, service
+      providers MUST specify the description.  OPTIONAL.
+
+   The following multi-valued attribute is defined:
+
+   attributes
+      A complex type that defines service provider attributes and their
+      qualities via the following set of sub-attributes:
+
+      name  The attribute's name.
+
+      type  The attribute's data type.  Valid values are "string",
+         "boolean", "decimal", "integer", "dateTime", "reference", and
+         "complex".  When an attribute is of type "complex", there
+         SHOULD be a corresponding schema attribute "subAttributes"
+         defined, listing the sub-attributes of the attribute.
+
+      subAttributes  When an attribute is of type "complex",
+         "subAttributes" defines a set of sub-attributes.
+         "subAttributes" has the same schema sub-attributes as
+         "attributes".
+
+      multiValued  A Boolean value indicating the attribute's plurality.
+
+      description  The attribute's human-readable description.  When
+         applicable, service providers MUST specify the description.
+
+      required  A Boolean value that specifies whether or not the
+         attribute is required.
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 31]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      canonicalValues  A collection of suggested canonical values that
+         MAY be used (e.g., "work" and "home").  In some cases, service
+         providers MAY choose to ignore unsupported values.  OPTIONAL.
+
+      caseExact  A Boolean value that specifies whether or not a string
+         attribute is case sensitive.  The server SHALL use case
+         sensitivity when evaluating filters.  For attributes that are
+         case exact, the server SHALL preserve case for any value
+         submitted.  If the attribute is case insensitive, the server
+         MAY alter case for a submitted value.  Case sensitivity also
+         impacts how attribute values MAY be compared against filter
+         values (see Section 3.4.2.2 of [RFC7644]).
+
+      mutability  A single keyword indicating the circumstances under
+         which the value of the attribute can be (re)defined:
+
+         readOnly  The attribute SHALL NOT be modified.
+
+         readWrite  The attribute MAY be updated and read at any time.
+            This is the default value.
+
+         immutable  The attribute MAY be defined at resource creation
+            (e.g., POST) or at record replacement via a request (e.g., a
+            PUT).  The attribute SHALL NOT be updated.
+
+         writeOnly  The attribute MAY be updated at any time.  Attribute
+            values SHALL NOT be returned (e.g., because the value is a
+            stored hash).  Note: An attribute with a mutability of
+            "writeOnly" usually also has a returned setting of "never".
+
+      returned  A single keyword that indicates when an attribute and
+         associated values are returned in response to a GET request or
+         in response to a PUT, POST, or PATCH request.  Valid keywords
+         are as follows:
+
+         always  The attribute is always returned, regardless of the
+            contents of the "attributes" parameter.  For example, "id"
+            is always returned to identify a SCIM resource.
+
+         never  The attribute is never returned.  This may occur because
+            the original attribute value (e.g., a hashed value) is not
+            retained by the service provider.  A service provider MAY
+            allow attributes to be used in a search filter.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 32]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+         default  The attribute is returned by default in all SCIM
+            operation responses where attribute values are returned.  If
+            the GET request "attributes" parameter is specified,
+            attribute values are only returned if the attribute is named
+            in the "attributes" parameter.  DEFAULT.
+
+         request  The attribute is returned in response to any PUT,
+            POST, or PATCH operations if the attribute was specified by
+            the client (for example, the attribute was modified).  The
+            attribute is returned in a SCIM query operation only if
+            specified in the "attributes" parameter.
+
+      uniqueness  A single keyword value that specifies how the service
+         provider enforces uniqueness of attribute values.  A server MAY
+         reject an invalid value based on uniqueness by returning HTTP
+         response code 400 (Bad Request).  A client MAY enforce
+         uniqueness on the client side to a greater degree than the
+         service provider enforces.  For example, a client could make a
+         value unique while the server has uniqueness of "none".  Valid
+         keywords are as follows:
+
+         none  The values are not intended to be unique in any way.
+            DEFAULT.
+
+         server  The value SHOULD be unique within the context of the
+            current SCIM endpoint (or tenancy) and MAY be globally
+            unique (e.g., a "username", email address, or other
+            server-generated key or counter).  No two resources on the
+            same server SHOULD possess the same value.
+
+         global  The value SHOULD be globally unique (e.g., an email
+            address, a GUID, or other value).  No two resources on any
+            server SHOULD possess the same value.
+
+      referenceTypes  A multi-valued array of JSON strings that indicate
+         the SCIM resource types that may be referenced.  Valid values
+         are as follows:
+
+         +  A SCIM resource type (e.g., "User" or "Group"),
+
+         +  "external" - indicating that the resource is an external
+            resource (e.g., a photo), or
+
+         +  "uri" - indicating that the reference is to a service
+            endpoint or an identifier (e.g., a schema URN).
+
+         This attribute is only applicable for attributes that are of
+         type "reference" (Section 2.3.7).
+
+
+
+Hunt, et al.                 Standards Track                   [Page 33]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.  JSON Representation
+
+8.1.  Minimal User Representation
+
+   The following is a non-normative example of the minimal required SCIM
+   representation in JSON format.
+
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "id": "2819c223-7f76-453a-919d-413861904646",
+  "userName": "bjensen@example.com",
+  "meta": {
+    "resourceType": "User",
+    "created": "2010-01-23T04:56:22Z",
+    "lastModified": "2011-05-13T04:42:34Z",
+    "version": "W\/\"3694e05e9dff590\"",
+    "location":
+     "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646"
+  }
+}
+
+            Figure 3: Example Minimal User JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 34]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.2.  Full User Representation
+
+   The following is a non-normative example of the fully populated SCIM
+   representation in JSON format.
+
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "id": "2819c223-7f76-453a-919d-413861904646",
+  "externalId": "701984",
+  "userName": "bjensen@example.com",
+  "name": {
+    "formatted": "Ms. Barbara J Jensen, III",
+    "familyName": "Jensen",
+    "givenName": "Barbara",
+    "middleName": "Jane",
+    "honorificPrefix": "Ms.",
+    "honorificSuffix": "III"
+  },
+  "displayName": "Babs Jensen",
+  "nickName": "Babs",
+  "profileUrl": "https://login.example.com/bjensen",
+  "emails": [
+    {
+      "value": "bjensen@example.com",
+      "type": "work",
+      "primary": true
+    },
+    {
+      "value": "babs@jensen.org",
+      "type": "home"
+    }
+  ],
+  "addresses": [
+    {
+      "type": "work",
+      "streetAddress": "100 Universal City Plaza",
+      "locality": "Hollywood",
+      "region": "CA",
+      "postalCode": "91608",
+      "country": "USA",
+      "formatted": "100 Universal City Plaza\nHollywood, CA 91608 USA",
+      "primary": true
+    },
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 35]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+    {
+      "type": "home",
+      "streetAddress": "456 Hollywood Blvd",
+      "locality": "Hollywood",
+      "region": "CA",
+      "postalCode": "91608",
+      "country": "USA",
+      "formatted": "456 Hollywood Blvd\nHollywood, CA 91608 USA"
+    }
+  ],
+  "phoneNumbers": [
+    {
+      "value": "555-555-5555",
+      "type": "work"
+    },
+    {
+      "value": "555-555-4444",
+      "type": "mobile"
+    }
+  ],
+  "ims": [
+    {
+      "value": "someaimhandle",
+      "type": "aim"
+    }
+  ],
+  "photos": [
+    {
+      "value":
+        "https://photos.example.com/profilephoto/72930000000Ccne/F",
+      "type": "photo"
+    },
+    {
+      "value":
+        "https://photos.example.com/profilephoto/72930000000Ccne/T",
+      "type": "thumbnail"
+    }
+  ],
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 36]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  "userType": "Employee",
+  "title": "Tour Guide",
+  "preferredLanguage": "en-US",
+  "locale": "en-US",
+  "timezone": "America/Los_Angeles",
+  "active":true,
+  "password": "t1meMa$heen",
+  "groups": [
+    {
+      "value": "e9e30dba-f08f-4109-8486-d5c6a331660a",
+      "$ref":
+"https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a",
+      "display": "Tour Guides"
+    },
+    {
+      "value": "fc348aa8-3835-40eb-a20b-c726e15c55b5",
+      "$ref":
+"https://example.com/v2/Groups/fc348aa8-3835-40eb-a20b-c726e15c55b5",
+      "display": "Employees"
+    },
+    {
+      "value": "71ddacd2-a8e7-49b8-a5db-ae50d0a5bfd7",
+      "$ref":
+"https://example.com/v2/Groups/71ddacd2-a8e7-49b8-a5db-ae50d0a5bfd7",
+      "display": "US Employees"
+    }
+  ],
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 37]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  "x509Certificates": [
+    {
+      "value":
+       "MIIDQzCCAqygAwIBAgICEAAwDQYJKoZIhvcNAQEFBQAwTjELMAkGA1UEBhMCVVMx
+        EzARBgNVBAgMCkNhbGlmb3JuaWExFDASBgNVBAoMC2V4YW1wbGUuY29tMRQwEgYD
+        VQQDDAtleGFtcGxlLmNvbTAeFw0xMTEwMjIwNjI0MzFaFw0xMjEwMDQwNjI0MzFa
+        MH8xCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRQwEgYDVQQKDAtl
+        eGFtcGxlLmNvbTEhMB8GA1UEAwwYTXMuIEJhcmJhcmEgSiBKZW5zZW4gSUlJMSIw
+        IAYJKoZIhvcNAQkBFhNiamVuc2VuQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0B
+        AQEFAAOCAQ8AMIIBCgKCAQEA7Kr+Dcds/JQ5GwejJFcBIP682X3xpjis56AK02bc
+        1FLgzdLI8auoR+cC9/Vrh5t66HkQIOdA4unHh0AaZ4xL5PhVbXIPMB5vAPKpzz5i
+        PSi8xO8SL7I7SDhcBVJhqVqr3HgllEG6UClDdHO7nkLuwXq8HcISKkbT5WFTVfFZ
+        zidPl8HZ7DhXkZIRtJwBweq4bvm3hM1Os7UQH05ZS6cVDgweKNwdLLrT51ikSQG3
+        DYrl+ft781UQRIqxgwqCfXEuDiinPh0kkvIi5jivVu1Z9QiwlYEdRbLJ4zJQBmDr
+        SGTMYn4lRc2HgHO4DqB/bnMVorHB0CC6AV1QoFK4GPe1LwIDAQABo3sweTAJBgNV
+        HRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZp
+        Y2F0ZTAdBgNVHQ4EFgQU8pD0U0vsZIsaA16lL8En8bx0F/gwHwYDVR0jBBgwFoAU
+        dGeKitcaF7gnzsNwDx708kqaVt0wDQYJKoZIhvcNAQEFBQADgYEAA81SsFnOdYJt
+        Ng5Tcq+/ByEDrBgnusx0jloUhByPMEVkoMZ3J7j1ZgI8rAbOkNngX8+pKfTiDz1R
+        C4+dx8oU6Za+4NJXUjlL5CvV6BEYb1+QAEJwitTVvxB/A67g42/vzgAtoRUeDov1
+        +GFiBZ+GNF/cAYKcMtGcrs2i97ZkJMo="
+    }
+  ],
+  "meta": {
+    "resourceType": "User",
+    "created": "2010-01-23T04:56:22Z",
+    "lastModified": "2011-05-13T04:42:34Z",
+    "version": "W\/\"a330bc54f0671c9\"",
+    "location":
+"https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646"
+  }
+}
+
+              Figure 4: Example Full User JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 38]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.3.  Enterprise User Extension Representation
+
+   The following is a non-normative example of the fully populated User
+   using the enterprise User extension in JSON format.
+
+{
+  "schemas":
+    ["urn:ietf:params:scim:schemas:core:2.0:User",
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
+  "id": "2819c223-7f76-453a-919d-413861904646",
+  "externalId": "701984",
+  "userName": "bjensen@example.com",
+  "name": {
+    "formatted": "Ms. Barbara J Jensen, III",
+    "familyName": "Jensen",
+    "givenName": "Barbara",
+    "middleName": "Jane",
+    "honorificPrefix": "Ms.",
+    "honorificSuffix": "III"
+  },
+  "displayName": "Babs Jensen",
+  "nickName": "Babs",
+  "profileUrl": "https://login.example.com/bjensen",
+  "emails": [
+    {
+      "value": "bjensen@example.com",
+      "type": "work",
+      "primary": true
+    },
+    {
+      "value": "babs@jensen.org",
+      "type": "home"
+    }
+  ],
+  "addresses": [
+    {
+      "streetAddress": "100 Universal City Plaza",
+      "locality": "Hollywood",
+      "region": "CA",
+      "postalCode": "91608",
+      "country": "USA",
+      "formatted": "100 Universal City Plaza\nHollywood, CA 91608 USA",
+      "type": "work",
+      "primary": true
+    },
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 39]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+    {
+      "streetAddress": "456 Hollywood Blvd",
+      "locality": "Hollywood",
+      "region": "CA",
+      "postalCode": "91608",
+      "country": "USA",
+      "formatted": "456 Hollywood Blvd\nHollywood, CA 91608 USA",
+      "type": "home"
+     }
+  ],
+  "phoneNumbers": [
+    {
+      "value": "555-555-5555",
+      "type": "work"
+    },
+    {
+      "value": "555-555-4444",
+      "type": "mobile"
+    }
+  ],
+  "ims": [
+    {
+      "value": "someaimhandle",
+      "type": "aim"
+    }
+  ],
+  "photos": [
+    {
+      "value":
+        "https://photos.example.com/profilephoto/72930000000Ccne/F",
+      "type": "photo"
+    },
+    {
+      "value":
+        "https://photos.example.com/profilephoto/72930000000Ccne/T",
+      "type": "thumbnail"
+    }
+  ],
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 40]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  "userType": "Employee",
+  "title": "Tour Guide",
+  "preferredLanguage": "en-US",
+  "locale": "en-US",
+  "timezone": "America/Los_Angeles",
+  "active":true,
+  "password": "t1meMa$heen",
+  "groups": [
+    {
+      "value": "e9e30dba-f08f-4109-8486-d5c6a331660a",
+      "$ref": "../Groups/e9e30dba-f08f-4109-8486-d5c6a331660a",
+      "display": "Tour Guides"
+    },
+    {
+      "value": "fc348aa8-3835-40eb-a20b-c726e15c55b5",
+      "$ref": "../Groups/fc348aa8-3835-40eb-a20b-c726e15c55b5",
+      "display": "Employees"
+    },
+    {
+      "value": "71ddacd2-a8e7-49b8-a5db-ae50d0a5bfd7",
+      "$ref": "../Groups/71ddacd2-a8e7-49b8-a5db-ae50d0a5bfd7",
+      "display": "US Employees"
+    }
+  ],
+  "x509Certificates": [
+    {
+      "value":
+       "MIIDQzCCAqygAwIBAgICEAAwDQYJKoZIhvcNAQEFBQAwTjELMAkGA1UEBhMCVVMx
+        EzARBgNVBAgMCkNhbGlmb3JuaWExFDASBgNVBAoMC2V4YW1wbGUuY29tMRQwEgYD
+        VQQDDAtleGFtcGxlLmNvbTAeFw0xMTEwMjIwNjI0MzFaFw0xMjEwMDQwNjI0MzFa
+        MH8xCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRQwEgYDVQQKDAtl
+        eGFtcGxlLmNvbTEhMB8GA1UEAwwYTXMuIEJhcmJhcmEgSiBKZW5zZW4gSUlJMSIw
+        IAYJKoZIhvcNAQkBFhNiamVuc2VuQGV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0B
+        AQEFAAOCAQ8AMIIBCgKCAQEA7Kr+Dcds/JQ5GwejJFcBIP682X3xpjis56AK02bc
+        1FLgzdLI8auoR+cC9/Vrh5t66HkQIOdA4unHh0AaZ4xL5PhVbXIPMB5vAPKpzz5i
+        PSi8xO8SL7I7SDhcBVJhqVqr3HgllEG6UClDdHO7nkLuwXq8HcISKkbT5WFTVfFZ
+        zidPl8HZ7DhXkZIRtJwBweq4bvm3hM1Os7UQH05ZS6cVDgweKNwdLLrT51ikSQG3
+        DYrl+ft781UQRIqxgwqCfXEuDiinPh0kkvIi5jivVu1Z9QiwlYEdRbLJ4zJQBmDr
+        SGTMYn4lRc2HgHO4DqB/bnMVorHB0CC6AV1QoFK4GPe1LwIDAQABo3sweTAJBgNV
+        HRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZp
+        Y2F0ZTAdBgNVHQ4EFgQU8pD0U0vsZIsaA16lL8En8bx0F/gwHwYDVR0jBBgwFoAU
+        dGeKitcaF7gnzsNwDx708kqaVt0wDQYJKoZIhvcNAQEFBQADgYEAA81SsFnOdYJt
+        Ng5Tcq+/ByEDrBgnusx0jloUhByPMEVkoMZ3J7j1ZgI8rAbOkNngX8+pKfTiDz1R
+        C4+dx8oU6Za+4NJXUjlL5CvV6BEYb1+QAEJwitTVvxB/A67g42/vzgAtoRUeDov1
+        +GFiBZ+GNF/cAYKcMtGcrs2i97ZkJMo="
+    }
+  ],
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 41]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+    "employeeNumber": "701984",
+    "costCenter": "4130",
+    "organization": "Universal Studios",
+    "division": "Theme Park",
+    "department": "Tour Operations",
+    "manager": {
+      "value": "26118915-6090-4610-87e4-49d8ca9f808d",
+      "$ref": "../Users/26118915-6090-4610-87e4-49d8ca9f808d",
+      "displayName": "John Smith"
+    }
+  },
+  "meta": {
+    "resourceType": "User",
+    "created": "2010-01-23T04:56:22Z",
+    "lastModified": "2011-05-13T04:42:34Z",
+    "version": "W\/\"3694e05e9dff591\"",
+    "location":
+"https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646"
+  }
+}
+
+           Figure 5: Example Enterprise User JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 42]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.4.  Group Representation
+
+   The following is a non-normative example of the SCIM Group
+   representation in JSON format.
+
+   {
+     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+     "id": "e9e30dba-f08f-4109-8486-d5c6a331660a",
+     "displayName": "Tour Guides",
+     "members": [
+       {
+         "value": "2819c223-7f76-453a-919d-413861904646",
+         "$ref":
+   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
+         "display": "Babs Jensen"
+       },
+       {
+         "value": "902c246b-6245-4190-8e05-00816be7344a",
+         "$ref":
+   "https://example.com/v2/Users/902c246b-6245-4190-8e05-00816be7344a",
+         "display": "Mandy Pepperidge"
+       }
+     ],
+     "meta": {
+       "resourceType": "Group",
+       "created": "2010-01-23T04:56:22Z",
+       "lastModified": "2011-05-13T04:42:34Z",
+       "version": "W\/\"3694e05e9dff592\"",
+       "location":
+   "https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a"
+     }
+   }
+
+                Figure 6: Example Group JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 43]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.5.  Service Provider Configuration Representation
+
+   The following is a non-normative example of the SCIM service provider
+   configuration representation in JSON format.
+
+  {
+    "schemas":
+      ["urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"],
+    "documentationUri": "http://example.com/help/scim.html",
+    "patch": {
+      "supported":true
+    },
+    "bulk": {
+      "supported":true,
+      "maxOperations":1000,
+      "maxPayloadSize":1048576
+    },
+    "filter": {
+      "supported":true,
+      "maxResults": 200
+    },
+    "changePassword": {
+      "supported":true
+    },
+    "sort": {
+      "supported":true
+    },
+    "etag": {
+      "supported":true
+    },
+    "authenticationSchemes": [
+      {
+        "name": "OAuth Bearer Token",
+        "description":
+          "Authentication scheme using the OAuth Bearer Token Standard",
+        "specUri": "http://www.rfc-editor.org/info/rfc6750",
+        "documentationUri": "http://example.com/help/oauth.html",
+        "type": "oauthbearertoken",
+        "primary": true
+      },
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 44]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name": "HTTP Basic",
+        "description":
+          "Authentication scheme using the HTTP Basic Standard",
+        "specUri": "http://www.rfc-editor.org/info/rfc2617",
+        "documentationUri": "http://example.com/help/httpBasic.html",
+        "type": "httpbasic"
+       }
+    ],
+    "meta": {
+      "location": "https://example.com/v2/ServiceProviderConfig",
+      "resourceType": "ServiceProviderConfig",
+      "created": "2010-01-23T04:56:22Z",
+      "lastModified": "2011-05-13T04:42:34Z",
+      "version": "W\/\"3694e05e9dff594\""
+    }
+  }
+
+   Figure 7: Example Service Provider Configuration JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 45]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.6.  Resource Type Representation
+
+   The following is a non-normative example of the SCIM resource types
+   in JSON format.
+
+   [{
+     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+     "id": "User",
+     "name": "User",
+     "endpoint": "/Users",
+     "description": "User Account",
+     "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+     "schemaExtensions": [
+       {
+         "schema":
+           "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+         "required": true
+       }
+     ],
+     "meta": {
+       "location": "https://example.com/v2/ResourceTypes/User",
+       "resourceType": "ResourceType"
+     }
+    },
+    {
+     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+     "id": "Group",
+     "name": "Group",
+     "endpoint": "/Groups",
+     "description": "Group",
+     "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
+     "meta": {
+       "location": "https://example.com/v2/ResourceTypes/Group",
+       "resourceType": "ResourceType"
+     }
+   }]
+
+            Figure 8: Example Resource Type JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 46]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.7.  Schema Representation
+
+   The following sections provide representations of schemas for both
+   SCIM resources and service provider schemas.  Note that the JSON
+   representation has been modified for readability and to fit the
+   specification format.
+
+8.7.1.  Resource Schema Representation
+
+   The following is intended as an example of the SCIM schema
+   representation in JSON format for SCIM resources.  Where permitted,
+   individual values and schema MAY change.  This example includes
+   schema representations for "User", "Group", and "EnterpriseUser";
+   other schema representations are possible.
+
+[
+  {
+    "id" : "urn:ietf:params:scim:schemas:core:2.0:User",
+    "name" : "User",
+    "description" : "User Account",
+    "attributes" : [
+      {
+        "name" : "userName",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Unique identifier for the User, typically
+used by the user to directly authenticate to the service provider.
+Each User MUST include a non-empty userName value.  This identifier
+MUST be unique across the service provider's entire set of Users.
+REQUIRED.",
+        "required" : true,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "server"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 47]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "name",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "The components of the user's real name.
+Providers MAY return just the full name as a single string in the
+formatted sub-attribute, or they MAY return just the individual
+component attributes using the other sub-attributes, or they MAY
+return both.  If both variants are returned, they SHOULD be
+describing the same name, with the formatted name indicating how the
+component attributes should be combined.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "formatted",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The full name, including all middle
+names, titles, and suffixes as appropriate, formatted for display
+(e.g., 'Ms. Barbara J Jensen, III').",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "familyName",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The family name of the User, or
+last name in most Western languages (e.g., 'Jensen' given the full
+name 'Ms. Barbara J Jensen, III').",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 48]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "givenName",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The given name of the User, or
+first name in most Western languages (e.g., 'Barbara' given the
+full name 'Ms. Barbara J Jensen, III').",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "middleName",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The middle name(s) of the User
+(e.g., 'Jane' given the full name 'Ms. Barbara J Jensen, III').",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "honorificPrefix",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The honorific prefix(es) of the User, or
+title in most Western languages (e.g., 'Ms.' given the full name
+'Ms. Barbara J Jensen, III').",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 49]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "honorificSuffix",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The honorific suffix(es) of the User, or
+suffix in most Western languages (e.g., 'III' given the full name
+'Ms. Barbara J Jensen, III').",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "displayName",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The name of the User, suitable for display
+to end-users.  The name SHOULD be the full name of the User being
+described, if known.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "nickName",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The casual way to address the user in real
+life, e.g., 'Bob' or 'Bobby' instead of 'Robert'.  This attribute
+SHOULD NOT be used to represent a User's username (e.g., 'bjensen' or
+'mpepperidge').",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 50]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "profileUrl",
+        "type" : "reference",
+        "referenceTypes" : ["external"],
+        "multiValued" : false,
+        "description" : "A fully qualified URL pointing to a page
+representing the User's online profile.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "title",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The user's title, such as
+\"Vice President.\"",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "userType",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Used to identify the relationship between
+the organization and the user.  Typical values used might be
+'Contractor', 'Employee', 'Intern', 'Temp', 'External', and
+'Unknown', but any value may be used.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 51]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "preferredLanguage",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Indicates the User's preferred written or
+spoken language.  Generally used for selecting a localized user
+interface; e.g., 'en_US' specifies the language English and country
+US.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "locale",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Used to indicate the User's default location
+for purposes of localizing items such as currency, date time format, or
+numerical representations.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "timezone",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The User's time zone in the 'Olson' time zone
+database format, e.g., 'America/Los_Angeles'.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 52]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "active",
+        "type" : "boolean",
+        "multiValued" : false,
+        "description" : "A Boolean value indicating the User's
+administrative status.",
+        "required" : false,
+        "mutability" : "readWrite",
+        "returned" : "default"
+      },
+      {
+        "name" : "password",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The User's cleartext password.  This
+attribute is intended to be used as a means to specify an initial
+password when creating a new User or to reset an existing User's
+password.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "writeOnly",
+        "returned" : "never",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "emails",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "Email addresses for the user.  The value
+SHOULD be canonicalized by the service provider, e.g.,
+'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.
+Canonical type values of 'work', 'home', and 'other'.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Email addresses for the user.  The value
+SHOULD be canonicalized by the service provider, e.g.,
+'bjensen@example.com' instead of 'bjensen@EXAMPLE.COM'.
+Canonical type values of 'work', 'home', and 'other'.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+Hunt, et al.                 Standards Track                   [Page 53]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function, e.g., 'work' or 'home'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "work",
+              "home",
+              "other"
+            ],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute, e.g., the preferred
+mailing address or primary email address.  The primary attribute
+value 'true' MUST appear no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 54]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "phoneNumbers",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "Phone numbers for the User.  The value
+SHOULD be canonicalized by the service provider according to the
+format specified in RFC 3966, e.g., 'tel:+1-201-555-0123'.
+Canonical type values of 'work', 'home', 'mobile', 'fax', 'pager',
+and 'other'.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Phone number of the User.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 55]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function, e.g., 'work', 'home', 'mobile'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "work",
+              "home",
+              "mobile",
+              "fax",
+              "pager",
+              "other"
+            ],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute, e.g., the preferred
+phone number or primary phone number.  The primary attribute value
+'true' MUST appear no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 56]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "ims",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "Instant messaging addresses for the User.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Instant messaging address for the User.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 57]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function, e.g., 'aim', 'gtalk', 'xmpp'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "aim",
+              "gtalk",
+              "icq",
+              "xmpp",
+              "msn",
+              "skype",
+              "qq",
+              "yahoo"
+            ],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute, e.g., the preferred
+messenger or primary messenger.  The primary attribute value 'true'
+MUST appear no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 58]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "photos",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "URLs of photos of the User.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "reference",
+            "referenceTypes" : ["external"],
+            "multiValued" : false,
+            "description" : "URL of a photo of the User.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 59]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function, i.e., 'photo' or 'thumbnail'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "photo",
+              "thumbnail"
+            ],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute, e.g., the preferred
+photo or thumbnail.  The primary attribute value 'true' MUST appear
+no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 60]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "addresses",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A physical mailing address for this User.
+Canonical type values of 'work', 'home', and 'other'.  This attribute
+is a complex type with the following sub-attributes.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "formatted",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The full mailing address, formatted for
+display or use with a mailing label.  This attribute MAY contain
+newlines.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "streetAddress",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The full street address component,
+which may include house number, street name, P.O. box, and multi-line
+extended street address information.  This attribute MAY contain
+newlines.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "locality",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The city or locality component.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 61]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "region",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The state or region component.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "postalCode",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The zip code or postal code component.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "country",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The country name component.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 62]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function, e.g., 'work' or 'home'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "work",
+              "home",
+              "other"
+            ],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "groups",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A list of groups to which the user belongs,
+either through direct membership, through nested groups, or
+dynamically calculated.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The identifier of the User's group.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 63]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "$ref",
+            "type" : "reference",
+            "referenceTypes" : [
+              "User",
+              "Group"
+            ],
+            "multiValued" : false,
+            "description" : "The URI of the corresponding 'Group'
+resource to which the user belongs.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function, e.g., 'direct' or 'indirect'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "direct",
+              "indirect"
+            ],
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ],
+        "mutability" : "readOnly",
+        "returned" : "default"
+      },
+
+
+
+Hunt, et al.                 Standards Track                   [Page 64]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "entitlements",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A list of entitlements for the User that
+represent a thing the User has.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The value of an entitlement.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 65]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute.  The primary
+attribute value 'true' MUST appear no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      },
+      {
+        "name" : "roles",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A list of roles for the User that
+collectively represent who the User is, e.g., 'Student', 'Faculty'.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The value of a role.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 66]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute.  The primary
+attribute value 'true' MUST appear no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      },
+      {
+        "name" : "x509Certificates",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A list of certificates issued to the User.",
+        "required" : false,
+        "caseExact" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "binary",
+            "multiValued" : false,
+            "description" : "The value of an X.509 certificate.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 67]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "display",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable name, primarily used
+for display purposes.  READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the attribute's
+function.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [],
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "primary",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating the 'primary'
+or preferred attribute value for this attribute.  The primary
+attribute value 'true' MUST appear no more than once.",
+            "required" : false,
+            "mutability" : "readWrite",
+            "returned" : "default"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      }
+    ],
+    "meta" : {
+      "resourceType" : "Schema",
+      "location" :
+        "/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:User"
+    }
+  },
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 68]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  {
+    "id" : "urn:ietf:params:scim:schemas:core:2.0:Group",
+    "name" : "Group",
+    "description" : "Group",
+    "attributes" : [
+      {
+        "name" : "displayName",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "A human-readable name for the Group.
+REQUIRED.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "members",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A list of members of the Group.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Identifier of the member of this Group.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "immutable",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 69]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "$ref",
+            "type" : "reference",
+            "referenceTypes" : [
+              "User",
+              "Group"
+            ],
+            "multiValued" : false,
+            "description" : "The URI corresponding to a SCIM resource
+that is a member of this Group.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "immutable",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A label indicating the type of resource,
+e.g., 'User' or 'Group'.",
+            "required" : false,
+            "caseExact" : false,
+            "canonicalValues" : [
+              "User",
+              "Group"
+            ],
+            "mutability" : "immutable",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      }
+    ],
+    "meta" : {
+      "resourceType" : "Schema",
+      "location" :
+        "/v2/Schemas/urn:ietf:params:scim:schemas:core:2.0:Group"
+    }
+  },
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 70]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  {
+    "id" : "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+    "name" : "EnterpriseUser",
+    "description" : "Enterprise User",
+    "attributes" : [
+      {
+        "name" : "employeeNumber",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Numeric or alphanumeric identifier assigned
+to a person, typically based on order of hire or association with an
+organization.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "costCenter",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Identifies the name of a cost center.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "organization",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Identifies the name of an organization.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 71]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "division",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Identifies the name of a division.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "department",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "Identifies the name of a department.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readWrite",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "manager",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "The User's manager.  A complex type that
+optionally allows service providers to represent organizational
+hierarchy by referencing the 'id' attribute of another User.",
+        "required" : false,
+        "subAttributes" : [
+          {
+            "name" : "value",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The id of the SCIM resource representing
+the User's manager.  REQUIRED.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 72]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "$ref",
+            "type" : "reference",
+            "referenceTypes" : [
+              "User"
+            ],
+            "multiValued" : false,
+            "description" : "The URI of the SCIM resource
+representing the User's manager.  REQUIRED.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readWrite",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "displayName",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The displayName of the User's manager.
+OPTIONAL and READ-ONLY.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ],
+        "mutability" : "readWrite",
+        "returned" : "default"
+      }
+    ],
+    "meta" : {
+      "resourceType" : "Schema",
+      "location" :
+"/v2/Schemas/urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+    }
+  }
+]
+
+         Figure 9: Example JSON Representation for Resource Schema
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 73]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+8.7.2.  Service Provider Schema Representation
+
+   The following is a representation of the SCIM schema for the fixed
+   service provider schemas: ServiceProviderConfig, ResourceType, and
+   Schema.
+
+[
+  {
+    "id" :
+      "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig",
+    "name" : "Service Provider Configuration",
+    "description" : "Schema for representing the service provider's
+      configuration",
+    "attributes" : [
+      {
+        "name" : "documentationUri",
+        "type" : "reference",
+        "referenceTypes" : ["external"],
+        "multiValued" : false,
+        "description" : "An HTTP-addressable URL pointing to the
+          service provider's human-consumable help documentation.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 74]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "patch",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "A complex type that specifies PATCH
+          configuration options.",
+        "required" : true,
+        "returned" : "default",
+        "mutability" : "readOnly",
+        "subAttributes" : [
+          {
+            "name" : "supported",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value specifying whether or not
+              the operation is supported.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          }
+        ]
+      },
+      {
+        "name" : "bulk",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "A complex type that specifies bulk
+          configuration options.",
+        "required" : true,
+        "returned" : "default",
+        "mutability" : "readOnly",
+        "subAttributes" : [
+          {
+            "name" : "supported",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value specifying whether or not
+              the operation is supported.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          },
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 75]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "maxOperations",
+            "type" : "integer",
+            "multiValued" : false,
+            "description" : "An integer value specifying the maximum
+              number of operations.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "maxPayloadSize",
+            "type" : "integer",
+            "multiValued" : false,
+            "description" : "An integer value specifying the maximum
+              payload size in bytes.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ]
+      },
+      {
+        "name" : "filter",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "A complex type that specifies
+          FILTER options.",
+        "required" : true,
+        "returned" : "default",
+        "mutability" : "readOnly",
+        "subAttributes" : [
+          {
+            "name" : "supported",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value specifying whether or not
+              the operation is supported.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          },
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 76]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "maxResults",
+            "type" : "integer",
+            "multiValued" : false,
+            "description" : "An integer value specifying the maximum
+              number of resources returned in a response.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ]
+      },
+      {
+        "name" : "changePassword",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "A complex type that specifies configuration
+          options related to changing a password.",
+        "required" : true,
+        "returned" : "default",
+        "mutability" : "readOnly",
+        "subAttributes" : [
+          {
+            "name" : "supported",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value specifying whether or not
+              the operation is supported.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          }
+        ]
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 77]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "sort",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "A complex type that specifies sort result
+          options.",
+        "required" : true,
+        "returned" : "default",
+        "mutability" : "readOnly",
+        "subAttributes" : [
+          {
+            "name" : "supported",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value specifying whether or not
+              the operation is supported.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          }
+        ]
+      },
+      {
+        "name" : "authenticationSchemes",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A complex type that specifies supported
+          authentication scheme properties.",
+        "required" : true,
+        "returned" : "default",
+        "mutability" : "readOnly",
+        "subAttributes" : [
+          {
+            "name" : "name",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The common authentication scheme name,
+              e.g., HTTP Basic.",
+            "required" : true,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 78]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "description",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A description of the authentication
+              scheme.",
+            "required" : true,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "specUri",
+            "type" : "reference",
+            "referenceTypes" : ["external"],
+            "multiValued" : false,
+            "description" : "An HTTP-addressable URL pointing to the
+              authentication scheme's specification.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "documentationUri",
+            "type" : "reference",
+            "referenceTypes" : ["external"],
+            "multiValued" : false,
+            "description" : "An HTTP-addressable URL pointing to the
+              authentication scheme's usage documentation.",
+            "required" : false,
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          }
+        ]
+      }
+    ]
+  },
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 79]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+  {
+    "id" : "urn:ietf:params:scim:schemas:core:2.0:ResourceType",
+    "name" : "ResourceType",
+    "description" : "Specifies the schema that describes a SCIM
+      resource type",
+    "attributes" : [
+      {
+        "name" : "id",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The resource type's server unique id.
+          May be the same as the 'name' attribute.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "name",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The resource type name.  When applicable,
+          service providers MUST specify the name, e.g., 'User'.",
+        "required" : true,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "description",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The resource type's human-readable
+          description.  When applicable, service providers MUST
+          specify the description.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 80]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "endpoint",
+        "type" : "reference",
+        "referenceTypes" : ["uri"],
+        "multiValued" : false,
+        "description" : "The resource type's HTTP-addressable
+          endpoint relative to the Base URL, e.g., '/Users'.",
+        "required" : true,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "schema",
+        "type" : "reference",
+        "referenceTypes" : ["uri"],
+        "multiValued" : false,
+        "description" : "The resource type's primary/base schema
+          URI.",
+        "required" : true,
+        "caseExact" : true,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "schemaExtensions",
+        "type" : "complex",
+        "multiValued" : false,
+        "description" : "A list of URIs of the resource type's schema
+          extensions.",
+        "required" : true,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "subAttributes" : [
+          {
+            "name" : "schema",
+            "type" : "reference",
+            "referenceTypes" : ["uri"],
+            "multiValued" : false,
+            "description" : "The URI of a schema extension.",
+            "required" : true,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+Hunt, et al.                 Standards Track                   [Page 81]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "required",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value that specifies whether
+              or not the schema extension is required for the
+              resource type.  If true, a resource of this type MUST
+              include this schema extension and also include any
+              attributes declared as required in this schema extension.
+              If false, a resource of this type MAY omit this schema
+              extension.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id" : "urn:ietf:params:scim:schemas:core:2.0:Schema",
+    "name" : "Schema",
+    "description" : "Specifies the schema that describes a
+      SCIM schema",
+    "attributes" : [
+      {
+        "name" : "id",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The unique URI of the schema.
+          When applicable, service providers MUST specify the URI.",
+        "required" : true,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 82]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+      {
+        "name" : "name",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The schema's human-readable name.  When
+          applicable, service providers MUST specify the name,
+          e.g., 'User'.",
+        "required" : true,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "description",
+        "type" : "string",
+        "multiValued" : false,
+        "description" : "The schema's human-readable name.  When
+          applicable, service providers MUST specify the name,
+          e.g., 'User'.",
+        "required" : false,
+        "caseExact" : false,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "uniqueness" : "none"
+      },
+      {
+        "name" : "attributes",
+        "type" : "complex",
+        "multiValued" : true,
+        "description" : "A complex attribute that includes the
+          attributes of a schema.",
+        "required" : true,
+        "mutability" : "readOnly",
+        "returned" : "default",
+        "subAttributes" : [
+          {
+            "name" : "name",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The attribute's name.",
+            "required" : true,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 83]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "type",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "The attribute's data type.
+              Valid values include 'string', 'complex', 'boolean',
+              'decimal', 'integer', 'dateTime', 'reference'.",
+            "required" : true,
+            "canonicalValues" : [
+              "string",
+              "complex",
+              "boolean",
+              "decimal",
+              "integer",
+              "dateTime",
+              "reference"
+            ],
+            "caseExact" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "multiValued",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating an
+              attribute's plurality.",
+            "required" : true,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          },
+          {
+            "name" : "description",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "A human-readable description of the
+              attribute.",
+            "required" : false,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 84]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "required",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A boolean value indicating whether or
+              not the attribute is required.",
+            "required" : false,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          },
+          {
+            "name" : "canonicalValues",
+            "type" : "string",
+            "multiValued" : true,
+            "description" : "A collection of canonical values.  When
+              applicable, service providers MUST specify the
+              canonical types, e.g., 'work', 'home'.",
+            "required" : false,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+          {
+            "name" : "caseExact",
+            "type" : "boolean",
+            "multiValued" : false,
+            "description" : "A Boolean value indicating whether or
+              not a string attribute is case sensitive.",
+            "required" : false,
+            "mutability" : "readOnly",
+            "returned" : "default"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 85]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "mutability",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Indicates whether or not an attribute
+              is modifiable.",
+            "required" : false,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none",
+            "canonicalValues" : [
+              "readOnly",
+              "readWrite",
+              "immutable",
+              "writeOnly"
+            ]
+          },
+          {
+            "name" : "returned",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Indicates when an attribute is returned
+              in a response (e.g., to a query).",
+            "required" : false,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none",
+            "canonicalValues" : [
+              "always",
+              "never",
+              "default",
+              "request"
+            ]
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 86]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "uniqueness",
+            "type" : "string",
+            "multiValued" : false,
+            "description" : "Indicates how unique a value must be.",
+            "required" : false,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none",
+            "canonicalValues" : [
+              "none",
+              "server",
+              "global"
+            ]
+          },
+          {
+            "name" : "referenceTypes",
+            "type" : "string",
+            "multiValued" : true,
+            "description" : "Used only with an attribute of type
+              'reference'.  Specifies a SCIM resourceType that a
+              reference attribute MAY refer to, e.g., 'User'.",
+            "required" : false,
+            "caseExact" : true,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "uniqueness" : "none"
+          },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 87]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+          {
+            "name" : "subAttributes",
+            "type" : "complex",
+            "multiValued" : true,
+            "description" : "Used to define the sub-attributes of a
+              complex attribute.",
+            "required" : false,
+            "mutability" : "readOnly",
+            "returned" : "default",
+            "subAttributes" : [
+              {
+                "name" : "name",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "The attribute's name.",
+                "required" : true,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none"
+              },
+              {
+                "name" : "type",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "The attribute's data type.
+                  Valid values include 'string', 'complex', 'boolean',
+                  'decimal', 'integer', 'dateTime', 'reference'.",
+                "required" : true,
+                "caseExact" : false,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none",
+                "canonicalValues" : [
+                  "string",
+                  "complex",
+                  "boolean",
+                  "decimal",
+                  "integer",
+                  "dateTime",
+                  "reference"
+                ]
+              },
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 88]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+              {
+                "name" : "multiValued",
+                "type" : "boolean",
+                "multiValued" : false,
+                "description" : "A Boolean value indicating an
+                  attribute's plurality.",
+                "required" : true,
+                "mutability" : "readOnly",
+                "returned" : "default"
+              },
+              {
+                "name" : "description",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "A human-readable description of the
+                  attribute.",
+                "required" : false,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none"
+              },
+              {
+                "name" : "required",
+                "type" : "boolean",
+                "multiValued" : false,
+                "description" : "A boolean value indicating whether or
+                  not the attribute is required.",
+                "required" : false,
+                "mutability" : "readOnly",
+                "returned" : "default"
+              },
+              {
+                "name" : "canonicalValues",
+                "type" : "string",
+                "multiValued" : true,
+                "description" : "A collection of canonical values.  When
+                  applicable, service providers MUST specify the
+                  canonical types, e.g., 'work', 'home'.",
+                "required" : false,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none"
+              },
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 89]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+              {
+                "name" : "caseExact",
+                "type" : "boolean",
+                "multiValued" : false,
+                "description" : "A Boolean value indicating whether or
+                  not a string attribute is case sensitive.",
+                "required" : false,
+                "mutability" : "readOnly",
+                "returned" : "default"
+              },
+              {
+                "name" : "mutability",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "Indicates whether or not an
+                  attribute is modifiable.",
+                "required" : false,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none",
+                "canonicalValues" : [
+                  "readOnly",
+                  "readWrite",
+                  "immutable",
+                  "writeOnly"
+                ]
+              },
+              {
+                "name" : "returned",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "Indicates when an attribute is
+                  returned in a response (e.g., to a query).",
+                "required" : false,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none",
+                "canonicalValues" : [
+                  "always",
+                  "never",
+                  "default",
+                  "request"
+                ]
+              },
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 90]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+              {
+                "name" : "uniqueness",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "Indicates how unique a value must be.",
+                "required" : false,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none",
+                "canonicalValues" : [
+                  "none",
+                  "server",
+                  "global"
+                ]
+              },
+              {
+                "name" : "referenceTypes",
+                "type" : "string",
+                "multiValued" : false,
+                "description" : "Used only with an attribute of type
+                  'reference'.  Specifies a SCIM resourceType that a
+                  reference attribute MAY refer to, e.g., 'User'.",
+                "required" : false,
+                "caseExact" : true,
+                "mutability" : "readOnly",
+                "returned" : "default",
+                "uniqueness" : "none"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]
+
+   Figure 10: Representation of Fixed Service Provider Endpoint Schemas
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 91]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+9.  Security Considerations
+
+9.1.  Protocol
+
+   SCIM data is intended to be exchanged using the SCIM protocol.  It is
+   important when handling data to implement the security considerations
+   outlined in Section 7 of [RFC7644].
+
+9.2.  Passwords and Other Sensitive Security Data
+
+   Passwords and other attributes related to security credentials are of
+   an extremely sensitive nature and require special handling when
+   transmitted or stored.  While the SCIM protocol uses cleartext
+   passwords for value assignment and equality-testing purposes,
+   password values MUST NOT be stored in cleartext form.
+
+   Administrators should undertake industry best practices to protect
+   the storage of credentials and in particular SHOULD follow
+   recommendations outlined in Section 5.1.4.1 of [RFC6819].  These
+   requirements include, but are not limited to, the following:
+
+   o  Provide injection attack countermeasures (e.g., by validating all
+      inputs and parameters);
+
+   o  Credentials should not be stored in cleartext form;
+
+   o  Store credentials using an encrypted protection mechanism (e.g.,
+      hashing); and
+
+   o  Where possible, avoid passwords as the sole form of
+      authentication, and consider using credentials that are based on
+      asymmetric cryptography.
+
+9.3.  Privacy
+
+   The SCIM core schema defines attributes that are sensitive and may be
+   considered personally identifying information (PII).  These privacy
+   considerations should be considered for extensions as well as the
+   schema defined in this specification.
+
+   For the purposes of this specification, PII is defined as any
+   attribute that may be used as a unique key to identify a person
+   (e.g., "User").  Since other information may be used in combination
+   to identify an individual, all attributes in SCIM are considered
+   "sensitive" personal information.  Consult regional jurisdictions to
+   see if there are special considerations for the handling of personal
+   information (e.g., PII).
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 92]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Information should be shared on an as-needed basis.  A SCIM client
+   should limit information to what it believes a service provider
+   requires, and a SCIM service provider should only accept information
+   it needs.  Clients and service providers should take into
+   consideration that personal information is being conveyed across
+   technical (e.g., protocol and applications), administrative (e.g.,
+   organizational, corporate), and jurisdictional boundaries.  In
+   particular, information security and privacy must be considered.
+
+   Security service level agreements for the handling of these
+   attributes are beyond the scope of this document but are to be
+   carefully considered by implementers and deploying organizations.
+
+   Please see the Privacy Considerations section of [RFC7644] for more
+   protocol-specific considerations regarding the handling of SCIM
+   information.
+
+   SCIM defines attributes such as "id", "externalId", and SCIM resource
+   URIs, which cause new PII to be generated; this information is
+   important to the way that the SCIM protocol identifies and locates
+   resources.  Where possible, it is suggested that service providers
+   take the following remediations:
+
+   o  Where possible, assign and bind identifiers to specific tenants
+      and/or clients.  When multiple tenants are able to reference the
+      same resource, they should do so via separate identifiers (id or
+      externalId).  This ensures that separate domains linked to the
+      same information cannot perform identifier correlation.
+
+   o  In the case of "externalId", if multiple values are supported, use
+      access control to restrict access to the client domain that
+      assigned the "externalId" value.
+
+   o  Ensure that access to data is appropriately restricted to
+      authorized parties with a "need to know".
+
+   o  When persisted, ensure that the appropriate protection mechanisms
+      are in place to restrict access by unauthorized parties, including
+      administrators or parties with access to backup data.
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 93]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+10.  IANA Considerations
+
+10.1.  Registration of SCIM URN Sub-namespace and SCIM Registry
+
+   IANA has added an entry to the "IETF URN Sub-namespace for Registered
+   Protocol Parameter Identifiers" registry and created a sub-namespace
+   for the Registered Parameter Identifier as per [RFC3553]:
+   "urn:ietf:params:scim".
+
+   To manage this sub-namespace, IANA has created the "System for
+   Cross-domain Identity Management (SCIM) Schema URIs" registry, which
+   is used to manage entries within the "urn:ietf:params:scim"
+   namespace.  The registry description is as follows:
+
+   o  Registry name: SCIM
+
+   o  Specification: this document (RFC 7643)
+
+   o  Repository: See Section 10.2
+
+   o  Index value: See Section 10.2
+
+10.2.  URN Sub-namespace for SCIM
+
+   SCIM schemas and SCIM messages utilize URIs to identify the schema in
+   use or other relevant context.  This section creates and registers an
+   IETF URN Sub-namespace for use in the SCIM specifications and future
+   extensions.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 94]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+10.2.1.  Specification Template
+
+   Namespace ID:
+
+      The Namespace ID "scim" has been assigned.
+
+   Registration Information:
+
+      Version: 1
+
+      Date: 2015-06-22
+
+   Declared registrant of the namespace:
+
+      Registering organization
+         The Internet Engineering Task Force
+
+      Designated contact
+         A designated expert will monitor the SCIM public mailing list,
+         "scim@ietf.org".
+
+   Declaration of Syntactic Structure:
+
+      The Namespace Specific String (NSS) of all URNs that use the
+      "scim" Namespace ID shall have the following structure:
+
+   urn:ietf:params:scim:{type}:{name}{:other}
+
+      The keywords have the following meaning:
+
+      type
+         The entity type, which is either "schemas" or "api".
+
+      name
+         A required US-ASCII string that conforms to the URN syntax
+         requirements (see [RFC2141]) and defines a major namespace of a
+         schema used within SCIM (e.g., "core", which is reserved for
+         SCIM specifications).  The value MAY also be an industry name
+         or organization name.
+
+      other
+         Any US-ASCII string that conforms to the URN syntax
+         requirements (see [RFC2141]) and defines the sub-namespace
+         (which MAY be further broken down in namespaces delimited by
+         colons) as needed to uniquely identify a schema.
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 95]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Relevant Ancillary Documentation:
+
+      None
+
+   Identifier Uniqueness Considerations:
+
+      The designated contact shall be responsible for reviewing and
+      enforcing uniqueness.
+
+   Identifier Persistence Considerations:
+
+      Once a name has been allocated, it MUST NOT be reallocated for a
+      different purpose.  The rules provided for assignments of values
+      within a sub-namespace MUST be constructed so that the meanings of
+      values cannot change.  This registration mechanism is not
+      appropriate for naming values whose meanings may change over time.
+
+      As the SCIM specifications are updated and the SCIM protocol
+      version is adjusted, a new registration will be made when
+      significant changes are made -- for example,
+      "urn:ietf:params:scim:schemas:core:1.0 (externally defined, not
+      previously registered)" and
+      "urn:ietf:params:scim:schemas:core:2.0".
+
+   Process of Identifier Assignment:
+
+      Identifiers with namespace type "schema" (e.g.,
+      "urn:ietf:params:scim:schemas") are assigned after the review of
+      the assigned contact via the SCIM public mailing list,
+      "scim@ietf.org", as documented in Section 10.3.
+
+      Namespaces with type "api" (e.g., "urn:ietf:params:scim:api") and
+      "param" (e.g., "urn:ietf:params:scim:param") are reserved for
+      IETF-approved SCIM specifications.
+
+   Process of Identifier Resolution:
+
+      The namespace is not currently listed with a Resolution Discovery
+      System (RDS), but nothing about the namespace prohibits the future
+      definition of appropriate resolution methods or listing with an
+      RDS.
+
+   Rules for Lexical Equivalence:
+
+      No special considerations; the rules for lexical equivalence
+      specified in [RFC2141] apply.
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 96]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Conformance with URN Syntax:
+
+      No special considerations.
+
+   Validation Mechanism:
+
+      None specified.
+
+   Scope:
+
+      Global.
+
+10.3.  Registering SCIM Schemas
+
+   This section defines the process for registering new SCIM schemas
+   with IANA in the "System for Cross-domain Identity Management (SCIM)
+   Schema URIs" registry (see Section 10.1).  A schema URI is used as a
+   value in the "schemas" attribute (Section 3) for the purpose of
+   distinguishing extensions used in a SCIM resource.
+
+10.3.1.  Registration Procedure
+
+   The IETF has created a mailing list, scim@ietf.org, which can be used
+   for public discussion of SCIM schema proposals prior to registration.
+   Use of the mailing list is strongly encouraged.  The IESG has
+   appointed a designated expert [RFC5226] who will monitor the
+   scim@ietf.org mailing list and review registrations.
+
+   Registration of new "core" schemas (e.g., in the namespace
+   "urn:ietf:params:scim:schemas:core") and "API" schemas (e.g., in the
+   namespace "urn:ietf:params:scim:api") MUST be reviewed by the
+   designated expert and published in an RFC.  An RFC is REQUIRED for
+   the registration of new value data types that modify existing
+   properties.  An RFC is also REQUIRED for registration of SCIM schema
+   URIs that modify SCIM schema previously documented in an existing
+   RFC.  URNs within "urn:ietf:params:scim" but outside the above
+   namespaces MAY be registered with a simple review (e.g., check for
+   spam) by the designated expert on a first-come-first-served basis.
+
+   The registration procedure begins when a completed registration
+   template, defined in the sections below, is sent to scim@ietf.org and
+   iana@iana.org.  Within two weeks, the designated expert is expected
+   to tell IANA and the submitter of the registration whether the
+   registration is approved, approved with minor changes, or rejected
+   with cause.  When a registration is rejected with cause, it can be
+   resubmitted if the concerns listed in the cause are addressed.
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 97]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   Decisions made by the designated expert can be appealed to the IESG
+   Applications Area Director, then to the IESG.  They follow the normal
+   appeals procedure for IESG decisions.
+
+   Once the registration procedure concludes successfully, IANA creates
+   or modifies the corresponding record in the SCIM schema registry.
+   The completed registration template is discarded.
+
+   An RFC specifying one or more new schema URIs MUST include the
+   completed registration templates, which MAY be expanded with
+   additional information.  These completed templates are intended to go
+   in the body of the document, not in the IANA Considerations section.
+   The RFC SHOULD include any attributes defined.
+
+10.3.2.  Schema Registration Template
+
+   A SCIM schema URI is defined by completing the following template:
+
+   Schema URI:  A unique URI for the SCIM schema extension.
+
+   Schema Name:  A descriptive name of the schema extension (e.g.,
+      "Generic Device").
+
+   Intended or Associated Resource Type:  A value defining the resource
+      type (e.g., "Device").
+
+   Purpose:  A description of the purpose of the extension and/or its
+      intended use.
+
+   Single-value Attributes:  A list and description of single-valued
+      attributes defined, including complex attributes.
+
+   Multi-valued Attributes:  A list and description of multi-valued
+      attributes defined, including complex attributes.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 98]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+10.4.  Initial SCIM Schema Registry
+
+   The IANA has populated the "System for Cross-domain Identity
+   Management (SCIM) Schema URIs" registry with the following registries
+   for SCIM schema URIs, with pointers to appropriate reference
+   documents.  Note: The schema URIs listed below are broken into two
+   lines for readability.
+
+   +-----------------------------------+-----------------+-------------+
+   | Schema URI                        | Name            | Reference   |
+   +-----------------------------------+-----------------+-------------+
+   | urn:ietf:params:scim:schemas:     | User Resource   | See Section |
+   | core:2.0:User                     |                 | 4.1         |
+   |                                   |                 |             |
+   | urn:ietf:params:scim:schemas:     | Enterprise User | See Section |
+   | extension:enterprise:2.0:User     | Extension       | 4.3         |
+   |                                   |                 |             |
+   | urn:ietf:params:scim:schemas:     | Group Resource  | See Section |
+   | core:2.0:Group                    |                 | 4.2         |
+   +-----------------------------------+-----------------+-------------+
+
+                    SCIM Schema URIs for Data Resources
+
+   +-----------------------------------+-------------------+-----------+
+   | Schema URI                        | Name              | Reference |
+   +-----------------------------------+-------------------+-----------+
+   | urn:ietf:params:scim:schemas:     | Service Provider  | See       |
+   | core:2.0:ServiceProviderConfig    | Configuration     | Section 5 |
+   |                                   | Schema            |           |
+   |                                   |                   |           |
+   | urn:ietf:params:scim:schemas:     | Resource Type     | See       |
+   | core:2.0:ResourceType             | Configuration     | Section 6 |
+   |                                   |                   |           |
+   | urn:ietf:params:scim:schemas:     | Schema            | See       |
+   | core:2.0:Schema                   | Definitions       | Section 7 |
+   |                                   | Schema            |           |
+   +-----------------------------------+-------------------+-----------+
+
+                      SCIM Server-Related Schema URIs
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 99]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC2141]  Moats, R., "URN Syntax", RFC 2141, DOI 10.17487/RFC2141,
+              May 1997, <http://www.rfc-editor.org/info/rfc2141>.
+
+   [RFC3553]  Mealling, M., Masinter, L., Hardie, T., and G. Klyne,
+              "An IETF URN Sub-namespace for Registered Protocol
+              Parameters", BCP 73, RFC 3553, DOI 10.17487/RFC3553,
+              June 2003, <http://www.rfc-editor.org/info/rfc3553>.
+
+   [RFC3629]  Yergeau, F., "UTF-8, a transformation format of
+              ISO 10646", STD 63, RFC 3629, DOI 10.17487/RFC3629,
+              November 2003, <http://www.rfc-editor.org/info/rfc3629>.
+
+   [RFC3966]  Schulzrinne, H., "The tel URI for Telephone Numbers",
+              RFC 3966, DOI 10.17487/RFC3966, December 2004,
+              <http://www.rfc-editor.org/info/rfc3966>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <http://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC4647]  Phillips, A. and M. Davis, "Matching of Language Tags",
+              BCP 47, RFC 4647, DOI 10.17487/RFC4647, September 2006,
+              <http://www.rfc-editor.org/info/rfc4647>.
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <http://www.rfc-editor.org/info/rfc4648>.
+
+   [RFC5234]  Crocker, D., Ed., and P. Overell, "Augmented BNF for
+              Syntax Specifications: ABNF", STD 68, RFC 5234,
+              DOI 10.17487/ RFC5234, January 2008,
+              <http://www.rfc-editor.org/info/rfc5234>.
+
+   [RFC5280]  Cooper, D., Santesson, S., Farrell, S., Boeyen, S.,
+              Housley, R., and W. Polk, "Internet X.509 Public Key
+              Infrastructure Certificate and Certificate Revocation List
+              (CRL) Profile", RFC 5280, DOI 10.17487/RFC5280, May 2008,
+              <http://www.rfc-editor.org/info/rfc5280>.
+
+
+
+Hunt, et al.                 Standards Track                  [Page 100]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   [RFC5321]  Klensin, J., "Simple Mail Transfer Protocol", RFC 5321,
+              DOI 10.17487/RFC5321, October 2008,
+              <http://www.rfc-editor.org/info/rfc5321>.
+
+   [RFC5646]  Phillips, A., Ed., and M. Davis, Ed., "Tags for
+              Identifying Languages", BCP 47, RFC 5646,
+              DOI 10.17487/RFC5646, September 2009,
+              <http://www.rfc-editor.org/info/rfc5646>.
+
+   [RFC6557]  Lear, E. and P. Eggert, "Procedures for Maintaining the
+              Time Zone Database", BCP 175, RFC 6557,
+              DOI 10.17487/RFC6557, February 2012,
+              <http://www.rfc-editor.org/info/rfc6557>.
+
+   [RFC7159]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", RFC 7159, DOI 10.17487/RFC7159,
+              March 2014, <http://www.rfc-editor.org/info/rfc7159>.
+
+   [RFC7231]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+              Transfer Protocol (HTTP/1.1): Semantics and Content",
+              RFC 7231, DOI 10.17487/RFC7231, June 2014,
+              <http://www.rfc-editor.org/info/rfc7231>.
+
+   [RFC7232]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+              Transfer Protocol (HTTP/1.1): Conditional Requests",
+              RFC 7232, DOI 10.17487/RFC7232, June 2014,
+              <http://www.rfc-editor.org/info/rfc7232>.
+
+   [RFC7644]  Hunt, P., Ed., Grizzle, K., Ansari, M., Wahlstroem, E.,
+              and C. Mortimore, "System for Cross-domain Identity
+              Management: Protocol", RFC 7644, DOI 10.17487/RFC7644,
+              September 2015, <http://www.rfc-editor.org/info/rfc7644>.
+
+11.2.  Informative References
+
+   [ISO3166]  International Organization for Standardization, "Codes for
+              the representation of names of countries and their
+              subdivisions - Part 1: Country codes", ISO 3166-1:2013,
+              November 2013, <http://www.iso.org>.
+
+   [Olson-TZ] Internet Assigned Numbers Authority, "IANA Time Zone
+              Database", <https://www.iana.org/time-zones>.
+
+   [PortableContacts]
+              Smarr, J., "Portable Contacts 1.0 Draft C - Schema Only",
+              August 2008,
+              <http://www.portablecontacts.net/draft-spec.html>.
+
+
+
+
+Hunt, et al.                 Standards Track                  [Page 101]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+   [RFC2277]  Alvestrand, H., "IETF Policy on Character Sets and
+              Languages", BCP 18, RFC 2277, DOI 10.17487/RFC2277,
+              January 1998, <http://www.rfc-editor.org/info/rfc2277>.
+
+   [RFC4512]  Zeilenga, K., Ed., "Lightweight Directory Access Protocol
+              (LDAP): Directory Information Models", RFC 4512,
+              DOI 10.17487/RFC4512, June 2006,
+              <http://www.rfc-editor.org/info/rfc4512>.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              DOI 10.17487/RFC5226, May 2008,
+              <http://www.rfc-editor.org/info/rfc5226>.
+
+   [RFC6350]  Perreault, S., "vCard Format Specification", RFC 6350,
+              DOI 10.17487/RFC6350, August 2011,
+              <http://www.rfc-editor.org/info/rfc6350>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <http://www.rfc-editor.org/info/rfc6749>.
+
+   [RFC6819]  Lodderstedt, T., Ed., McGloin, M., and P. Hunt, "OAuth 2.0
+              Threat Model and Security Considerations", RFC 6819,
+              DOI 10.17487/RFC6819, January 2013,
+              <http://www.rfc-editor.org/info/rfc6819>.
+
+   [XML-Schema]
+              Peterson, D., Gao, S., Malhotra, A., Sperberg-McQueen, C.,
+              and H. Thompson, "XML Schema Definition Language (XSD) 1.1
+              Part 2: Datatypes", April 2012,
+              <http://www.w3.org/TR/xmlschema11-2/>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                  [Page 102]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+Acknowledgements
+
+   The editor would like to acknowledge the contribution and work of the
+   editors of draft versions of this document:
+
+      Chuck Mortimore, Salesforce
+
+      Patrick Harding, Ping
+
+      Paul Madsen, Ping
+
+      Trey Drake, UnboundID
+
+   The SCIM Community would like to thank the following people for the
+   work they've done in the research, formulation, drafting, editing,
+   and support of this specification.
+
+      Morteza Ansari (morteza.ansari@cisco.com)
+
+      Sidharth Choudhury (schoudhury@salesforce.com)
+
+      Samuel Erdtman (samuel@erdtman.se)
+
+      Kelly Grizzle (kelly.grizzle@sailpoint.com)
+
+      Chris Phillips (cjphillips@gmail.com)
+
+      Erik Wahlstroem (erik.wahlstrom@nexusgroup.com)
+
+      Phil Hunt (phil.hunt@yahoo.com)
+
+   Special thanks to Joseph Smarr, whose excellent work on the Portable
+   Contacts Specification [PortableContacts] provided a basis for the
+   SCIM schema structure and text.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                  [Page 103]
+
+RFC 7643                    SCIM Core Schema              September 2015
+
+
+Authors' Addresses
+
+   Phil Hunt (editor)
+   Oracle Corporation
+
+   Email: phil.hunt@yahoo.com
+
+
+   Kelly Grizzle
+   SailPoint
+
+   Email: kelly.grizzle@sailpoint.com
+
+
+   Erik Wahlstroem
+   Nexus Technology
+
+   Email: erik.wahlstrom@nexusgroup.com
+
+
+   Chuck Mortimore
+   Salesforce.com
+
+   Email: cmortimore@salesforce.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                  [Page 104]
+

--- a/docs/event-specs/rfc7644.txt
+++ b/docs/event-specs/rfc7644.txt
@@ -1,0 +1,4987 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                      P. Hunt, Ed.
+Request for Comments: 7644                                        Oracle
+Category: Standards Track                                     K. Grizzle
+ISSN: 2070-1721                                                SailPoint
+                                                               M. Ansari
+                                                                   Cisco
+                                                           E. Wahlstroem
+                                                        Nexus Technology
+                                                            C. Mortimore
+                                                              Salesforce
+                                                          September 2015
+
+
+         System for Cross-domain Identity Management: Protocol
+
+Abstract
+
+   The System for Cross-domain Identity Management (SCIM) specification
+   is an HTTP-based protocol that makes managing identities in multi-
+   domain scenarios easier to support via a standardized service.
+   Examples include, but are not limited to, enterprise-to-cloud service
+   providers and inter-cloud scenarios.  The specification suite seeks
+   to build upon experience with existing schemas and deployments,
+   placing specific emphasis on simplicity of development and
+   integration, while applying existing authentication, authorization,
+   and privacy models.  SCIM's intent is to reduce the cost and
+   complexity of user management operations by providing a common user
+   schema, an extension model, and a service protocol defined by this
+   document.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7644.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 1]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+Copyright Notice
+
+   Copyright (c) 2015 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1. Introduction and Overview .......................................3
+      1.1. Intended Audience ..........................................3
+      1.2. Notational Conventions .....................................4
+      1.3. Definitions ................................................4
+   2. Authentication and Authorization ................................5
+      2.1. Use of Tokens as Authorizations ............................7
+      2.2. Anonymous Requests .........................................7
+   3. SCIM Protocol ...................................................8
+      3.1. Background .................................................8
+      3.2. SCIM Endpoints and HTTP Methods ............................9
+      3.3. Creating Resources ........................................11
+           3.3.1. Resource Types .....................................13
+      3.4. Retrieving Resources ......................................13
+           3.4.1. Retrieving a Known Resource ........................14
+           3.4.2. Query Resources ....................................15
+           3.4.3. Querying Resources Using HTTP POST .................27
+      3.5. Modifying Resources .......................................29
+           3.5.1. Replacing with PUT .................................30
+           3.5.2. Modifying with PATCH ...............................32
+      3.6. Deleting Resources ........................................48
+      3.7. Bulk Operations ...........................................49
+           3.7.1. Circular Reference Processing ......................51
+           3.7.2. "bulkId" Temporary Identifiers .....................53
+           3.7.3. Response and Error Handling ........................58
+           3.7.4. Maximum Operations .................................63
+      3.8. Data Input/Output Formats .................................64
+      3.9. Additional Operation Response Parameters ..................64
+      3.10. Attribute Notation .......................................66
+      3.11. "/Me" Authenticated Subject Alias ........................66
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 2]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+      3.12. HTTP Status and Error Response Handling ..................67
+      3.13. SCIM Protocol Versioning .................................71
+      3.14. Versioning Resources .....................................71
+   4. Service Provider Configuration Endpoints .......................73
+   5. Preparation and Comparison of Internationalized Strings ........76
+   6. Multi-Tenancy ..................................................76
+      6.1. Associating Clients to Tenants ............................77
+      6.2. SCIM Identifiers with Multiple Tenants ....................78
+   7. Security Considerations ........................................78
+      7.1. HTTP Considerations .......................................78
+      7.2. TLS Support Considerations ................................78
+      7.3. Authorization Token Considerations ........................78
+      7.4. Bearer Token and Cookie Considerations ....................79
+      7.5. Privacy Considerations ....................................79
+           7.5.1. Personal Information ...............................79
+           7.5.2. Disclosure of Sensitive Information in URIs ........80
+      7.6. Anonymous Requests ........................................80
+      7.7. Secure Storage and Handling of Sensitive Data .............81
+      7.8. Case-Insensitive Comparison and International Languages ...82
+   8. IANA Considerations ............................................82
+      8.1. Media Type Registration ...................................82
+      8.2. Registering URIs for SCIM Messages ........................84
+   9. References .....................................................85
+      9.1. Normative References ......................................85
+      9.2. Informative References ....................................87
+   Acknowledgements ..................................................88
+   Contributors ......................................................88
+   Authors' Addresses ................................................89
+
+1.  Introduction and Overview
+
+   The SCIM protocol is an application-level HTTP-based protocol for
+   provisioning and managing identity data on the web and in
+   cross-domain environments such as enterprise-to-cloud service
+   providers or inter-cloud scenarios.  The protocol supports creation,
+   modification, retrieval, and discovery of core identity resources
+   such as Users and Groups, as well as custom resources and resource
+   extensions.
+
+   The definition of resources, attributes, and overall schema are
+   defined in the SCIM Core Schema document [RFC7643].
+
+1.1.  Intended Audience
+
+   This document is intended to serve as a guide to SCIM protocol usage
+   for both SCIM HTTP service providers and HTTP clients who may
+   provision information to service providers or retrieve information
+   from them.
+
+
+
+Hunt, et al.                 Standards Track                    [Page 3]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+1.2.  Notational Conventions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].  These key
+   words are capitalized when used to unambiguously specify requirements
+   of the protocol or application features and behavior that affect the
+   interoperability and security of implementations.  When these words
+   are not capitalized, they are meant in their natural-language sense.
+
+   For purposes of readability, examples are not URL encoded.
+   Implementers MUST percent-encode URLs as described in Section 2.1 of
+   [RFC3986].
+
+   Throughout this document, figures may contain spaces and extra line
+   wrapping to improve readability and accommodate space limitations.
+   Similarly, some URIs contained within examples have been shortened
+   for space and readability reasons (as indicated by "...").
+
+1.3.  Definitions
+
+   This specification uses the definitions from [RFC7643] and defines
+   the following additional term:
+
+   Base URI
+      The SCIM HTTP protocol is described in terms of a path relative to
+      a Base URI.  The Base URI MUST NOT contain a query string, as
+      clients MAY append additional path information and query
+      parameters as part of forming the request.  The base URI is a URL
+      that most often consists of the "https" protocol scheme, a domain
+      name, and some initial path [RFC3986].  For example:
+
+      "https://example.com/scim/"
+
+   For readability, all examples in this document assume that the SCIM
+   service root and the server root are the same (no path prefix).  It
+   is expected that SCIM servers may be deployed using any URI path
+   prefix.  For example, a SCIM server might have a prefix of
+   "https://example.com/" or "https://example.com/scim/tenancypath/".
+   Additionally, a client MAY apply a version number to the server root
+   prefix (see Section 3.13).
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 4]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+2.  Authentication and Authorization
+
+   The SCIM protocol is based upon HTTP and does not itself define a
+   SCIM-specific scheme for authentication and authorization.  SCIM
+   depends on the use of Transport Layer Security (TLS) and/or standard
+   HTTP authentication and authorization schemes as per [RFC7235].  For
+   example, the following methodologies could be used, among others:
+
+   TLS Client Authentication
+      The SCIM service provider MAY request TLS client authentication
+      (also known as mutual authentication).  See Section 7.3 of
+      [RFC5246].
+
+   HOBA Authentication
+      HTTP Origin-Bound Authentication (HOBA) is a variation on TLS
+      client authentication and uses a digital-signature-based design
+      for an HTTP authentication method (see [RFC7486]).  The design can
+      also be used in JavaScript-based authentication embedded in HTML.
+      HOBA is an alternative to HTTP authentication schemes that require
+      passwords and therefore avoids all problems related to passwords,
+      such as leakage of server-side password databases.
+
+   Bearer Tokens
+      Bearer tokens [RFC6750] MAY be used when combined with TLS and a
+      token framework such as OAuth 2.0 [RFC6749].  Tokens that are
+      issued based on weak or no authentication of authorizing users
+      and/or OAuth clients SHOULD NOT be used, unless, for example, they
+      are being used as single-use tokens to permit one-time requests
+      such as anonymous registration (see Section 3.3).  For security
+      considerations regarding the use of bearer tokens in SCIM, see
+      Section 7.4.  While bearer tokens most often represent an
+      authorization, it is assumed that the authorization was based upon
+      a successful authentication of the SCIM client.  Accordingly, the
+      SCIM service provider must have a method for validating, parsing,
+      and/or "introspecting" the bearer token for the relevant
+      authentication and authorization information.  The method for this
+      is assumed to be defined by the token-issuing system and is beyond
+      the scope of this specification.
+
+   PoP Tokens
+      A proof-of-possession (PoP) token demonstrates that the presenter
+      of the token possesses a particular key and that the recipient can
+      cryptographically confirm proof of possession of the key by the
+      presenter.  This property is sometimes also described as the
+      presenter being a holder of the key.  See [OAuth-PoP-Arch] for an
+      example of such a token and its use.
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 5]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Cookies
+      JavaScript clients MAY assert HTTP cookies over TLS that contain
+      an authentication state that is understood by the SCIM service
+      provider (see [RFC6265]).  An example of this is scenarios where
+      web-form authentication has taken place with the user and HTTP
+      cookies were set representing the authentication state.  For the
+      purposes of SCIM, the security considerations in Section 7.4
+      apply.
+
+   Basic Authentication
+      Usage of basic authentication should be avoided, due to its use of
+      a single factor that is based upon a relatively static, symmetric
+      secret.  Implementers SHOULD combine the use of basic
+      authentication with other factors.  The security considerations of
+      HTTP Basic are well documented in [HTTP-BASIC-AUTH]; therefore,
+      implementers are encouraged to use stronger authentication
+      methods.  Designating the specific methods of authentication and
+      authorization is out of scope for SCIM; however, this information
+      is provided as a resource to implementers.
+
+   As per Section 4.1 of [RFC7235], a SCIM service provider SHALL
+   indicate supported HTTP authentication schemes via the
+   "WWW-Authenticate" header.
+
+   Regardless of methodology, the SCIM service provider MUST be able to
+   map the authenticated client to an access control policy in order to
+   determine the client's authorization to retrieve and update SCIM
+   resources.  For example, while a browser session may have been
+   established via HTTP cookie or TLS client authentication, the unique
+   client MUST be mapped to a security subject (e.g., User).  The
+   authorization model and the process by which this is done are beyond
+   the scope of this specification.
+
+   When processing requests, the service provider SHOULD consider the
+   subject performing the request and whether or not the action is
+   appropriate given the subject and the resource affected by the
+   request.  The subject performing the request is usually determined
+   directly or indirectly from the "Authorization" header present in the
+   request.  For example, a subject MAY be permitted to retrieve and
+   update their own "User" resource but will normally have restricted
+   ability to access resources associated with other Users.  In other
+   cases, the SCIM service provider might only grant access to a
+   subject's own associated "User" resource (e.g., for the purpose of
+   updating personal contact attributes).
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 6]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   For illustrative purposes only, SCIM protocol examples show an
+   OAuth 2.0 bearer token value [RFC6750] in the authorization
+   header, e.g.,
+
+   GET /Users/2819c223-7f76-453a-919d-413861904646 HTTP/1.1
+   Host: example.com
+   Authorization: Bearer h480djs93hd8
+
+   This is not intended to imply that bearer tokens are preferred.
+   However, the use of bearer tokens in the specification does reflect
+   common implementation practice.
+
+2.1.  Use of Tokens as Authorizations
+
+   When using bearer tokens or PoP tokens that represent an
+   authorization grant, such as a grant issued by OAuth (see [RFC6749]),
+   implementers SHOULD consider the type of authorization granted, any
+   authorized scopes (see Section 3.3 of [RFC6749]), and the security
+   subject(s) that SHOULD be mapped from the authorization when
+   considering local access control rules.  Section 6 of [RFC7521]
+   documents common scenarios for authorization, including:
+
+   o  A client using an assertion to authenticate and/or act on behalf
+      of itself,
+
+   o  A client acting on behalf of a user, and
+
+   o  A client acting on behalf of an anonymous user (for example, see
+      Section 2.2).
+
+   When using OAuth authorization tokens, implementers MUST take into
+   account the threats and countermeasures related to the use of client
+   authorizations, as documented in Section 8 of [RFC7521].  When using
+   other token formats or frameworks, implementers MUST take into
+   account similar threats and countermeasures, especially those
+   documented by the relevant specifications.
+
+2.2.  Anonymous Requests
+
+   In some SCIM deployments, it MAY be acceptable to permit
+   unauthenticated (anonymous) requests -- for example, a user
+   self-registration request where the service provider chooses to
+   accept a SCIM Create request (see Section 3.3) from an anonymous
+   client.  See Section 7.6 for security considerations regarding
+   anonymous requests.
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 7]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.  SCIM Protocol
+
+3.1.  Background
+
+   SCIM is a protocol that is based on HTTP [RFC7230].  Along with HTTP
+   headers and URIs, SCIM uses JSON [RFC7159] payloads to convey SCIM
+   resources, as well as protocol-specific payload messages that convey
+   request parameters and response information such as errors.  Both
+   resources and messages are passed in the form of JSON-based
+   structures in the message body of an HTTP request or response.  To
+   identify this content, SCIM uses a media type of
+   "application/scim+json" (see Section 8.1).
+
+   A SCIM "resource" is a JSON object [RFC7159] that may be created,
+   maintained, and retrieved via HTTP request methods as described in
+   this document.  Each JSON resource representation contains a
+   "schemas" attribute that contains a list of one or more URIs that
+   indicate included SCIM schemas that are used to indicate the
+   attributes contained within a resource.  Specific information about
+   what attributes are defined within a schema MAY be obtained by
+   querying a SCIM service provider's "/Schemas" endpoint for a schema
+   definition (see Section 8.7 of [RFC7643]).  Responses from this
+   endpoint describe the schema supported by a service provider,
+   including attribute characteristics such as cardinality,
+   case-exactness, mutability, uniqueness, returnability, and whether or
+   not attributes are required.  While SCIM schemas and an associated
+   extension model are defined in [RFC7643], SCIM clients should expect
+   that some attribute schema may change from service provider to
+   service provider, particularly across administrative domains.  In
+   cases where SCIM may be used as an open protocol in front of an
+   application service, it is quite reasonable to expect that some
+   service providers may only support a subset of the schema defined in
+   [RFC7643].
+
+   A SCIM message conveys protocol parameters related to a SCIM request
+   or response; this specification defines these parameters.  As with a
+   SCIM resource, a SCIM message is a JSON object [RFC7159] that
+   contains a "schemas" attribute with a URI whose namespace prefix MUST
+   begin with "urn:ietf:params:scim:api:".  As SCIM protocol messages
+   are fixed and defined by SCIM specifications and registered
+   extensions, SCIM message schemas using the above prefix URN SHALL NOT
+   be discoverable using the "/Schemas" endpoint.
+
+   As SCIM is intended for use in cross-domain scenarios where schema
+   and implementations may vary, techniques such as document validation
+   (e.g., [XML-Schema]) are not recommended.  A SCIM service provider
+   interprets a request in the context of its own schema (which may be
+   different from the client's schema) and following the defined
+
+
+
+Hunt, et al.                 Standards Track                    [Page 8]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   processing rules for each request.  The sections that follow define
+   the processing rules for SCIM and provide allowances for schema
+   differences where appropriate.  For example, in a SCIM PUT request,
+   "readOnly" attributes are ignored, while "readWrite" attributes are
+   updated.  There is no need for a SCIM client to discover which
+   attributes are "readOnly", and the client does not need to remove
+   them from a PUT request in order to be accepted.  Similarly, a SCIM
+   client SHOULD NOT expect a service provider to return SCIM resources
+   with exactly the same schema and values as submitted.  SCIM responses
+   SHALL reflect resource state as interpreted by the SCIM service
+   provider.
+
+3.2.  SCIM Endpoints and HTTP Methods
+
+   The SCIM protocol specifies well-known endpoints and HTTP methods for
+   managing resources defined in the SCIM Core Schema document
+   ([RFC7643]); i.e., "User" and "Group" resources correspond to
+   "/Users" and "/Groups", respectively.  Service providers that support
+   extended resources SHOULD define resource endpoints using the
+   convention of pluralizing the resource name defined in the extended
+   schema, by appending an 's'.  Given that there are cases where
+   resource pluralization is ambiguous, e.g., a resource named "Person"
+   is legitimately "Persons" and "People", clients SHOULD discover
+   resource endpoints via the "/ResourceTypes" endpoint.
+
+   HTTP   SCIM Usage
+   Method
+   ------ --------------------------------------------------------------
+   GET    Retrieves one or more complete or partial resources.
+
+   POST   Depending on the endpoint, creates new resources, creates a
+          search request, or MAY be used to bulk-modify resources.
+
+   PUT    Modifies a resource by replacing existing attributes with a
+          specified set of replacement attributes (replace).  PUT
+          MUST NOT be used to create new resources.
+
+   PATCH  Modifies a resource with a set of client-specified changes
+          (partial update).
+
+   DELETE Deletes a resource.
+
+                        Table 1: SCIM HTTP Methods
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                    [Page 9]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Resource Endpoint         Operations             Description
+   -------- ---------------- ---------------------- --------------------
+   User     /Users           GET (Section 3.4.1),   Retrieve, add,
+                             POST (Section 3.3),    modify Users.
+                             PUT (Section 3.5.1),
+                             PATCH (Section 3.5.2),
+                             DELETE (Section 3.6)
+
+   Group    /Groups          GET (Section 3.4.1),   Retrieve, add,
+                             POST (Section 3.3),    modify Groups.
+                             PUT (Section 3.5.1),
+                             PATCH (Section 3.5.2),
+                             DELETE (Section 3.6)
+
+   Self     /Me              GET, POST, PUT, PATCH, Alias for operations
+                             DELETE (Section 3.11)  against a resource
+                                                    mapped to an
+                                                    authenticated
+                                                    subject (e.g.,
+                                                    User).
+
+   Service  /ServiceProvider GET (Section 4)        Retrieve service
+   provider Config                                  provider's
+   config.                                          configuration.
+
+   Resource /ResourceTypes   GET (Section 4)        Retrieve supported
+   type                                             resource types.
+
+   Schema   /Schemas         GET (Section 4)        Retrieve one or more
+                                                    supported schemas.
+
+   Bulk     /Bulk            POST (Section 3.7)     Bulk updates to one
+                                                    or more resources.
+
+   Search   [prefix]/.search POST (Section 3.4.3)   Search from system
+                                                    root or within a
+                                                    resource endpoint
+                                                    for one or more
+                                                    resource types using
+                                                    POST.
+
+                        Table 2: Defined Endpoints
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 10]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   All requests to the service provider are made via HTTP methods as per
+   Section 4.3 of [RFC7231] on a URL derived from the Base URL.
+   Responses are returned in the body of the HTTP response, formatted as
+   JSON.  Error status codes SHOULD be transmitted via the HTTP status
+   code of the response (if possible) and SHOULD also be specified in
+   the body of the response (see Section 3.12).
+
+3.3.  Creating Resources
+
+   To create new resources, clients send HTTP POST requests to the
+   resource endpoint, such as "/Users" or "/Groups", as defined by the
+   associated resource type endpoint discovery (see Section 4).
+
+   The server SHALL process attributes according to the following
+   mutability rules:
+
+   o  In the request body, attributes whose mutability is "readOnly"
+      (see Sections 2.2 and 7 of [RFC7643]) SHALL be ignored.
+
+   o  Attributes whose mutability is "readWrite" (see Section 2.2 of
+      [RFC7643]) and that are omitted from the request body MAY be
+      assumed to be not asserted by the client.  The service provider
+      MAY assign a default value to non-asserted attributes in the final
+      resource representation.
+
+   o  Service providers MAY take into account whether or not a client
+      has access to all of the resource's attributes when deciding
+      whether or not non-asserted attributes should be defaulted.
+
+   o  Clients that intend to override existing or server-defaulted
+      values for attributes MAY specify "null" for a single-valued
+      attribute or an empty array "[]" for a multi-valued attribute to
+      clear all values.
+
+   When the service provider successfully creates the new resource, an
+   HTTP response SHALL be returned with HTTP status code 201 (Created).
+   The response body SHOULD contain the service provider's
+   representation of the newly created resource.  The URI of the created
+   resource SHALL include, in the HTTP "Location" header and the HTTP
+   body, a JSON representation [RFC7159] with the attribute
+   "meta.location".  Since the server is free to alter and/or ignore
+   POSTed content, returning the full representation can be useful to
+   the client, enabling it to correlate the client's and server's views
+   of the new resource.
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 11]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   If the service provider determines that the creation of the requested
+   resource conflicts with existing resources (e.g., a "User" resource
+   with a duplicate "userName"), the service provider MUST return HTTP
+   status code 409 (Conflict) with a "scimType" error code of
+   "uniqueness", as per Section 3.12.
+
+   In the following example, a client sends a POST request containing a
+   "User" to the "/Users" endpoint.
+
+   POST /Users  HTTP/1.1
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: ...
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "userName":"bjensen",
+     "externalId":"bjensen",
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara"
+     }
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 12]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   In response to the example request above, the server signals a
+   successful creation with an HTTP status code 201 (Created) and
+   returns a representation of the resource created:
+
+   HTTP/1.1 201 Created
+   Content-Type: application/scim+json
+   Location:
+    https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
+   ETag: W/"e180ee84f0671b1"
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "externalId":"bjensen",
+     "meta":{
+       "resourceType":"User",
+       "created":"2011-08-01T21:32:44.882Z",
+       "lastModified":"2011-08-01T21:32:44.882Z",
+       "location":
+   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
+       "version":"W\/\"e180ee84f0671b1\""
+     },
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara"
+     },
+     "userName":"bjensen"
+   }
+
+3.3.1.  Resource Types
+
+   When adding a resource to a specific endpoint, the meta attribute
+   "resourceType" SHALL be set by the HTTP service provider to the
+   corresponding resource type for the endpoint.  For example, a POST to
+   the endpoint "/Users" will set "resourceType" to "User", and
+   "/Groups" will set "resourceType" to "Group".
+
+3.4.  Retrieving Resources
+
+   Resources MAY be retrieved via opaque, unique URLs or via queries
+   (see Section 3.4.2).  The attributes returned are defined in the
+   server's attribute schema (see Section 8.7 of [RFC7643]) and may be
+   modified by request parameters (see Section 3.9).  By default,
+   resource attributes returned in a response are those attributes whose
+   characteristic "returned" setting is "always" or "default" (see
+   Section 2.2 of [RFC7643]).
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 13]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.4.1.  Retrieving a Known Resource
+
+   To retrieve a known resource, clients send GET requests to the
+   resource endpoint, e.g., "/Users/{id}", "/Groups/{id}", or
+   "/Schemas/{id}", where "{id}" is a resource identifier (for example,
+   the value of the "id" attribute).
+
+   If the resource exists, the server responds with HTTP status code 200
+   (OK) and includes the result in the body of the response.
+
+   The example below retrieves a single User via the "/Users" endpoint.
+
+   GET /Users/2819c223-7f76-453a-919d-413861904646
+   Host: example.com
+   Accept: application/scim+json
+   Authorization: Bearer h480djs93hd8
+
+   The server responds with:
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+   Location:
+     https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
+   ETag: W/"f250dd84f0671c3"
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "externalId":"bjensen",
+     "meta":{
+       "resourceType":"User",
+       "created":"2011-08-01T18:29:49.793Z",
+       "lastModified":"2011-08-01T18:29:49.793Z",
+       "location":
+   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
+       "version":"W\/\"f250dd84f0671c3\""
+     },
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara"
+     },
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 14]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+     "userName":"bjensen",
+     "phoneNumbers":[
+       {
+         "value":"555-555-8377",
+         "type":"work"
+       }
+     ],
+     "emails":[
+       {
+         "value":"bjensen@example.com",
+         "type":"work"
+       }
+     ]
+   }
+
+3.4.2.  Query Resources
+
+   The SCIM protocol defines a standard set of query parameters that can
+   be used to filter, sort, and paginate to return zero or more
+   resources in a query response.  Queries MAY be made against a single
+   resource or a resource type endpoint (e.g., "/Users"), or the service
+   provider Base URI.  SCIM service providers MAY support additional
+   query parameters not specified here and SHOULD ignore any query
+   parameters they do not recognize instead of rejecting the query for
+   versioning compatibility reasons.
+
+   Responses MUST be identified using the following URI:
+   "urn:ietf:params:scim:api:messages:2.0:ListResponse".  The following
+   attributes are defined for responses:
+
+   totalResults  The total number of results returned by the list or
+      query operation.  The value may be larger than the number of
+      resources returned, such as when returning a single page (see
+      Section 3.4.2.4) of results where multiple pages are available.
+      REQUIRED.
+
+   Resources  A multi-valued list of complex objects containing the
+      requested resources.  This MAY be a subset of the full set of
+      resources if pagination (Section 3.4.2.4) is requested.  REQUIRED
+      if "totalResults" is non-zero.
+
+   startIndex  The 1-based index of the first result in the current set
+      of list results.  REQUIRED when partial results are returned due
+      to pagination.
+
+   itemsPerPage  The number of resources returned in a list response
+      page.  REQUIRED when partial results are returned due to
+      pagination.
+
+
+
+Hunt, et al.                 Standards Track                   [Page 15]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   A query that does not return any matches SHALL return success (HTTP
+   status code 200) with "totalResults" set to a value of 0.
+
+   The example query below requests the userName for all Users:
+
+   GET /Users?attributes=userName
+   Host: example.com
+   Accept: application/scim+json
+   Authorization: Bearer h480djs93hd8
+
+   The following is an example response to the query above:
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+
+   {
+     "schemas":["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+     "totalResults":2,
+     "Resources":[
+       {
+         "id":"2819c223-7f76-453a-919d-413861904646",
+         "userName":"bjensen"
+       },
+       {
+         "id":"c75ad752-64ae-4823-840d-ffa80929976c",
+         "userName":"jsmith"
+       }
+     ]
+   }
+
+   Note that in the above example, "id" is returned because the "id"
+   attribute has the "returned" characteristic of "always".
+
+3.4.2.1.  Query Endpoints
+
+   Queries MAY be performed against a SCIM resource object, a resource
+   type endpoint, or a SCIM server root.  For example:
+
+      "/Users/{id}"
+
+      "/Users"
+
+      "/Groups"
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 16]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   A query against a server root indicates that all resources within the
+   server SHALL be included, subject to filtering.  A filter expression
+   using "meta.resourceType" MAY be used to restrict results to one or
+   more specific resource types (to exclude others).  For example:
+
+   filter=(meta.resourceType eq User) or (meta.resourceType eq Group)
+
+   If a SCIM service provider determines that too many results would be
+   returned (e.g., because a client queried a resource type endpoint or
+   the server base URI), the server SHALL reject the request by
+   returning an HTTP response with HTTP status code 400 (Bad Request)
+   and JSON attribute "scimType" set to "tooMany" (see Table 9).
+
+   When processing query operations using endpoints that include more
+   than one SCIM resource type (e.g., a query from the server root
+   endpoint), filters MUST be processed as outlined in Section 3.4.2.2.
+   For filtered attributes that are not part of a particular resource
+   type, the service provider SHALL treat the attribute as if there is
+   no attribute value.  For example, a presence or equality filter for
+   an undefined attribute evaluates to false.
+
+3.4.2.2.  Filtering
+
+   Filtering is an OPTIONAL parameter for SCIM service providers.
+   Clients MAY discover service provider filter capabilities by looking
+   at the "filter" attribute of the "ServiceProviderConfig" endpoint
+   (see Section 4).  Clients MAY request a subset of resources by
+   specifying the "filter" query parameter containing a filter
+   expression.  When specified, only those resources matching the filter
+   expression SHALL be returned.  The expression language that is used
+   with the filter parameter supports references to attributes and
+   literals.
+
+   Attribute names and attribute operators used in filters are case
+   insensitive.  For example, the following two expressions will
+   evaluate to the same logical value:
+
+   filter=userName Eq "john"
+
+   filter=Username eq "john"
+
+   The filter parameter MUST contain at least one valid expression (see
+   Table 3).  Each expression MUST contain an attribute name followed by
+   an attribute operator and optional value.  Multiple expressions MAY
+   be combined using logical operators (see Table 4).  Expressions MAY
+   be grouped together using round brackets "(" and ")" (see Table 5).
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 17]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The operators supported in the expression are listed in Table 3.
+
+   +----------+-------------+------------------------------------------+
+   | Operator | Description | Behavior                                 |
+   +----------+-------------+------------------------------------------+
+   | eq       | equal       | The attribute and operator values must   |
+   |          |             | be identical for a match.                |
+   |          |             |                                          |
+   | ne       | not equal   | The attribute and operator values are    |
+   |          |             | not identical.                           |
+   |          |             |                                          |
+   | co       | contains    | The entire operator value must be a      |
+   |          |             | substring of the attribute value for a   |
+   |          |             | match.                                   |
+   |          |             |                                          |
+   | sw       | starts with | The entire operator value must be a      |
+   |          |             | substring of the attribute value,        |
+   |          |             | starting at the beginning of the         |
+   |          |             | attribute value.  This criterion is      |
+   |          |             | satisfied if the two strings are         |
+   |          |             | identical.                               |
+   |          |             |                                          |
+   | ew       | ends with   | The entire operator value must be a      |
+   |          |             | substring of the attribute value,        |
+   |          |             | matching at the end of the attribute     |
+   |          |             | value.  This criterion is satisfied if   |
+   |          |             | the two strings are identical.           |
+   |          |             |                                          |
+   | pr       | present     | If the attribute has a non-empty or      |
+   |          | (has value) | non-null value, or if it contains a      |
+   |          |             | non-empty node for complex attributes,   |
+   |          |             | there is a match.                        |
+   |          |             |                                          |
+   | gt       | greater     | If the attribute value is greater than   |
+   |          | than        | the operator value, there is a match.    |
+   |          |             | The actual comparison is dependent on    |
+   |          |             | the attribute type.  For string          |
+   |          |             | attribute types, this is a               |
+   |          |             | lexicographical comparison, and for      |
+   |          |             | DateTime types, it is a chronological    |
+   |          |             | comparison.  For integer attributes, it  |
+   |          |             | is a comparison by numeric value.        |
+   |          |             | Boolean and Binary attributes SHALL      |
+   |          |             | cause a failed response (HTTP status     |
+   |          |             | code 400) with "scimType" of             |
+   |          |             | "invalidFilter".                         |
+   |          |             |                                          |
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 18]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   | ge       | greater     | If the attribute value is greater than   |
+   |          | than or     | or equal to the operator value, there is |
+   |          | equal to    | a match.  The actual comparison is       |
+   |          |             | dependent on the attribute type.  For    |
+   |          |             | string attribute types, this is a        |
+   |          |             | lexicographical comparison, and for      |
+   |          |             | DateTime types, it is a chronological    |
+   |          |             | comparison.  For integer attributes, it  |
+   |          |             | is a comparison by numeric value.        |
+   |          |             | Boolean and Binary attributes SHALL      |
+   |          |             | cause a failed response (HTTP status     |
+   |          |             | code 400) with "scimType" of             |
+   |          |             | "invalidFilter".                         |
+   |          |             |                                          |
+   | lt       | less than   | If the attribute value is less than the  |
+   |          |             | operator value, there is a match.  The   |
+   |          |             | actual comparison is dependent on the    |
+   |          |             | attribute type.  For string attribute    |
+   |          |             | types, this is a lexicographical         |
+   |          |             | comparison, and for DateTime types, it   |
+   |          |             | is a chronological comparison.  For      |
+   |          |             | integer attributes, it is a comparison   |
+   |          |             | by numeric value.  Boolean and Binary    |
+   |          |             | attributes SHALL cause a failed response |
+   |          |             | (HTTP status code 400) with "scimType"   |
+   |          |             | of "invalidFilter".                      |
+   |          |             |                                          |
+   | le       | less than   | If the attribute value is less than or   |
+   |          | or equal to | equal to the operator value, there is a  |
+   |          |             | match.  The actual comparison is         |
+   |          |             | dependent on the attribute type.  For    |
+   |          |             | string attribute types, this is a        |
+   |          |             | lexicographical comparison, and for      |
+   |          |             | DateTime types, it is a chronological    |
+   |          |             | comparison.  For integer attributes, it  |
+   |          |             | is a comparison by numeric value.        |
+   |          |             | Boolean and Binary attributes SHALL      |
+   |          |             | cause a failed response (HTTP status     |
+   |          |             | code 400) with "scimType" of             |
+   |          |             | "invalidFilter".                         |
+   +----------+-------------+------------------------------------------+
+
+                       Table 3: Attribute Operators
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 19]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   +----------+-------------+------------------------------------------+
+   | Operator | Description | Behavior                                 |
+   +----------+-------------+------------------------------------------+
+   | and      | Logical     | The filter is only a match if both       |
+   |          | "and"       | expressions evaluate to true.            |
+   |          |             |                                          |
+   | or       | Logical     | The filter is a match if either          |
+   |          | "or"        | expression evaluates to true.            |
+   |          |             |                                          |
+   | not      | "Not"       | The filter is a match if the expression  |
+   |          | function    | evaluates to false.                      |
+   +----------+-------------+------------------------------------------+
+
+                        Table 4: Logical Operators
+
+
+   +----------+-------------+------------------------------------------+
+   | Operator | Description | Behavior                                 |
+   +----------+-------------+------------------------------------------+
+   | ( )      | Precedence  | Boolean expressions MAY be grouped using |
+   |          | grouping    | parentheses to change the standard order |
+   |          |             | of operations, i.e., to evaluate logical |
+   |          |             | "or" operators before logical "and"      |
+   |          |             | operators.                               |
+   |          |             |                                          |
+   | [ ]      | Complex     | Service providers MAY support complex    |
+   |          | attribute   | filters where expressions MUST be        |
+   |          | filter      | applied to the same value of a parent    |
+   |          | grouping    | attribute specified immediately before   |
+   |          |             | the left square bracket ("[").  The      |
+   |          |             | expression within square brackets ("["   |
+   |          |             | and "]") MUST be a valid filter          |
+   |          |             | expression based upon sub-attributes of  |
+   |          |             | the parent attribute.  Nested            |
+   |          |             | expressions MAY be used.  See examples   |
+   |          |             | below.                                   |
+   +----------+-------------+------------------------------------------+
+
+                        Table 5: Grouping Operators
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 20]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   SCIM filters MUST conform to the following ABNF [RFC5234] rules as
+   specified below:
+
+     FILTER    = attrExp / logExp / valuePath / *1"not" "(" FILTER ")"
+
+     valuePath = attrPath "[" valFilter "]"
+                 ; FILTER uses sub-attributes of a parent attrPath
+
+     valFilter = attrExp / logExp / *1"not" "(" valFilter ")"
+
+     attrExp   = (attrPath SP "pr") /
+                 (attrPath SP compareOp SP compValue)
+
+     logExp    = FILTER SP ("and" / "or") SP FILTER
+
+     compValue = false / null / true / number / string
+                 ; rules from JSON (RFC 7159)
+
+     compareOp = "eq" / "ne" / "co" /
+                        "sw" / "ew" /
+                        "gt" / "lt" /
+                        "ge" / "le"
+
+     attrPath  = [URI ":"] ATTRNAME *1subAttr
+                 ; SCIM attribute name
+                 ; URI is SCIM "schema" URI
+
+     ATTRNAME  = ALPHA *(nameChar)
+
+     nameChar  = "-" / "_" / DIGIT / ALPHA
+
+     subAttr   = "." ATTRNAME
+                 ; a sub-attribute of a complex attribute
+
+               Figure 1: ABNF Specification of SCIM Filters
+
+   In the above ABNF rules, the "compValue" (comparison value) rule is
+   built on JSON Data Interchange format ABNF rules as specified in
+   [RFC7159], "DIGIT" and "ALPHA" are defined per Appendix B.1 of
+   [RFC5234], and "URI" is defined per Appendix A of [RFC3986].
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 21]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Filters MUST be evaluated using the following order of operations, in
+   order of precedence:
+
+   1.  Grouping operators
+
+   2.  Logical operators - where "not" takes precedence over "and",
+       which takes precedence over "or"
+
+   3.  Attribute operators
+
+   If the specified attribute in a filter expression is a multi-valued
+   attribute, the filter matches if any of the values of the specified
+   attribute match the specified criterion; e.g., if a User has multiple
+   "emails" values, only one has to match for the entire User to match.
+   For complex attributes, a fully qualified sub-attribute MUST be
+   specified using standard attribute notation (Section 3.10).  For
+   example, to filter by userName, the parameter value is "userName".
+   To filter by first name, the parameter value is "name.givenName".
+
+   When applying a comparison (e.g., "eq") or presence filter (e.g.,
+   "pr") to a defaulted attribute, the service provider SHALL use the
+   value that was returned to the client that last created or modified
+   the attribute.
+
+   Providers MAY support additional filter operations if they choose.
+   Providers MUST decline to filter results if the specified filter
+   operation is not recognized and return an HTTP 400 error with a
+   "scimType" error of "invalidFilter" and an appropriate human-readable
+   response as per Section 3.12.  For example, if a client specified an
+   unsupported operator named 'regex', the service provider should
+   specify an error response description identifying the client error,
+   e.g., 'The operator 'regex' is not supported.'
+
+   When comparing attributes of type String, the case sensitivity for
+   String type attributes SHALL be determined by the attribute's
+   "caseExact" characteristic (see Section 2.2 of [RFC7643]).
+
+   Clients MAY query by schema or schema extensions by using a filter
+   expression including the "schemas" attribute (as shown in Figure 2).
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 22]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following are examples of valid filters.  Some attributes (e.g.,
+   rooms and rooms.number) are hypothetical extensions and are not part
+   of the SCIM core schema:
+
+filter=userName eq "bjensen"
+
+filter=name.familyName co "O'Malley"
+
+filter=userName sw "J"
+
+filter=urn:ietf:params:scim:schemas:core:2.0:User:userName sw "J"
+
+filter=title pr
+
+filter=meta.lastModified gt "2011-05-13T04:42:34Z"
+
+filter=meta.lastModified ge "2011-05-13T04:42:34Z"
+
+filter=meta.lastModified lt "2011-05-13T04:42:34Z"
+
+filter=meta.lastModified le "2011-05-13T04:42:34Z"
+
+filter=title pr and userType eq "Employee"
+
+filter=title pr or userType eq "Intern"
+
+filter=
+ schemas eq "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+
+filter=userType eq "Employee" and (emails co "example.com" or
+  emails.value co "example.org")
+
+filter=userType ne "Employee" and not (emails co "example.com" or
+  emails.value co "example.org")
+
+filter=userType eq "Employee" and (emails.type eq "work")
+
+filter=userType eq "Employee" and emails[type eq "work" and
+  value co "@example.com"]
+
+filter=emails[type eq "work" and value co "@example.com"] or
+  ims[type eq "xmpp" and value co "@foo.com"]
+
+                         Figure 2: Example Filters
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 23]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.4.2.3.  Sorting
+
+   Sort is OPTIONAL.  Clients MAY discover sort capability by looking at
+   the "sort" attribute of the service provider configuration (see
+   Section 4).  Sorting allows clients to specify the order in which
+   resources are returned by specifying a combination of "sortBy" and
+   "sortOrder" URL parameters.
+
+   sortBy  The "sortBy" parameter specifies the attribute whose value
+      SHALL be used to order the returned responses.  If the "sortBy"
+      attribute corresponds to a singular attribute, resources are
+      sorted according to that attribute's value; if it's a multi-valued
+      attribute, resources are sorted by the value of the primary
+      attribute (see Section 2.4 of [RFC7643]), if any, or else the
+      first value in the list, if any.  If the attribute is complex, the
+      attribute name must be a path to a sub-attribute in standard
+      attribute notation (Section 3.10), e.g., "sortBy=name.givenName".
+      For all attribute types, if there is no data for the specified
+      "sortBy" value, they are sorted via the "sortOrder" parameter,
+      i.e., they are ordered last if ascending and first if descending.
+
+   sortOrder  The order in which the "sortBy" parameter is applied.
+      Allowed values are "ascending" and "descending".  If a value for
+      "sortBy" is provided and no "sortOrder" is specified, "sortOrder"
+      SHALL default to ascending.  String type attributes are case
+      insensitive by default, unless the attribute type is defined as a
+      case-exact string.  "sortOrder" MUST sort according to the
+      attribute type; i.e., for case-insensitive attributes, sort the
+      result using case-insensitive Unicode alphabetic sort order with
+      no specific locale implied, and for case-exact attribute types,
+      sort the result using case-sensitive Unicode alphabetic sort
+      order.
+
+3.4.2.4.  Pagination
+
+   Pagination parameters can be used together to "page through" large
+   numbers of resources so as not to overwhelm the client or service
+   provider.  Because pagination is not stateful, clients MUST be
+   prepared to handle inconsistent results.  For example, a request for
+   a list of 10 resources beginning with a startIndex of 1 MAY return
+   different results when repeated, since resources on the service
+   provider may have changed between requests.  Pagination parameters
+   and general behavior are derived from the OpenSearch Protocol
+   [OpenSearch].
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 24]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Table 6 describes the URL pagination parameters.
+
+   +------------+----------------------------+-------------------------+
+   | Parameter  | Description                | Default                 |
+   +------------+----------------------------+-------------------------+
+   | startIndex | The 1-based index of the   | 1                       |
+   |            | first query result.  A     |                         |
+   |            | value less than 1 SHALL be |                         |
+   |            | interpreted as 1.          |                         |
+   |            |                            |                         |
+   | count      | Non-negative integer.      | None.  When specified,  |
+   |            | Specifies the desired      | the service provider    |
+   |            | maximum number of query    | MUST NOT return more    |
+   |            | results per page, e.g.,    | results than specified, |
+   |            | 10.  A negative value      | although it MAY return  |
+   |            | SHALL be interpreted as    | fewer results.  If      |
+   |            | "0".  A value of "0"       | unspecified, the        |
+   |            | indicates that no resource | maximum number of       |
+   |            | results are to be returned | results is set by the   |
+   |            | except for "totalResults". | service provider.       |
+   +------------+----------------------------+-------------------------+
+
+                  Table 6: Pagination Request Parameters
+
+
+   Table 7 describes the query response pagination attributes specified
+   by the service provider.
+
+   +--------------+----------------------------------------------------+
+   | Element      | Description                                        |
+   +--------------+----------------------------------------------------+
+   | itemsPerPage | Non-negative integer.  Specifies the number of     |
+   |              | query results returned in a query response page,   |
+   |              | e.g., 10.                                          |
+   |              |                                                    |
+   | totalResults | Non-negative integer.  Specifies the total number  |
+   |              | of results matching the client query, e.g., 1000.  |
+   |              |                                                    |
+   | startIndex   | The 1-based index of the first result in the       |
+   |              | current set of query results, e.g., 1.             |
+   +--------------+----------------------------------------------------+
+
+                   Table 7: Pagination Response Elements
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 25]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   For example, to retrieve the first 10 Users, set the startIndex to 1
+   and the count to 10:
+
+   GET /Users?startIndex=1&count=10
+   Host: example.com
+   Accept: application/scim+json
+   Authorization: Bearer h480djs93hd8
+
+   The response to the query above returns metadata regarding paging
+   similar to the following example (actual resources removed for
+   brevity):
+
+   {
+     "totalResults":100,
+     "itemsPerPage":10,
+     "startIndex":1,
+     "schemas":["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+     "Resources":[{
+       ...
+     }]
+   }
+
+      Figure 3: ListResponse Format for Returning Multiple Resources
+
+   Given the example above, to continue paging, set the startIndex to 11
+   and re-fetch, i.e., /Users?startIndex=11&count=10.
+
+3.4.2.5.  Attributes
+
+   The following attributes control which attributes SHALL be returned
+   with a returned resource.  SCIM clients MAY use one of these two
+   OPTIONAL parameters, which MUST be supported by SCIM service
+   providers:
+
+   attributes  A multi-valued list of strings indicating the names of
+      resource attributes to return in the response, overriding the set
+      of attributes that would be returned by default.  Attribute names
+      MUST be in standard attribute notation (Section 3.10) form.  See
+      Section 3.9 for additional retrieval query parameters.
+
+   excludedAttributes  A multi-valued list of strings indicating the
+      names of resource attributes to be removed from the default set of
+      attributes to return.  This parameter SHALL have no effect on
+      attributes whose schema "returned" setting is "always" (see
+      Sections 2.2 and 7 of [RFC7643]).  Attribute names MUST be in
+      standard attribute notation (Section 3.10) form.  See Section 3.9
+      for additional retrieval query parameters.
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 26]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.4.3.  Querying Resources Using HTTP POST
+
+   Clients MAY execute queries without passing parameters on the URL by
+   using the HTTP POST verb combined with the "/.search" path extension.
+   The inclusion of "/.search" on the end of a valid SCIM endpoint SHALL
+   be used to indicate that the HTTP POST verb is intended to be a query
+   operation.
+
+   To create a new query result set, a SCIM client sends an HTTP POST
+   request to the desired SCIM resource endpoint (ending in "/.search").
+   The body of the POST request MAY include any of the parameters
+   defined in Section 3.4.2.
+
+   Query requests MUST be identified using the following URI:
+   "urn:ietf:params:scim:api:messages:2.0:SearchRequest".  The following
+   attributes are defined for query requests:
+
+   attributes  A multi-valued list of strings indicating the names of
+      resource attributes to return in the response, overriding the set
+      of attributes that would be returned by default.  Attribute names
+      MUST be in standard attribute notation (Section 3.10) form.  See
+      Section 3.9 for additional retrieval query parameters.  OPTIONAL.
+
+   excludedAttributes  A multi-valued list of strings indicating the
+      names of resource attributes to be removed from the default set of
+      attributes to return.  This parameter SHALL have no effect on
+      attributes whose schema "returned" setting is "always" (see
+      Sections 2.2 and 7 of [RFC7643]).  Attribute names MUST be in
+      standard attribute notation (Section 3.10) form.  See Section 3.9
+      for additional retrieval query parameters.  OPTIONAL.
+
+   filter  The filter string used to request a subset of resources.  The
+      filter string MUST be a valid filter (Section 3.4.2.2) expression.
+      OPTIONAL.
+
+   sortBy  A string indicating the attribute whose value SHALL be used
+      to order the returned responses.  The "sortBy" attribute MUST be
+      in standard attribute notation (Section 3.10) form.  See
+      Section 3.4.2.3.  OPTIONAL.
+
+   sortOrder  A string indicating the order in which the "sortBy"
+      parameter is applied.  Allowed values are "ascending" and
+      "descending".  See Section 3.4.2.3.  OPTIONAL.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 27]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   startIndex  An integer indicating the 1-based index of the first
+      query result.  See Section 3.4.2.4.  OPTIONAL.
+
+   count  An integer indicating the desired maximum number of query
+      results per page.  See Section 3.4.2.4.  OPTIONAL.
+
+   After receiving an HTTP POST request, a response is returned as
+   specified in Section 3.4.2.
+
+   The following example shows an HTTP POST Query request with search
+   parameters "attributes", "filter", and "count" included:
+
+   POST /.search
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: ...
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:SearchRequest"],
+     "attributes": ["displayName", "userName"],
+     "filter":
+       "displayName sw \"smith\"",
+     "startIndex": 1,
+     "count": 10
+   }
+
+                   Figure 4: Example POST Query Request
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 28]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The example below shows a query response with the first page of
+   results.  For brevity, only two matches are shown: one User and
+   one Group.
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+   Location: https://example.com/.search
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+     "totalResults":100,
+     "itemsPerPage":10,
+     "startIndex":1,
+     "Resources":[
+       {
+         "id":"2819c223-7f76-413861904646",
+         "userName":"jsmith",
+         "displayName":"Smith, James"
+       },
+       {
+         "id":"c8596b90-7539-4f20968d1908",
+         "displayName":"Smith Family"
+       },
+        ...
+     ]
+   }
+
+                   Figure 5: Example POST Query Response
+
+3.5.  Modifying Resources
+
+   Resources can be modified in whole or in part using HTTP PUT or HTTP
+   PATCH, respectively.  Implementers MUST support HTTP PUT as specified
+   in Section 4.3 of [RFC7231].  Resources such as Groups may be very
+   large; hence, implementers SHOULD support HTTP PATCH [RFC5789] to
+   enable partial resource modifications.  Service provider support for
+   HTTP PATCH may be discovered by querying the service provider
+   configuration (see Section 4).
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 29]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.5.1.  Replacing with PUT
+
+   HTTP PUT is used to replace a resource's attributes.  For example,
+   clients that have previously retrieved the entire resource in advance
+   and revised it MAY replace the resource using an HTTP PUT.  Because
+   SCIM resource identifiers are assigned by the service provider, HTTP
+   PUT MUST NOT be used to create new resources.
+
+   As the operation's intent is to replace all attributes, SCIM clients
+   MAY send all attributes, regardless of each attribute's mutability.
+   The server will apply attribute-by-attribute replacements according
+   to the following attribute mutability rules:
+
+   readWrite, writeOnly  Any values provided SHALL replace the existing
+      attribute values.
+
+      Attributes whose mutability is "readWrite" that are omitted from
+      the request body MAY be assumed to be not asserted by the client.
+      The service provider MAY assume that any existing values are to be
+      cleared, or the service provider MAY assign a default value to the
+      final resource representation.  Service providers MAY take into
+      account whether or not a client has access to, or understands, all
+      of the resource's attributes when deciding whether non-asserted
+      attributes SHALL be removed or defaulted.  Clients that want to
+      override a server's defaults MAY specify "null" for a
+      single-valued attribute, or an empty array "[]" for a multi-valued
+      attribute, to clear all values.
+
+   immutable  If one or more values are already set for the attribute,
+      the input value(s) MUST match, or HTTP status code 400 SHOULD be
+      returned with a "scimType" error code of "mutability".  If the
+      service provider has no existing values, the new value(s) SHALL be
+      applied.
+
+   readOnly  Any values provided SHALL be ignored.
+
+   If an attribute is "required", clients MUST specify the attribute in
+   the PUT request.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 30]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Unless otherwise specified, a successful PUT operation returns a 200
+   OK response code and the entire resource within the response body,
+   enabling the client to correlate the client's and the service
+   provider's views of the updated resource.  For example:
+
+   PUT /Users/2819c223-7f76-453a-919d-413861904646
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "userName":"bjensen",
+     "externalId":"bjensen",
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara",
+       "middleName":"Jane"
+     },
+     "roles":[],
+     "emails":[
+       {
+           "value":"bjensen@example.com"
+       },
+       {
+           "value":"babs@jensen.org"
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 31]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The service responds with the entire updated User:
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+   ETag: W/"b431af54f0671a2"
+   Location:
+     "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646"
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "userName":"bjensen",
+     "externalId":"bjensen",
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara",
+       "middleName":"Jane"
+     },
+     "emails":[
+       {
+           "value":"bjensen@example.com"
+       },
+       {
+           "value":"babs@jensen.org"
+       }
+     ],
+     "meta": {
+       "resourceType":"User",
+       "created":"2011-08-08T04:56:22Z",
+       "lastModified":"2011-08-08T08:00:12Z",
+       "location":
+   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
+       "version":"W\/\"b431af54f0671a2\""
+     }
+   }
+
+3.5.2.  Modifying with PATCH
+
+   HTTP PATCH is an OPTIONAL server function that enables clients to
+   update one or more attributes of a SCIM resource using a sequence of
+   operations to "add", "remove", or "replace" values.  Clients may
+   discover service provider support for PATCH by querying the service
+   provider configuration (see Section 4).
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 32]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The general form of the SCIM PATCH request is based on JSON Patch
+   [RFC6902].  One difference between SCIM PATCH and JSON Patch is that
+   SCIM servers do not support array indexing and do not support
+   [RFC6902] operation types relating to array element manipulation,
+   such as "move".
+
+   The body of each request MUST contain the "schemas" attribute with
+   the URI value of "urn:ietf:params:scim:api:messages:2.0:PatchOp".
+
+   The body of an HTTP PATCH request MUST contain the attribute
+   "Operations", whose value is an array of one or more PATCH
+   operations.  Each PATCH operation object MUST have exactly one "op"
+   member, whose value indicates the operation to perform and MAY be one
+   of "add", "remove", or "replace".  The semantics of each operation
+   are defined in the following subsections.
+
+   The following is an example representation of a PATCH request showing
+   the basic JSON structure (non-normative):
+
+   { "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations":[
+       {
+        "op":"add",
+        "path":"members",
+        "value":[
+         {
+           "display": "Babs Jensen",
+           "$ref":
+   "https://example.com/v2/Users/2819c223...413861904646",
+           "value": "2819c223-7f76-453a-919d-413861904646"
+         }
+        ]
+       },
+       ... + additional operations if needed ...
+     ]
+   }
+
+            Figure 6: Example JSON Body for SCIM PATCH Request
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 33]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The "path" attribute value is a String containing an attribute path
+   describing the target of the operation.  The "path" attribute is
+   OPTIONAL for "add" and "replace" and is REQUIRED for "remove"
+   operations.  See relevant operation sections below for details.
+
+   The "path" attribute is described by the following ABNF syntax rule:
+
+                   PATH = attrPath / valuePath [subAttr]
+
+                      Figure 7: SCIM PATCH PATH Rule
+
+   The ABNF rules "attrPath", "valuePath", and "subAttr" are defined in
+   Section 3.4.2.2.  The "valuePath" rule allows specific values of a
+   complex multi-valued attribute to be selected.
+
+   Valid examples of "path" are as follows:
+
+       "path":"members"
+
+       "path":"name.familyName"
+
+       "path":"addresses[type eq \"work\"]"
+
+       "path":"members[value eq
+              \"2819c223-7f76-453a-919d-413861904646\"]"
+
+       "path":"members[value eq
+              \"2819c223-7f76-453a-919d-413861904646\"].displayName"
+
+                       Figure 8: Example Path Values
+
+   Each operation against an attribute MUST be compatible with the
+   attribute's mutability and schema as defined in Sections 2.2 and 2.3
+   of [RFC7643].  For example, a client MUST NOT modify an attribute
+   that has mutability "readOnly" or "immutable".  However, a client MAY
+   "add" a value to an "immutable" attribute if the attribute had no
+   previous value.  An operation that is not compatible with an
+   attribute's mutability or schema SHALL return the appropriate HTTP
+   response status code and a JSON detail error response as defined in
+   Section 3.12.
+
+   The attribute notation rules described in Section 3.10 apply for
+   describing attribute paths.  For all operations, the value of the
+   "schemas" attribute on the SCIM service provider's representation of
+   the resource SHALL be assumed by default.  If one of the PATCH
+   operations modifies the "schemas" attribute, subsequent operations
+   SHALL assume the modified state of the "schemas" attribute.  Clients
+   MAY implicitly modify the "schemas" attribute by adding (or
+
+
+
+Hunt, et al.                 Standards Track                   [Page 34]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   replacing) an attribute with its fully qualified name, including
+   schema URN.  For example, adding the attribute "urn:ietf:params:scim:
+   schemas:extension:enterprise:2.0:User:employeeNumber" automatically
+   adds the value
+   "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" to the
+   resource's "schemas" attribute.
+
+   Each PATCH operation represents a single action to be applied to the
+   same SCIM resource specified by the request URI.  Operations are
+   applied sequentially in the order they appear in the array.  Each
+   operation in the sequence is applied to the target resource; the
+   resulting resource becomes the target of the next operation.
+   Evaluation continues until all operations are successfully applied or
+   until an error condition is encountered.
+
+   For multi-valued attributes, a PATCH operation that sets a value's
+   "primary" sub-attribute to "true" SHALL cause the server to
+   automatically set "primary" to "false" for any other values in the
+   array.
+
+   A PATCH request, regardless of the number of operations, SHALL be
+   treated as atomic.  If a single operation encounters an error
+   condition, the original SCIM resource MUST be restored, and a failure
+   status SHALL be returned.
+
+   If a request fails, the server SHALL return an HTTP response status
+   code and a JSON detail error response as defined in Section 3.12.
+
+   On successful completion, the server either MUST return a 200 OK
+   response code and the entire resource within the response body,
+   subject to the "attributes" query parameter (see Section 3.9), or MAY
+   return HTTP status code 204 (No Content) and the appropriate response
+   headers for a successful PATCH request.  The server MUST return a 200
+   OK if the "attributes" parameter is specified in the request.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 35]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.5.2.1.  Add Operation
+
+   The "add" operation is used to add a new attribute value to an
+   existing resource.
+
+   The operation MUST contain a "value" member whose content specifies
+   the value to be added.  The value MAY be a quoted value, or it may be
+   a JSON object containing the sub-attributes of the complex attribute
+   specified in the operation's "path".
+
+   The result of the add operation depends upon what the target location
+   indicated by "path" references:
+
+   o  If omitted, the target location is assumed to be the resource
+      itself.  The "value" parameter contains a set of attributes to be
+      added to the resource.
+
+   o  If the target location does not exist, the attribute and value are
+      added.
+
+   o  If the target location specifies a complex attribute, a set of
+      sub-attributes SHALL be specified in the "value" parameter.
+
+   o  If the target location specifies a multi-valued attribute, a new
+      value is added to the attribute.
+
+   o  If the target location specifies a single-valued attribute, the
+      existing value is replaced.
+
+   o  If the target location specifies an attribute that does not exist
+      (has no value), the attribute is added with the new value.
+
+   o  If the target location exists, the value is replaced.
+
+   o  If the target location already contains the value specified, no
+      changes SHOULD be made to the resource, and a success response
+      SHOULD be returned.  Unless other operations change the resource,
+      this operation SHALL NOT change the modify timestamp of the
+      resource.
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 36]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to add a member to a group.  Some
+   text was removed for readability (indicated by "..."):
+
+   PATCH /Groups/acbf3ae7-8463-...-9b4da3f908ce
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   { "schemas":
+      ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations":[
+       {
+        "op":"add",
+        "path":"members",
+        "value":[
+         {
+           "display": "Babs Jensen",
+           "$ref":
+   "https://example.com/v2/Users/2819c223...413861904646",
+           "value": "2819c223-7f76-453a-919d-413861904646"
+         }
+        ]
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 37]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   If the user was already a member of this group, no changes should be
+   made to the resource, and a success response should be returned.
+   The server responds with either the entire updated Group or no
+   response body:
+
+   HTTP/1.1 204 No Content
+   Authorization: Bearer h480djs93hd8
+   ETag: W/"b431af54f0671a2"
+   Location:
+   "https://example.com/Groups/acbf3ae7-8463-...-9b4da3f908ce"
+
+   The following example shows how to add one or more attributes to a
+   User resource without using a "path" attribute.
+
+   PATCH /Users/2819c223-7f76-453a-919d-413861904646
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations":[{
+       "op":"add",
+       "value":{
+         "emails":[
+           {
+             "value":"babs@jensen.org",
+             "type":"home"
+           }
+         ],
+         "nickname":"Babs"
+     }]
+   }
+
+   In the above example, an additional value is added to the
+   multi-valued attribute "emails".  The second attribute, "nickname",
+   is added to the User resource.  If the resource already had an
+   existing "nickname", the value is replaced per the processing rules
+   above for single-valued attributes.
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 38]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.5.2.2.  Remove Operation
+
+   The "remove" operation removes the value at the target location
+   specified by the required attribute "path".  The operation performs
+   the following functions, depending on the target location specified
+   by "path":
+
+   o  If "path" is unspecified, the operation fails with HTTP status
+      code 400 and a "scimType" error code of "noTarget".
+
+   o  If the target location is a single-value attribute, the attribute
+      and its associated value is removed, and the attribute SHALL be
+      considered unassigned.
+
+   o  If the target location is a multi-valued attribute and no filter
+      is specified, the attribute and all values are removed, and the
+      attribute SHALL be considered unassigned.
+
+   o  If the target location is a multi-valued attribute and a complex
+      filter is specified comparing a "value", the values matched by the
+      filter are removed.  If no other values remain after removal of
+      the selected values, the multi-valued attribute SHALL be
+      considered unassigned.
+
+   o  If the target location is a complex multi-valued attribute and a
+      complex filter is specified based on the attribute's
+      sub-attributes, the matching records are removed.  Sub-attributes
+      whose values have been removed SHALL be considered unassigned.  If
+      the complex multi-valued attribute has no remaining records, the
+      attribute SHALL be considered unassigned.
+
+   If an attribute is removed or becomes unassigned and is defined as a
+   required attribute or a read-only attribute, the server SHALL return
+   an HTTP response status code and a JSON detail error response as
+   defined in Section 3.12, with a "scimType" error code of
+   "mutability".
+
+   The following example shows how to remove a member from a group.  As
+   with the previous example, the "display" sub-attribute is optional.
+   If the user was not a member of this group, no changes should be made
+   to the resource, and a success response should be returned.
+
+   Note that server responses have been omitted for the rest of the
+   PATCH examples.
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 39]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Remove a single member from a group.  Some text was removed for
+   readability (indicated by "..."):
+
+   PATCH /Groups/acbf3ae7-8463-...-9b4da3f908ce
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+      ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations":[{
+       "op":"remove",
+       "path":"members[value eq \"2819c223-7f76-...413861904646\"]"
+     }]
+   }
+
+   Remove all members of a group:
+
+   PATCH /Groups/acbf3ae7-8463-...-9b4da3f908ce
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   { "schemas":
+      ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations":[{
+       "op":"remove","path":"members"
+     }]
+   }
+
+   Removal of a value from a complex multi-valued attribute (request
+   headers removed for brevity):
+
+   {
+     "schemas":
+      ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [{
+     "op":"remove",
+     "path":"emails[type eq \"work\" and value ew \"example.com\"]"
+     }]
+   }
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 40]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Example request to remove and add a member.  Some text was removed
+   for readability (indicated by "..."):
+
+   PATCH /Groups/acbf3ae7-8463-...-9b4da3f908ce
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   { "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [
+       {
+         "op":"remove",
+         "path":
+           "members[value eq\"2819c223...919d-413861904646\"]"
+       },
+       {
+         "op":"add",
+         "path":"members",
+         "value": [
+           {
+             "display": "James Smith",
+             "$ref":
+   "https://example.com/v2/Users/08e1d05d...473d93df9210",
+             "value": "08e1d05d...473d93df9210"
+           }
+         ]
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 41]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to replace all of the members of a
+   group with a different members list.  Some text was removed for
+   readability (indicated by "..."):
+
+   PATCH /Groups/acbf3ae7-8463-4692-b4fd-9b4da3f908ce
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [
+       {
+         "op":"remove","path":"members"
+       },
+       {
+         "op":"add",
+         "path":"members",
+         "value":[
+         {
+           "display": "Babs Jensen",
+           "$ref":
+   "https://example.com/v2/Users/2819c223...413861904646",
+           "value": "2819c223-7f76-453a-919d-413861904646"
+         },
+         {
+           "display": "James Smith",
+           "$ref":
+   "https://example.com/v2/Users/08e1d05d...473d93df9210",
+           "value": "08e1d05d-121c-4561-8b96-473d93df9210"
+         }]
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 42]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.5.2.3.  Replace Operation
+
+   The "replace" operation replaces the value at the target location
+   specified by the "path".  The operation performs the following
+   functions, depending on the target location specified by "path":
+
+   o  If the "path" parameter is omitted, the target is assumed to be
+      the resource itself.  In this case, the "value" attribute SHALL
+      contain a list of one or more attributes that are to be replaced.
+
+   o  If the target location is a single-value attribute, the attributes
+      value is replaced.
+
+   o  If the target location is a multi-valued attribute and no filter
+      is specified, the attribute and all values are replaced.
+
+   o  If the target location path specifies an attribute that does not
+      exist, the service provider SHALL treat the operation as an "add".
+
+   o  If the target location specifies a complex attribute, a set of
+      sub-attributes SHALL be specified in the "value" parameter, which
+      replaces any existing values or adds where an attribute did not
+      previously exist.  Sub-attributes that are not specified in the
+      "value" parameter are left unchanged.
+
+   o  If the target location is a multi-valued attribute and a value
+      selection ("valuePath") filter is specified that matches one or
+      more values of the multi-valued attribute, then all matching
+      record values SHALL be replaced.
+
+   o  If the target location is a complex multi-valued attribute with a
+      value selection filter ("valuePath") and a specific sub-attribute
+      (e.g., "addresses[type eq "work"].streetAddress"), the matching
+      sub-attribute of all matching records is replaced.
+
+   o  If the target location is a multi-valued attribute for which a
+      value selection filter ("valuePath") has been supplied and no
+      record match was made, the service provider SHALL indicate failure
+      by returning HTTP status code 400 and a "scimType" error code of
+      "noTarget".
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 43]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to replace all of the members of a
+   group with a different members list in a single replace operation.
+   Some text was removed for readability (indicated by "..."):
+
+   PATCH /Groups/acbf3ae7-8463-4692-b4fd-9b4da3f908ce
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [{
+       "op":"replace",
+       "path":"members",
+       "value":[
+         {
+           "display": "Babs Jensen",
+           "$ref":
+   "https://example.com/v2/Users/2819c223...413861904646",
+           "value": "2819c223...413861904646"
+         },
+         {
+           "display": "James Smith",
+           "$ref":
+   "https://example.com/v2/Users/08e1d05d...473d93df9210",
+           "value": "08e1d05d...473d93df9210"
+         }
+       ]
+     }]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 44]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to change a User's entire "work"
+   address, using a "valuePath" filter.  Note that by setting "primary"
+   to "true", the service provider will reset "primary" to "false" for
+   any other existing values of "addresses".
+
+   PATCH /Users/2819c223-7f76-453a-919d-413861904646
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [{
+       "op":"replace",
+       "path":"addresses[type eq \"work\"]",
+       "value":
+       {
+         "type": "work",
+         "streetAddress": "911 Universal City Plaza",
+         "locality": "Hollywood",
+         "region": "CA",
+         "postalCode": "91608",
+         "country": "US",
+         "formatted":
+   "911 Universal City Plaza\nHollywood, CA 91608 US",
+         "primary": true
+       }
+     }]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 45]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to change a specific sub-attribute
+   "streetAddress" of complex attribute "emails" selected by a
+   "valuePath" filter:
+
+   PATCH /Users/2819c223-7f76-453a-919d-413861904646
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [{
+       "op":"replace",
+       "path":"addresses[type eq \"work\"].streetAddress",
+       "value":"1010 Broadway Ave"
+     }]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 46]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to replace all values of one or more
+   specific attributes of a User resource.  Note that other attributes
+   are unaffected.
+
+   PATCH /Users/2819c223-7f76-453a-919d-413861904646
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   If-Match: W/"a330bc54f0671c9"
+
+   {
+     "schemas":
+       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+     "Operations": [{
+       "op":"replace",
+       "value":{
+         "emails":[
+           {
+             "value":"bjensen@example.com",
+             "type":"work",
+             "primary":true
+           },
+           {
+             "value":"babs@jensen.org",
+             "type":"home"
+           }
+         ],
+         "nickname":"Babs"
+     }]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 47]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.6.  Deleting Resources
+
+   Clients request resource removal via DELETE.  Service providers MAY
+   choose not to permanently delete the resource but MUST return a 404
+   (Not Found) error code for all operations associated with the
+   previously deleted resource.  Service providers MUST omit the
+   resource from future query results.  In addition, the service
+   provider SHOULD NOT consider the deleted resource in conflict
+   calculation.  For example, if a User resource is deleted, a CREATE
+   request for a User resource with the same userName as the previously
+   deleted resource SHOULD NOT fail with a 409 error due to userName
+   conflict.
+
+            DELETE /Users/2819c223-7f76-453a-919d-413861904646
+            Host: example.com
+            Authorization: Bearer h480djs93hd8
+            If-Match: W/"c310cd84f0281b7"
+
+   In response to a successful DELETE, the server SHALL return a
+   successful HTTP status code 204 (No Content).  A non-normative
+   example response:
+
+                          HTTP/1.1 204 No Content
+
+   Example: Client's attempt to retrieve the previously deleted User
+
+              GET /Users/2819c223-7f76-453a-919d-413861904646
+              Host: example.com
+              Authorization: Bearer h480djs93hd8
+
+   Server response:
+
+   HTTP/1.1 404 Not Found
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+     "detail":"Resource 2819c223-7f76-453a-919d-413861904646 not found",
+     "status": "404"
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 48]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.7.  Bulk Operations
+
+   The SCIM bulk operation is an optional server feature that enables
+   clients to send a potentially large collection of resource operations
+   in a single request.  Support for bulk requests can be discovered by
+   querying the service provider configuration (see Section 4).  The
+   body of a bulk operation contains a set of HTTP resource operations
+   using one of the HTTP methods supported by the API, i.e., POST, PUT,
+   PATCH, or DELETE.
+
+   Bulk requests are identified using the following schema URI:
+   "urn:ietf:params:scim:api:messages:2.0:BulkRequest".  Bulk responses
+   are identified using the following URI:
+   "urn:ietf:params:scim:api:messages:2.0:BulkResponse".  Bulk requests
+   and bulk responses share many attributes.  Unless otherwise
+   specified, each attribute below is present in both bulk requests and
+   bulk responses.
+
+   The following singular attribute is defined, in addition to the
+   common attributes defined in [RFC7643].
+
+   failOnErrors
+      An integer specifying the number of errors that the service
+      provider will accept before the operation is terminated and an
+      error response is returned.  OPTIONAL in a request.  Not valid in
+      a response.
+
+   The following complex multi-valued attribute is defined, in addition
+   to the common attributes defined in [RFC7643].
+
+   Operations
+      Defines operations within a bulk job.  Each operation corresponds
+      to a single HTTP request against a resource endpoint.  REQUIRED.
+      The Operations attribute has the following sub-attributes:
+
+      method  The HTTP method of the current operation.  Possible values
+         are "POST", "PUT", "PATCH", or "DELETE".  REQUIRED.
+
+      bulkId  The transient identifier of a newly created resource,
+         unique within a bulk request and created by the client.  The
+         bulkId serves as a surrogate resource id enabling clients to
+         uniquely identify newly created resources in the response and
+         cross-reference new resources in and across operations within a
+         bulk request.  REQUIRED when "method" is "POST".
+
+      version  The current resource version.  Version MAY be used if the
+         service provider supports entity-tags (ETags) (Section 2.3 of
+         [RFC7232]) and "method" is "PUT", "PATCH", or "DELETE".
+
+
+
+Hunt, et al.                 Standards Track                   [Page 49]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+      path  The resource's relative path to the SCIM service provider's
+         root.  If "method" is "POST", the value must specify a resource
+         type endpoint, e.g., /Users or /Groups, whereas all other
+         "method" values must specify the path to a specific resource,
+         e.g., /Users/2819c223-7f76-453a-919d-413861904646.  REQUIRED in
+         a request.
+
+      data  The resource data as it would appear for a single SCIM POST,
+         PUT, or PATCH operation.  REQUIRED in a request when "method"
+         is "POST", "PUT", or "PATCH".
+
+      location  The resource endpoint URL.  REQUIRED in a response,
+         except in the event of a POST failure.
+
+      response  The HTTP response body for the specified request
+         operation.  When indicating a response with an HTTP status
+         other than a 200-series response, the response body MUST be
+         included.  For normal completion, the server MAY elect to omit
+         the response body.
+
+      status  The HTTP response status code for the requested operation.
+         When indicating an error, the "response" attribute MUST contain
+         the detail error response as per Section 3.12.
+
+   If a bulk job is processed successfully, HTTP response code 200 OK
+   MUST be returned; otherwise, an appropriate HTTP error code MUST be
+   returned.
+
+   The service provider MUST continue performing as many changes as
+   possible and disregard partial failures.  The client MAY override
+   this behavior by specifying a value for the "failOnErrors" attribute.
+   The "failOnErrors" attribute defines the number of errors that the
+   service provider should accept before failing the remaining
+   operations returning the response.
+
+   To be able to reference a newly created resource, the bulkId
+   attribute MAY be specified when creating new resources.  The "bulkId"
+   is defined by the client as a surrogate identifier in a POST
+   operation (see Section 3.7.2).  The service provider MUST return the
+   same "bulkId" together with the newly created resource.  The "bulkId"
+   can then be used by the client to map the service provider id with
+   the "bulkId" of the created resource.
+
+   A SCIM service provider MAY elect to optimize the sequence of
+   operations received (e.g., to improve processing performance).  When
+   doing so, the service provider MUST ensure that the client's intent
+   is preserved and the same stateful result is achieved as for
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 50]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   non-optimized processing.  For example, before a "User" can be added
+   to a "Group", they must first be created.  Processing these requests
+   out of order might result in a failure to add the new "User" to the
+   "Group".
+
+3.7.1.  Circular Reference Processing
+
+   The service provider MUST try to resolve circular cross-references
+   between resources in a single bulk job but MAY stop after a failed
+   attempt and instead return HTTP status code 409 (Conflict).  The
+   following example exhibits the potential conflict.
+
+   POST /v2/Bulk
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: ...
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],
+     "Operations": [
+       {
+         "method": "POST",
+         "path": "/Groups",
+         "bulkId": "qwerty",
+         "data": {
+           "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+           "displayName": "Group A",
+           "members": [
+             {
+               "type": "Group",
+               "value": "bulkId:ytrewq"
+             }
+           ]
+         }
+       },
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 51]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+       {
+         "method": "POST",
+         "path": "/Groups",
+         "bulkId": "ytrewq",
+         "data": {
+           "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+           "displayName": "Group B",
+           "members": [
+             {
+               "type": "Group",
+               "value": "bulkId:qwerty"
+             }
+           ]
+         }
+       }
+     ]
+   }
+
+   If the service provider resolved the above circular references, the
+   following is returned from a subsequent GET request.
+
+   GET /v2/Groups?filter=displayName sw 'Group'
+   Host: example.com
+   Accept: application/scim+json
+   Authorization: Bearer h480djs93hd8
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+     "totalResults": 2,
+     "Resources": [
+       {
+         "id": "c3a26dd3-27a0-4dec-a2ac-ce211e105f97",
+         "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+         "displayName": "Group A",
+         "meta": {
+           "resourceType": "Group",
+           "created": "2011-08-01T18:29:49.793Z",
+           "lastModified": "2011-08-01T18:29:51.135Z",
+           "location":
+   "https://example.com/v2/Groups/c3a26dd3-27a0-4dec-a2ac-ce211e105f97",
+           "version": "W\/\"mvwNGaxB5SDq074p\""
+         },
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 52]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+         "members": [
+           {
+             "value": "6c5bb468-14b2-4183-baf2-06d523e03bd3",
+             "$ref":
+   "https://example.com/v2/Groups/6c5bb468-14b2-4183-baf2-06d523e03bd3",
+             "type": "Group"
+           }
+         ]
+       },
+       {
+         "id": "6c5bb468-14b2-4183-baf2-06d523e03bd3",
+         "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+         "displayName": "Group B",
+         "meta": {
+           "resourceType": "Group",
+           "created": "2011-08-01T18:29:50.873Z",
+           "lastModified": "2011-08-01T18:29:50.873Z",
+           "location":
+   "https://example.com/v2/Groups/6c5bb468-14b2-4183-baf2-06d523e03bd3",
+           "version": "W\/\"wGB85s2QJMjiNnuI\""
+         },
+         "members": [
+           {
+             "value": "c3a26dd3-27a0-4dec-a2ac-ce211e105f97",
+             "$ref":
+   "https://example.com/v2/Groups/c3a26dd3-27a0-4dec-a2ac-ce211e105f97",
+             "type": "Group"
+           }
+         ]
+       }
+     ]
+   }
+
+3.7.2.  "bulkId" Temporary Identifiers
+
+   A SCIM client can, within one bulk operation, create a new "User",
+   create a new "Group", and add the newly created "User" to the newly
+   created "Group".  In order to add the new "User" to the "Group", the
+   client must use the surrogate id attribute, "bulkId", to reference
+   the User.  The "bulkId" attribute value must be prepended with the
+   literal "bulkId:"; e.g., if the bulkId is 'qwerty', the value is
+   "bulkId:qwerty".  The service provider MUST replace the string
+   "bulkId:qwerty" with the permanent resource id once created.
+
+   To create multiple distinct requests, each with their own "bulkId",
+   the SCIM client specifies different "bulkId" values for each separate
+   request.
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 53]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example creates a User with the "userName" 'Alice' and
+   a "Group" with "displayName", with a value of "Tour Guides" with
+   Alice as a member.  Notice that each operation has its own "bulkId"
+   value.  However, the second operation (whose "bulkId" is "ytrewq")
+   refers to the "bulkId" of "qwerty" in order to add Alice to the new
+   'Tour Guides' group.
+
+   POST /v2/Bulk
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: ...
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],
+     "Operations": [
+       {
+         "method": "POST",
+         "path": "/Users",
+         "bulkId": "qwerty",
+         "data": {
+           "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+           "userName": "Alice"
+         }
+       },
+       {
+         "method": "POST",
+         "path": "/Groups",
+         "bulkId": "ytrewq",
+         "data": {
+           "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+           "displayName": "Tour Guides",
+           "members": [
+             {
+               "type": "User",
+               "value": "bulkId:qwerty"
+             }
+           ]
+         }
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 54]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The service provider returns the following response:
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],
+     "Operations": [
+       {
+         "location":
+   "https://example.com/v2/Users/92b725cd-9465-4e7d-8c16-01f8e146b87a",
+         "method": "POST",
+         "bulkId": "qwerty",
+         "version": "W\/\"4weymrEsh5O6cAEK\"",
+         "status": {
+           "code": "201"
+         }
+       },
+       {
+         "location":
+   "https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a",
+         "method": "POST",
+         "bulkId": "ytrewq",
+         "version": "W\/\"lha5bbazU3fNvfe5\"",
+         "status": {
+           "code": "201"
+         }
+       }
+     ]
+   }
+
+   In the above example, the "Alice" User resource has an "id" of
+   "92b725cd-9465-4e7d-8c16-01f8e146b87a" and the 'Tour Guides' Group
+   has an "id" of "e9e30dba-f08f-4109-8486-d5c6a331660a".
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 55]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   A subsequent GET request for the 'Tour Guides' Group (with an "id" of
+   "e9e30dba-f08f-4109-8486-d5c6a331660a") returns the following, with
+   Alice's "id" as the value for the member in the Group 'Tour Guides':
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+   Location:
+    https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a
+   ETag: W/"lha5bbazU3fNvfe5"
+
+   {
+     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+     "id": "e9e30dba-f08f-4109-8486-d5c6a331660a",
+     "displayName": "Tour Guides",
+     "meta": {
+       "resourceType": "Group",
+       "created": "2011-08-01T18:29:49.793Z",
+       "lastModified": "2011-08-01T20:31:02.315Z",
+       "location":
+   "https://example.com/v2/Groups/e9e30dba-f08f-4109-8486-d5c6a331660a",
+       "version": "W\/\"lha5bbazU3fNvfe5\""
+     },
+     "members": [
+       {
+         "value": "92b725cd-9465-4e7d-8c16-01f8e146b87a",
+         "$ref":
+   "https://example.com/v2/Users/92b725cd-9465-4e7d-8c16-01f8e146b87a",
+         "type": "User"
+       }
+     ]
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 56]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Extensions that include references to other resources MUST be handled
+   in the same way by the service provider.  The following example uses
+   the bulkId attribute within the enterprise extension managerId
+   attribute.
+
+ POST /v2/Bulk
+ Host: example.com
+ Accept: application/scim+json
+ Content-Type: application/scim+json
+ Authorization: Bearer h480djs93hd8
+ Content-Length: ...
+
+ {
+   "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],
+   "Operations": [
+     {
+       "method": "POST",
+       "path": "/Users",
+       "bulkId": "qwerty",
+       "data": {
+         "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+         "userName": "Alice"
+       }
+     },
+     {
+       "method": "POST",
+       "path": "/Users",
+       "bulkId": "ytrewq",
+       "data": {
+         "schemas": [
+           "urn:ietf:params:scim:schemas:core:2.0:User",
+           "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+         ],
+         "userName": "Bob",
+         "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+           "employeeNumber": "11250",
+           "manager": {
+             "value": "bulkId:qwerty"
+           }
+         }
+       }
+     }
+   ]
+ }
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 57]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.7.3.  Response and Error Handling
+
+   The service provider response MUST include the result of all
+   processed operations.  A "location" attribute that includes the
+   resource's endpoint MUST be returned for all operations except for
+   failed POST operations (which have no location).  The status
+   attribute includes information about the success or failure of one
+   operation within the bulk job.  The status attribute MUST include the
+   code attribute that holds the HTTP response code that would have been
+   returned if a single HTTP request would have been used.  If an error
+   occurred, the status MUST also include the description attribute
+   containing a human-readable explanation of the error.
+
+   "status": "201"
+
+   The following is an example of a status in a failed operation.
+
+  "status": "400",
+  "response":{
+       "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+       "scimType":"invalidSyntax"
+       "detail":
+  "Request is unparsable, syntactically incorrect, or violates schema.",
+       "status":"400"
+   }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 58]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following example shows how to add, update, and remove a user.
+   The "failOnErrors" attribute is set to '1', indicating that the
+   service provider will stop processing and return results after one
+   error.  The POST operation's bulkId value is set to 'qwerty',
+   enabling the client to match the new User with the returned
+   resource "id" of
+   "92b725cd-9465-4e7d-8c16-01f8e146b87a".
+
+   POST /v2/Bulk
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: ...
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkRequest"],
+     "failOnErrors":1,
+     "Operations":[
+       {
+         "method":"POST",
+         "path":"/Users",
+         "bulkId":"qwerty",
+         "data":{
+           "schemas": ["urn:ietf:params:scim:api:messages:2.0:User"],
+           "userName":"Alice"
+         }
+       },
+       {
+         "method":"PUT",
+         "path":"/Users/b7c14771-226c-4d05-8860-134711653041",
+         "version":"W\/\"3694e05e9dff591\"",
+         "data":{
+           "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+           "id":"b7c14771-226c-4d05-8860-134711653041",
+           "userName":"Bob"
+         }
+       },
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 59]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+       {
+         "method": "PATCH",
+         "path": "/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc",
+         "version": "W/\"edac3253e2c0ef2\"",
+         "data": {[
+           {
+               "op": "remove",
+               "path": "nickName"
+           },
+           {
+               "op": "add",
+               "path": "userName",
+               "value": "Dave"
+           }
+         ]}
+       },
+       {
+         "method":"DELETE",
+         "path":"/Users/e9025315-6bea-44e1-899c-1e07454e468b",
+         "version":"W\/\"0ee8add0a938e1a\""
+       }
+     ]
+   }
+
+   The service provider returns the following response:
+
+  HTTP/1.1 200 OK
+  Content-Type: application/scim+json
+
+  {
+      "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],
+      "Operations": [
+          {
+              "location":
+  "https://example.com/v2/Users/92b725cd-9465-4e7d-8c16-01f8e146b87a",
+              "method": "POST",
+              "bulkId": "qwerty",
+              "version": "W\/\"oY4m4wn58tkVjJxK\"",
+              "status": "201"
+          },
+          {
+              "location":
+  "https://example.com/v2/Users/b7c14771-226c-4d05-8860-134711653041",
+              "method": "PUT",
+              "version": "W\/\"huJj29dMNgu3WXPD\"",
+              "status": "200"
+          },
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 60]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+          {
+              "location":
+  "https://example.com/v2/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc",
+              "method": "PATCH",
+              "version": "W\/\"huJj29dMNgu3WXPD\"",
+              "status": "200"
+          },
+          {
+              "location":
+  "https://example.com/v2/Users/e9025315-6bea-44e1-899c-1e07454e468b",
+              "method": "DELETE",
+              "status": "204"
+          }
+      ]
+  }
+
+   The following response is returned if an error occurred when
+   attempting to create the User 'Alice'.  The service provider stops
+   processing the bulk operation and immediately returns a response to
+   the client.  The response contains the error and any successful
+   results prior to the error.
+
+  HTTP/1.1 200 OK
+  Content-Type: application/scim+json
+
+  {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],
+    "Operations": [
+      {
+        "method": "POST",
+        "bulkId": "qwerty",
+        "status": "400",
+        "response":{
+           "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+           "scimType":"invalidSyntax"
+           "detail":
+  "Request is unparsable, syntactically incorrect, or violates schema.",
+           "status":"400"
+        }
+      }
+    ]
+  }
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 61]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   If the "failOnErrors" attribute is not specified or the service
+   provider has not reached the error limit defined by the client, the
+   service provider will continue to process all operations.  The
+   following is an example in which all operations failed.
+
+  HTTP/1.1 200 OK
+  Content-Type: application/scim+json
+
+  {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:BulkResponse"],
+    "Operations": [
+      {
+        "method": "POST",
+        "bulkId": "qwerty",
+        "status": "400",
+        "response":{
+           "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+           "scimType":"invalidSyntax"
+           "detail":
+  "Request is unparsable, syntactically incorrect, or violates schema.",
+           "status":"400"
+        }
+      },
+      {
+        "location":
+  "https://example.com/v2/Users/b7c14771-226c-4d05-8860-134711653041",
+        "method": "PUT",
+        "status": "412",
+        "response":{
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail":
+                  "Failed to update.  Resource changed on the server.",
+            "status":"412"
+        }
+      },
+      {
+        "location":
+  "https://example.com/v2/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc",
+        "method": "PATCH",
+        "status": "412",
+        "response":{
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail":
+                  "Failed to update.  Resource changed on the server.",
+            "status":"412"
+        }
+      },
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 62]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+      {
+        "location":
+  "https://example.com/v2/Users/e9025315-6bea-44e1-899c-1e07454e468b",
+        "method": "DELETE",
+        "status": "404",
+        "response":{
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail":"Resource does not exist.",
+            "status":"404"
+        }
+      }
+    ]
+  }
+
+3.7.4.  Maximum Operations
+
+   The service provider MUST define the maximum number of operations and
+   maximum payload size a client may send in a single request.  These
+   limits MAY be retrieved from the service provider configuration (see
+   'bulk' in Sections 5 and 8.5 of [RFC7643]).  If either limit is
+   exceeded, the service provider MUST return HTTP response code 413
+   (Payload Too Large).  The returned response MUST specify the limit
+   exceeded in the body of the error response.
+
+   In the following example, the client sent a request exceeding the
+   service provider's maximum payload size of 1 megabyte:
+
+   POST /v2/Bulk
+   Host: example.com
+   Accept: application/scim+json
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: 4294967296
+
+   ...
+
+   The server sends the following error in response to the oversized
+   request:
+
+  HTTP/1.1 413 Payload Too Large
+  Content-Type: application/scim+json
+
+  {
+    "schemas":["urn:ietf:params:scim:api:messages:2.0:Error"],
+    "status": "413",
+    "detail":
+  "The size of the bulk operation exceeds the maxPayloadSize (1048576)."
+  }
+
+
+
+Hunt, et al.                 Standards Track                   [Page 63]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.8.  Data Input/Output Formats
+
+   Servers MUST accept requests and be able to return JSON-structured
+   responses using UTF-8 encoding [RFC3629].  UTF-8 SHALL be the default
+   encoding format.  Other media types MAY be supported by service
+   providers but are beyond the scope of this specification.
+
+   Clients using other encodings MUST specify the format in which the
+   data is submitted via an HTTP "Content-Type" header as specified in
+   Section 3.1.1.5 of [RFC7231] and MAY specify the desired response
+   data format via an HTTP "Accept" header (Section 5.3.2 of [RFC7231]),
+   e.g., "Accept: application/scim+json", or via URI suffix:
+
+   GET /Users/2819c223-7f76-453a-919d-413861904646.scim
+   Host: example.com
+
+   Service providers MUST support the "Accept" header
+   "Accept: application/scim+json" and SHOULD support the header
+   "Accept: application/json", both of which specify JSON documents
+   conforming to [RFC7159].  The format defaults to
+   "application/scim+json" if no format is specified.
+
+   Singular attributes are encoded as string name-value pairs in
+   JSON, e.g.,
+
+   "attribute": "value"
+
+   Multi-valued attributes in JSON are encoded as arrays, e.g.,
+
+   "attributes": [ "value1", "value2" ]
+
+   Elements with nested elements are represented as objects in
+   JSON, e.g.,
+
+   "attribute": { "subattribute1": "value1", "subattribute2": "value2" }
+
+3.9.  Additional Operation Response Parameters
+
+   For any SCIM operation where a resource representation is returned
+   (e.g., HTTP GET), the attributes returned are defined as the minimum
+   attribute set plus default attribute set.  The minimum set is
+   composed of those attributes that have their "returned"
+   characteristic set to "always" (see Section 2.2 of [RFC7643]).  The
+   default attribute set is composed of those attributes that have the
+   "returned" characteristic set to "default".
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 64]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Clients MAY request a partial resource representation on any
+   operation that returns a resource within the response by specifying
+   either of the mutually exclusive URL query parameters "attributes" or
+   "excludedAttributes", as follows:
+
+   attributes  When specified, the default list of attributes SHALL be
+           overridden, and each resource returned MUST contain the
+           minimum set of resource attributes and any attributes or
+           sub-attributes explicitly requested by the "attributes"
+           parameter.  The query parameter attributes value is a
+           comma-separated list of resource attribute names in standard
+           attribute notation (Section 3.10) form (e.g., userName, name,
+           emails).
+
+   excludedAttributes  When specified, each resource returned MUST
+           contain the minimum set of resource attributes.
+           Additionally, the default set of attributes minus those
+           attributes listed in "excludedAttributes" is returned.  The
+           query parameter attributes value is a comma-separated list of
+           resource attribute names in standard attribute notation
+           (Section 3.10) form (e.g., userName, name, emails).
+
+   GET /Users/2819c223-7f76-453a-919d-413861904646?attributes=userName
+   Host: example.com
+   Accept: application/scim+json
+   Authorization: Bearer h480djs93hd8
+
+   The following response is returned:
+
+   HTTP/1.1 200 OK
+   Content-Type: application/scim+json
+   Location:
+    https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
+   ETag: W/"a330bc54f0671c9"
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "userName":"bjensen"
+   }
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 65]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.10.  Attribute Notation
+
+   All operations share a common scheme for referencing simple and
+   complex attributes.  In general, attributes are uniquely identified
+   by prefixing the attribute name with its schema URN separated by a
+   colon (":") character; e.g., the core User resource attribute
+   'userName' is identified as
+   "urn:ietf:params:scim:schemas:core:2.0:User:userName".  Clients MAY
+   omit core schema attribute URN prefixes but SHOULD fully qualify
+   extended attributes with the associated schema extension URN to avoid
+   naming conflicts.  For example, the attribute 'age' defined in
+   "urn:ietf:params:scim:schemas:exampleCo:2.0:hr" is uniquely
+   identified as "urn:ietf:params:scim:schemas:exampleCo:2.0:hr:age".
+   Complex attributes' sub-attributes are referenced via nested dot
+   ('.') notation, i.e., {urn}:{Attribute name}.{Sub-Attribute name}.
+   For example, the fully qualified path for a User's givenName is
+   "urn:ietf:params:scim:schemas:core:2.0:User:name.givenName".  All
+   facets (URN, attribute, and sub-attribute name) of the fully encoded
+   attribute name are case insensitive.
+
+3.11.  "/Me" Authenticated Subject Alias
+
+   A client MAY use a URL of the form "<base-URI>/Me" as a URI alias for
+   the User or other resource associated with the currently
+   authenticated subject for any SCIM operation.  A service provider MAY
+   respond in one of three ways:
+
+   o  A service provider that does NOT support this feature SHOULD
+      respond with HTTP status code 501 (Not Implemented).
+
+   o  A service provider MAY choose to redirect the client using HTTP
+      status code 308 (Permanent Redirect) to the resource associated
+      with the authenticated subject.  The client MAY then repeat the
+      request at the indicated location.
+
+   o  A service provider MAY process the SCIM request directly.  In any
+      response, the HTTP "Location" header MUST be the permanent
+      location of the aliased resource associated with the authenticated
+      subject.
+
+   When using the SCIM Create Resource command (HTTP POST) with the
+   "/Me" alias, the desired resourceType being created is at the
+   discretion of the service provider, based on the authenticated
+   subject (if not anonymous) making the request and any request body
+   attributes (e.g., "schemas").  See Section 7.6 for information on
+   security considerations related to this operation.
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 66]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+3.12.  HTTP Status and Error Response Handling
+
+   The SCIM protocol uses the HTTP response status codes defined in
+   Section 6 of [RFC7231] to indicate operation success or failure.  In
+   addition to returning an HTTP response code, implementers MUST return
+   the errors in the body of the response in a JSON format, using the
+   attributes described below.  Error responses are identified using the
+   following "schema" URI:
+   "urn:ietf:params:scim:api:messages:2.0:Error".  The following
+   attributes are defined for a SCIM error response using a JSON body:
+
+   status
+      The HTTP status code (see Section 6 of [RFC7231]) expressed as a
+      JSON string.  REQUIRED.
+
+   scimType
+      A SCIM detail error keyword.  See Table 9.  OPTIONAL.
+
+   detail
+      A detailed human-readable message.  OPTIONAL.
+
+   Implementers SHOULD handle the identified HTTP status codes as
+   described below.
+
+   +----------------+---------------+----------------------------------+
+   | Status         | Applicability | Suggested Explanation            |
+   +----------------+---------------+----------------------------------+
+   | 307 (Temporary | GET, POST,    | The client is directed to repeat |
+   | Redirect)      | PUT, PATCH,   | the same HTTP request at the     |
+   |                | DELETE        | location identified.  The client |
+   |                |               | SHOULD NOT use the location      |
+   |                |               | provided in the response as a    |
+   |                |               | permanent reference to the       |
+   |                |               | resource and SHOULD continue to  |
+   |                |               | use the original request URI     |
+   |                |               | [RFC7231].                       |
+   |                |               |                                  |
+   | 308 (Permanent | GET, POST,    | The client is directed to repeat |
+   | Redirect)      | PUT, PATCH,   | the same HTTP request at the     |
+   |                | DELETE        | location identified.  The client |
+   |                |               | SHOULD use the location provided |
+   |                |               | in the response as the permanent |
+   |                |               | reference to the resource        |
+   |                |               | [RFC7538].                       |
+   |                |               |                                  |
+   | 400 (Bad       | GET, POST,    | Request is unparsable,           |
+   | Request)       | PUT, PATCH,   | syntactically incorrect, or      |
+   |                | DELETE        | violates schema.                 |
+
+
+
+Hunt, et al.                 Standards Track                   [Page 67]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   |                |               |                                  |
+   | 401            | GET, POST,    | Authorization failure.  The      |
+   | (Unauthorized) | PUT, PATCH,   | authorization header is invalid  |
+   |                | DELETE        | or missing.                      |
+   |                |               |                                  |
+   | 403            | GET, POST,    | Operation is not permitted based |
+   | (Forbidden)    | PUT, PATCH,   | on the supplied authorization.   |
+   |                | DELETE        |                                  |
+   |                |               |                                  |
+   | 404 (Not       | GET, POST,    | Specified resource (e.g., User)  |
+   | Found)         | PUT, PATCH,   | or endpoint does not exist.      |
+   |                | DELETE        |                                  |
+   |                |               |                                  |
+   | 409 (Conflict) | POST, PUT,    | The specified version number     |
+   |                | PATCH, DELETE | does not match the resource's    |
+   |                |               | latest version number, or a      |
+   |                |               | service provider refused to      |
+   |                |               | create a new, duplicate          |
+   |                |               | resource.                        |
+   |                |               |                                  |
+   | 412            | PUT, PATCH,   | Failed to update.  Resource has  |
+   | (Precondition  | DELETE        | changed on the server.           |
+   | Failed)        |               |                                  |
+   |                |               |                                  |
+   | 413 (Payload   | POST          | {"maxOperations":                |
+   | Too Large)     |               | 1000,"maxPayloadSize": 1048576}  |
+   |                |               |                                  |
+   | 500 (Internal  | GET, POST,    | An internal error.  Implementers |
+   | Server Error)  | PUT, PATCH,   | SHOULD provide descriptive       |
+   |                | DELETE        | debugging advice.                |
+   |                |               |                                  |
+   | 501 (Not       | GET, POST,    | Service provider does not        |
+   | Implemented)   | PUT, PATCH,   | support the request operation,   |
+   |                | DELETE        | e.g., PATCH.                     |
+   +----------------+---------------+----------------------------------+
+
+                   Table 8: SCIM HTTP Status Code Usage
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 68]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   For HTTP status code 400 (Bad Request) responses, the following
+   detail error types are defined:
+
+   +---------------+--------------------------------+------------------+
+   | scimType      | Description                    | Applicability    |
+   +---------------+--------------------------------+------------------+
+   | invalidFilter | The specified filter syntax    | GET (Section     |
+   |               | was invalid (does not comply   | 3.4.2), POST     |
+   |               | with Figure 1), or the         | (Search -        |
+   |               | specified attribute and filter | Section 3.4.3),  |
+   |               | comparison combination is not  | PATCH (Path      |
+   |               | supported.                     | Filter - Section |
+   |               |                                | 3.5.2)           |
+   |               |                                |                  |
+   | tooMany       | The specified filter yields    | GET (Section     |
+   |               | many more results than the     | 3.4.2), POST     |
+   |               | server is willing to calculate | (Search -        |
+   |               | or process.  For example, a    | Section 3.4.3)   |
+   |               | filter such as "(userName pr)" |                  |
+   |               | by itself would return all     |                  |
+   |               | entries with a "userName" and  |                  |
+   |               | MAY not be acceptable to the   |                  |
+   |               | service provider.              |                  |
+   |               |                                |                  |
+   | uniqueness    | One or more of the attribute   | POST (Create -   |
+   |               | values are already in use or   | Section 3.3),    |
+   |               | are reserved.                  | PUT (Section     |
+   |               |                                | 3.5.1), PATCH    |
+   |               |                                | (Section 3.5.2)  |
+   |               |                                |                  |
+   | mutability    | The attempted modification is  | PUT (Section     |
+   |               | not compatible with the target | 3.5.1), PATCH    |
+   |               | attribute's mutability or      | (Section 3.5.2)  |
+   |               | current state (e.g.,           |                  |
+   |               | modification of an "immutable" |                  |
+   |               | attribute with an existing     |                  |
+   |               | value).                        |                  |
+   |               |                                |                  |
+   | invalidSyntax | The request body message       | POST (Search -   |
+   |               | structure was invalid or did   | Section 3.4.3,   |
+   |               | not conform to the request     | Create - Section |
+   |               | schema.                        | 3.3, Bulk -      |
+   |               |                                | Section 3.7),    |
+   |               |                                | PUT (Section     |
+   |               |                                | 3.5.1)           |
+   |               |                                |                  |
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 69]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   | invalidPath   | The "path" attribute was       | PATCH (Section   |
+   |               | invalid or malformed (see      | 3.5.2)           |
+   |               | Figure 7).                     |                  |
+   |               |                                |                  |
+   | noTarget      | The specified "path" did not   | PATCH (Section   |
+   |               | yield an attribute or          | 3.5.2)           |
+   |               | attribute value that could be  |                  |
+   |               | operated on.  This occurs when |                  |
+   |               | the specified "path" value     |                  |
+   |               | contains a filter that yields  |                  |
+   |               | no match.                      |                  |
+   |               |                                |                  |
+   | invalidValue  | A required value was missing,  | GET (Section     |
+   |               | or the value specified was not | 3.4.2), POST     |
+   |               | compatible with the operation  | (Create -        |
+   |               | or attribute type (see Section | Section 3.3,     |
+   |               | 2.2 of [RFC7643]), or resource | Query - Section  |
+   |               | schema (see Section 4 of       | 3.4.3), PUT      |
+   |               | [RFC7643]).                    | (Section 3.5.1), |
+   |               |                                | PATCH (Section   |
+   |               |                                | 3.5.2)           |
+   |               |                                |                  |
+   | invalidVers   | The specified SCIM protocol    | GET (Section     |
+   |               | version is not supported (see  | 3.4.2), POST     |
+   |               | Section 3.13).                 | (ALL), PUT       |
+   |               |                                | (Section 3.5.1), |
+   |               |                                | PATCH (Section   |
+   |               |                                | 3.5.2), DELETE   |
+   |               |                                | (Section 3.6)    |
+   |               |                                |                  |
+   | sensitive     | The specified request cannot   | GET (Section     |
+   |               | be completed, due to the       | 3.4.2)           |
+   |               | passing of sensitive (e.g.,    |                  |
+   |               | personal) information in a     |                  |
+   |               | request URI.  For example,     |                  |
+   |               | personal information SHALL NOT |                  |
+   |               | be transmitted over request    |                  |
+   |               | URIs.  See Section 7.5.2.      |                  |
+   +---------------+--------------------------------+------------------+
+
+                 Table 9: SCIM Detail Error Keyword Values
+
+   Note that in Table 9 above, the information in the Applicability
+   column applies to the normal HTTP method but MAY apply within a SCIM
+   bulk operation (via HTTP POST).
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 70]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Example of an error in response to a non-existent GET request:
+
+   HTTP/1.1 404 Not Found
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+     "detail":"Resource 2819c223-7f76-453a-919d-413861904646 not found",
+     "status": "404"
+   }
+
+   Example of an error in response to a PUT request:
+
+   HTTP/1.1 400 Bad Request
+
+   {
+     "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+     "scimType":"mutability"
+     "detail":"Attribute 'id' is readOnly",
+     "status": "400"
+   }
+
+3.13.  SCIM Protocol Versioning
+
+   The Base URL MAY be appended with a version identifier as a separate
+   segment in the URL path.  At the time of this writing, the identifier
+   is 'v2'.  If specified, the version identifier MUST appear in the URL
+   path immediately preceding the resource endpoint and conform to the
+   following scheme: the character 'v' followed by the desired SCIM
+   version number, e.g., a version 'v2' User request is specified as
+   /v2/Users.  When specified, service providers MUST perform the
+   operation using the desired version or reject the request.  When
+   omitted, service providers SHOULD perform the operation using the
+   most recent SCIM protocol version supported by the service provider.
+
+3.14.  Versioning Resources
+
+   The SCIM protocol supports resource versioning via standard HTTP
+   ETags (Section 2.3 of [RFC7232]).  Service providers MAY support weak
+   ETags as the preferred mechanism for performing conditional
+   retrievals and ensuring that clients do not inadvertently overwrite
+   each other's changes, respectively.  When supported, SCIM ETags MUST
+   be specified as an HTTP header and SHOULD be specified within the
+   'version' attribute contained in the resource's 'meta' attribute.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 71]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Example create request:
+
+   POST /Users  HTTP/1.1
+   Host: example.com
+   Content-Type:  application/scim+json
+   Authorization: Bearer h480djs93hd8
+   Content-Length: ...
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "userName":"bjensen",
+     "externalId":"bjensen",
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara"
+     }
+   }
+
+   The server responds with an ETag in the response header and meta
+   structure:
+
+   HTTP/1.1 201 Created
+   Content-Type: application/scim+json
+   Location:
+    https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646
+   ETag: W/"e180ee84f0671b1"
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "meta":{
+       "resourceType":"User",
+       "created":"2011-08-01T21:32:44.882Z",
+       "lastModified":"2011-08-01T21:32:44.882Z",
+       "location":
+   "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
+       "version":"W\/\"e180ee84f0671b1\""
+     },
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III",
+       "familyName":"Jensen",
+       "givenName":"Barbara"
+     },
+     "userName":"bjensen"
+   }
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 72]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   With the returned ETag, clients MAY choose to retrieve the resource
+   only if the resource has been modified.
+
+   An example of conditional retrieval, using the If-None-Match header
+   (Section 3.2 of [RFC7232]):
+
+  GET /Users/2819c223-7f76-453a-919d-413861904646?attributes=displayName
+  Host: example.com
+  Accept: application/scim+json
+  Authorization: Bearer h480djs93hd8
+  If-None-Match: W/"e180ee84f0671b1"
+
+   If the resource has not changed, the service provider simply returns
+   an empty body with a 304 (Not Modified) response code.
+
+   If the service provider supports versioning of resources, the client
+   MAY supply an If-Match header (Section 3.1 of [RFC7232]) for PUT and
+   PATCH operations to ensure that the requested operation succeeds only
+   if the supplied ETag matches the latest service provider resource,
+   e.g., If-Match: W/"e180ee84f0671b1".
+
+4.  Service Provider Configuration Endpoints
+
+   SCIM defines three endpoints to facilitate discovery of SCIM service
+   provider features and schema that MAY be retrieved using HTTP GET:
+
+   /ServiceProviderConfig
+      An HTTP GET to this endpoint will return a JSON structure that
+      describes the SCIM specification features available on a service
+      provider.  This endpoint SHALL return responses with a JSON object
+      using a "schemas" attribute of
+      "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig".
+      The attributes returned in the JSON object are defined in
+      Section 5 of [RFC7643].  An example representation of SCIM service
+      provider configuration may be found in Section 8.5 of [RFC7643].
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 73]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   /Schemas
+      An HTTP GET to this endpoint is used to retrieve information about
+      resource schemas supported by a SCIM service provider.  An HTTP
+      GET to the endpoint "/Schemas" SHALL return all supported schemas
+      in ListResponse format (see Figure 3).  Individual schema
+      definitions can be returned by appending the schema URI to the
+      /Schemas endpoint.  For example:
+
+            /Schemas/urn:ietf:params:scim:schemas:core:2.0:User
+
+      The contents of each schema returned are described in Section 7 of
+      [RFC7643].  An example representation of SCIM schemas may be found
+      in Section 8.7 of [RFC7643].
+
+   /ResourceTypes
+      An HTTP GET to this endpoint is used to discover the types of
+      resources available on a SCIM service provider (e.g., Users and
+      Groups).  Each resource type defines the endpoints, the core
+      schema URI that defines the resource, and any supported schema
+      extensions.  The attributes defining a resource type can be found
+      in Section 6 of [RFC7643], and an example representation can be
+      found in Section 8.6 of [RFC7643].
+
+   In cases where a request is for a specific "ResourceType" or
+   "Schema", the single JSON object is returned in the same way that a
+   single User or Group is retrieved, as per Section 3.4.1.  When
+   returning multiple ResourceTypes or Schemas, the message form
+   described by the "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+   (ListResponse) form SHALL be used as shown in Figure 3 and in
+   Figure 9 below.  Query parameters described in Section 3.4.2, such as
+   filtering, sorting, and pagination, SHALL be ignored.  If a "filter"
+   is provided, the service provider SHOULD respond with HTTP status
+   code 403 (Forbidden) to ensure that clients cannot incorrectly assume
+   that any matching conditions specified in a filter are true.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 74]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The following is a non-normative example of an HTTP GET to the
+   /ResourceTypes endpoint:
+
+  {
+    "totalResults":2,
+    "itemsPerPage":10,
+    "startIndex":1,
+    "schemas":["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+    "Resources":[{
+      "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+      "id":"User",
+      "name":"User",
+      "endpoint": "/Users",
+      "description": "User Account",
+      "schema": "urn:ietf:params:scim:schemas:core:2.0:User",
+      "schemaExtensions": [{
+        "schema":
+          "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+        "required": true
+      }],
+      "meta": {
+        "location":"https://example.com/v2/ResourceTypes/User",
+        "resourceType": "ResourceType"
+      }
+    },
+   {
+     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:ResourceType"],
+     "id":"Group",
+     "name":"Group",
+     "endpoint": "/Groups",
+     "description": "Group",
+     "schema": "urn:ietf:params:scim:schemas:core:2.0:Group",
+     "meta": {
+       "location":"https://example.com/v2/ResourceTypes/Group",
+       "resourceType": "ResourceType"
+     }
+   }]
+  }
+
+            Figure 9: Example Resource Type JSON Representation
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 75]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+5.  Preparation and Comparison of Internationalized Strings
+
+   To increase the likelihood that the input and comparison of usernames
+   and passwords will work in ways that make sense for typical users
+   throughout the world, there are rules for preparing, enforcing, and
+   comparing internationalized strings that represent usernames and
+   passwords.  Before comparing or evaluating the uniqueness of a
+   "userName" or "password" attribute, service providers MUST use the
+   preparation, enforcement, and comparison of internationalized strings
+   (PRECIS) preparation and comparison rules described in Sections 3 and
+   4, respectively, of [RFC7613], which is based on the PRECIS framework
+   specification [RFC7564].  See Section 3.4 of [RFC7613] for discussion
+   on "Case Mapping vs. Case Preparation" regarding "userName"
+   attributes.
+
+6.  Multi-Tenancy
+
+   A single service provider may expose the SCIM protocol to multiple
+   clients.  Depending on the nature of the service, the clients may
+   have authority to access and alter resources initially created by
+   other clients.  Alternatively, clients may expect to access disjoint
+   sets of resources and may expect that their resources are
+   inaccessible to other clients.  These scenarios are called
+   "multi-tenancy", where each client is understood to be or represent
+   a "tenant" of the service provider.  Clients may also be
+   multi-tenanted.
+
+   The following common cases may occur:
+
+   1.  All clients share all resources (no tenancy).
+
+   2.  Each single client creates and accesses a private subset of
+       resources (1 client:1 Tenant).
+
+   3.  Sets of clients share sets of resources (M clients:1 Tenant).
+
+   4.  One client can create and access several private subsets of
+       resources (1 client:M Tenants).
+
+   Service providers may implement any subset of the above cases.
+
+   Multi-tenancy is OPTIONAL.  The SCIM protocol does not define a
+   scheme for multi-tenancy.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 76]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   The SCIM protocol does not prescribe the mechanisms whereby clients
+   and service providers interact for the following:
+
+   o  Registering or provisioning Tenants
+
+   o  Associating a subset of clients with a subset of the Tenants
+
+   o  Indicating which tenant is associated with the data in a request
+      or response, or indicating which Tenant is the subject of a query
+
+6.1.  Associating Clients to Tenants
+
+   The service provider MAY use one of the authentication mechanisms
+   discussed in Section 2 to determine the identity of the client and
+   thus infer the associated Tenant.
+
+   For implementations where a client is associated with more than one
+   Tenant, the service provider MAY use one of the three methods below
+   for explicit specification of the Tenant.
+
+   If any of these methods of allowing the client to explicitly specify
+   the Tenant are employed, the service provider should ensure that
+   access controls are in place to prevent or allow cross-tenant use
+   cases.
+
+   The service provider should consider precedence in cases where a
+   client may explicitly specify a Tenant while being implicitly
+   associated with a different Tenant.
+
+   In all of these methods, the {tenant_id} is a unique identifier for
+   the Tenant as defined by the service provider.
+
+   o  A URL prefix: "https://www.example.com/Tenants/{tenant_id}/v2/
+      Users".
+
+   o  A sub-domain: "https://{tenant_id}.example.com/v2/Groups".
+
+   o  An HTTP header: The service provider may recognize a {tenant_id}
+      provided by the client in an HTTP header as the indicator of the
+      desired target Tenant.
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 77]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+6.2.  SCIM Identifiers with Multiple Tenants
+
+   Considerations for a multi-tenant implementation:
+
+   o  The service provider may choose to implement SCIM ids that are
+      unique across all resources for all Tenants, but this is not
+      required.
+
+   o  The externalId, defined by the client, is required to be unique
+      ONLY within the resources associated with the associated Tenant.
+
+7.  Security Considerations
+
+7.1.  HTTP Considerations
+
+   The SCIM protocol layers on top of HTTP and is thus subject to the
+   security considerations of HTTP (Section 9 of [RFC7230]) and its
+   related specifications.
+
+   As stated in Section 2.7.1 of [RFC7230], a SCIM client MUST NOT
+   generate the "userinfo" (i.e., username and password) component
+   (and its "@" delimiter) when an "http" URI reference is generated
+   with a message, as userinfo and its "@" delimiter are now disallowed
+   in HTTP.
+
+7.2.  TLS Support Considerations
+
+   SCIM resources (e.g., Users and Groups) contain sensitive
+   information, including passwords.  Therefore, SCIM clients and
+   service providers MUST require the use of a transport-layer security
+   mechanism when communicating with SCIM service providers.  The SCIM
+   service provider MUST support TLS 1.2 [RFC5246] and MAY support
+   additional transport-layer mechanisms meeting its security
+   requirements.  When using TLS, the client MUST perform a TLS/SSL
+   server identity check, per [RFC6125].  Implementation security
+   considerations for TLS can be found in [RFC7525].
+
+7.3.  Authorization Token Considerations
+
+   When using authorization tokens such as those issued by OAuth 2.0
+   [RFC6749], implementers MUST take into account threats and
+   countermeasures as documented in Section 8 of [RFC7521].
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 78]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+7.4.  Bearer Token and Cookie Considerations
+
+   Since the possession of a bearer token or cookie MAY authorize the
+   holder to potentially read, modify, or delete resources, bearer
+   tokens and cookies MUST contain sufficient entropy to prevent a
+   random guessing attack; for example, see Section 5.2 of [RFC6750] and
+   Section 5.1.4.2.2 of [RFC6819].
+
+   As with all SCIM communications, bearer tokens and HTTP cookies MUST
+   be exchanged using TLS.
+
+   Bearer tokens MUST have a limited lifetime that can be determined
+   directly or indirectly (e.g., by checking with a validation service)
+   by the service provider.  By expiring tokens, clients are forced to
+   obtain a new token (which usually involves re-authentication) for
+   continued authorized access.  For example, in OAuth 2.0, a client MAY
+   use OAuth token refresh to obtain a new bearer token after
+   authenticating to an authorization server.  See Section 6 of
+   [RFC6749].
+
+   As with bearer tokens, an HTTP cookie SHOULD last no longer than the
+   lifetime of a browser session.  An expiry time should be set that
+   limits session cookie lifetime as per Section 5.2.1 of [RFC6265].
+
+   Implementations supporting OAuth bearer tokens need to factor in
+   security considerations of this authorization method [RFC7521].
+   Since security is only as good as the weakest link, implementers also
+   need to consider authentication choices coupled with OAuth bearer
+   tokens.  The security considerations of the default authentication
+   method for OAuth bearer tokens, HTTP Basic, are well documented in
+   [HTTP-BASIC-AUTH]; therefore, implementers are encouraged to use
+   stronger authentication methods.  Designating the specific methods of
+   authentication and authorization is out of scope for SCIM; however,
+   this information is provided as a resource to implementers.
+
+7.5.  Privacy Considerations
+
+7.5.1.  Personal Information
+
+   The SCIM Core Schema specification [RFC7643] defines attributes that
+   may contain personally identifying information as well as other
+   sensitive personal data.  The privacy considerations in the Security
+   Considerations section of [RFC7643] MUST be considered.
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 79]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+7.5.2.  Disclosure of Sensitive Information in URIs
+
+   As mentioned in Section 9.4 of [RFC7231], SCIM clients requesting
+   information using query filters that use HTTP GET SHOULD give
+   consideration to the information content of the filters and whether
+   or not their exposure in a URI would represent a breach of security
+   or confidentiality through leakage in web browsers or server logs.
+   This is particularly true for information that is legally considered
+   "personally identifiable information" or is otherwise restricted by
+   privacy laws.  In these situations, to ensure maximum security and
+   confidentiality, clients SHOULD query using HTTP POST (see
+   Section 3.4.3).
+
+   Servers that receive HTTP GET requests using filters that contain
+   sensitive or confidential personal information SHOULD respond with
+   HTTP status code 403 to indicate that the operation is forbidden.  A
+   "scimType" error code of "sensitive" may be returned to indicate that
+   the request must be submitted using POST.  The following is a
+   non-normative example:
+
+  HTTP/1.1 403 Forbidden
+
+  {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+    "detail":
+          "Query filter involving 'name' is restricted or confidential",
+    "scimType": "sensitive",
+    "status": "404"
+  }
+
+7.6.  Anonymous Requests
+
+   If a SCIM service provider accepts anonymous requests such as SCIM
+   resource creation requests (via HTTP POST), appropriate security
+   measures should be put in place to prevent or limit exposure to
+   attacks.  The following countermeasures MAY be used:
+
+   o  Try to authenticate web user interface components that formulate
+      the SCIM creation request.  While the end-user may be anonymous,
+      the web user interface component often has its own way to
+      authenticate to the SCIM service provider (e.g., has an OAuth
+      client credential [RFC6749]), and the web user interface component
+      may implement its own measures (e.g., the Completely Automated
+      Public Turing test to tell Computers and Humans Apart (CAPTCHA))
+      to ensure that a legitimate request is being made.
+
+   o  Limit the number of requests that any particular client MAY make
+      in a period of time.
+
+
+
+Hunt, et al.                 Standards Track                   [Page 80]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   o  For User resources, default newly created resources with an
+      "active" setting of "false", and use a secondary confirmation
+      process (e.g., email confirmation) to ensure that the resource
+      created is real.
+
+7.7.  Secure Storage and Handling of Sensitive Data
+
+   An attacker may obtain valid username/password combinations from the
+   SCIM service provider's underlying database by gaining access to the
+   database and/or launching injection attacks.  This could lead to
+   unintended disclosure of username/password combinations.  The impact
+   may extend beyond the domain of the SCIM service provider if the data
+   was provisioned from other domains.
+
+   Administrators should undertake industry best practices to protect
+   the storage of credentials and, in particular, SHOULD follow
+   recommendations outlined in Section 5.1.4.1 of [RFC6819].  These
+   recommendations include, but are not limited to, the following:
+
+   o  Provide injection attack countermeasures (e.g., by validating all
+      inputs and parameters);
+
+   o  Credentials should not be stored in cleartext form;
+
+   o  Store credentials using an encrypted protection mechanism (e.g.,
+      hashing); and
+
+   o  Where possible, avoid passwords as the sole form of
+      authentication, and consider using credentials that are based on
+      asymmetric cryptography.
+
+   As outlined in Section 5.1.4.2 of [RFC6819], administrators SHOULD
+   take countermeasures such as the following, to prevent online attacks
+   on secrets:
+
+   o  Utilize a secure password policy in order to increase user
+      password entropy, which will in turn hinder online attacks and
+      password guessing;
+
+   o  Mitigate attacks on passwords by locking respective accounts that
+      have a number of failed attempts;
+
+   o  Use "tar pit" techniques by temporarily locking a respective
+      account and delaying responses for a certain duration.  The
+      duration may increase with the number of failed attempts; and
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 81]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   o  Use authentication systems that use CAPTCHAs and other factors for
+      authenticating users, to further reduce the possibility of
+      automated attacks.
+
+   Service providers SHOULD define an access control model that
+   differentiates between individual client applications and their
+   specific need to access information, and any User self-service rights
+   to review and update personal profile information.  This may include
+   OAuth 2.0 delegation profiles that allow client systems to act on
+   behalf of users with their permission.
+
+7.8.  Case-Insensitive Comparison and International Languages
+
+   When comparing Unicode strings such as those in query filters or
+   testing for uniqueness of usernames and passwords, strings MUST be
+   appropriately prepared before comparison.  See Section 5.
+
+8.  IANA Considerations
+
+8.1.  Media Type Registration
+
+   To:  ietf-types@iana.org
+
+   Subject:  Registration of media type application/scim+json
+
+   Type name:  application
+
+   Subtype name:  scim+json
+
+   Required parameters:  none
+
+   Optional parameters:  none
+
+   Encoding considerations:  8bit
+
+   Security considerations:  See Section 7 of this document (RFC 7644)
+
+   Interoperability considerations:  The "application/scim+json" media
+      type is intended to identify JSON structure data that conforms to
+      the SCIM protocol and schema specifications.  Older versions of
+      SCIM are known to informally use "application/json".
+
+   Published specification:  this document (RFC 7644)
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 82]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   Applications that use this media type:  It is expected that
+      applications that use this type may be special-purpose
+      applications intended for inter-domain provisioning.  Clients may
+      also be applications (e.g., mobile applications) that need to use
+      SCIM for self-registration of user accounts.  SCIM services may be
+      offered by web applications that offer support for standards-based
+      provisioning or may be a dedicated SCIM service provider such as a
+      "cloud directory".  Content may be treated as equivalent to the
+      "application/json" type for the purpose of displaying in web
+      browsers.
+
+   Additional information:
+
+         Magic number(s):
+
+         File extension(s): .scim .scm
+
+         Macintosh file type code(s):
+
+   Person & email address to contact for further information:  SCIM
+      mailing list "<scim@ietf.org>"
+
+   Intended usage:  COMMON* (see restrictions)
+
+   Restrictions on usage:  For most client types, it is sufficient to
+      recognize the content as equivalent to "application/json".
+      Applications intending to use the SCIM protocol SHOULD use the
+      "application/scim+json" media type.
+
+   Author:  Phil Hunt
+
+   Change controller:  IETF
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 83]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+8.2.  Registering URIs for SCIM Messages
+
+   As per the "SCIM Schema URIs for Data Resources" registry established
+   by [RFC7643], the following defines and registers the SCIM protocol
+   request/response JSON schema URN identifier prefix of
+   "urn:ietf:params:scim:api:messages:2.0", which is part of the
+   URN sub-namespace for SCIM.  There is no specific associated
+   resource type.
+
+   +---------------------------------+-----------------+---------------+
+   | Schema URI                      | Name            | Reference     |
+   +---------------------------------+-----------------+---------------+
+   | urn:ietf:params:scim:api:       | List/Query      | See Section   |
+   | messages:2.0:ListResponse       | Response        | 3.4.2         |
+   |                                 |                 |               |
+   | urn:ietf:params:scim:api:       | POST Query      | See Section   |
+   | messages:2.0:SearchRequest      | Request         | 3.4.3         |
+   |                                 |                 |               |
+   | urn:ietf:params:scim:api:       | PATCH Operation | See Section   |
+   | messages:2.0:PatchOp            |                 | 3.5.2         |
+   |                                 |                 |               |
+   | urn:ietf:params:scim:api:       | Bulk Operations | See Section   |
+   | messages:2.0:BulkRequest        | Request         | 3.7           |
+   |                                 |                 |               |
+   | urn:ietf:params:scim:api:       | Bulk Operations | See Section   |
+   | messages:2.0:BulkResponse       | Response        | 3.7           |
+   |                                 |                 |               |
+   | urn:ietf:params:scim:api:       | Error Response  | See Section   |
+   | messages:2.0:Error              |                 | 3.12          |
+   +---------------------------------+-----------------+---------------+
+
+               Table 10: SCIM Schema URIs for Data Resources
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 84]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC3629]  Yergeau, F., "UTF-8, a transformation format of
+              ISO 10646", STD 63, RFC 3629, DOI 10.17487/RFC3629,
+              November 2003, <http://www.rfc-editor.org/info/rfc3629>.
+
+   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
+              Resource Identifier (URI): Generic Syntax", STD 66,
+              RFC 3986, DOI 10.17487/RFC3986, January 2005,
+              <http://www.rfc-editor.org/info/rfc3986>.
+
+   [RFC5234]  Crocker, D., Ed., and P. Overell, "Augmented BNF for
+              Syntax Specifications: ABNF", STD 68, RFC 5234,
+              DOI 10.17487/RFC5234, January 2008,
+              <http://www.rfc-editor.org/info/rfc5234>.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246,
+              DOI 10.17487/RFC5246, August 2008,
+              <http://www.rfc-editor.org/info/rfc5246>.
+
+   [RFC5789]  Dusseault, L. and J. Snell, "PATCH Method for HTTP",
+              RFC 5789, DOI 10.17487/RFC5789, March 2010,
+              <http://www.rfc-editor.org/info/rfc5789>.
+
+   [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
+              Verification of Domain-Based Application Service Identity
+              within Internet Public Key Infrastructure Using X.509
+              (PKIX) Certificates in the Context of Transport Layer
+              Security (TLS)", RFC 6125, DOI 10.17487/RFC6125,
+              March 2011, <http://www.rfc-editor.org/info/rfc6125>.
+
+   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
+              RFC 6749, DOI 10.17487/RFC6749, October 2012,
+              <http://www.rfc-editor.org/info/rfc6749>.
+
+   [RFC6750]  Jones, M. and D. Hardt, "The OAuth 2.0 Authorization
+              Framework: Bearer Token Usage", RFC 6750,
+              DOI 10.17487/RFC6750, October 2012,
+              <http://www.rfc-editor.org/info/rfc6750>.
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 85]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   [RFC7159]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
+              Interchange Format", RFC 7159, DOI 10.17487/RFC7159,
+              March 2014, <http://www.rfc-editor.org/info/rfc7159>.
+
+   [RFC7230]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+              Transfer Protocol (HTTP/1.1): Message Syntax and Routing",
+              RFC 7230, DOI 10.17487/RFC7230, June 2014,
+              <http://www.rfc-editor.org/info/rfc7230>.
+
+   [RFC7231]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+              Transfer Protocol (HTTP/1.1): Semantics and Content",
+              RFC 7231, DOI 10.17487/RFC7231, June 2014,
+              <http://www.rfc-editor.org/info/rfc7231>.
+
+   [RFC7232]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+              Transfer Protocol (HTTP/1.1): Conditional Requests",
+              RFC 7232, DOI 10.17487/RFC7232, June 2014,
+              <http://www.rfc-editor.org/info/rfc7232>.
+
+   [RFC7235]  Fielding, R., Ed., and J. Reschke, Ed., "Hypertext
+              Transfer Protocol (HTTP/1.1): Authentication", RFC 7235,
+              DOI 10.17487/RFC7235, June 2014,
+              <http://www.rfc-editor.org/info/rfc7235>.
+
+   [RFC7538]  Reschke, J., "The Hypertext Transfer Protocol Status
+              Code 308 (Permanent Redirect)", RFC 7538,
+              DOI 10.17487/RFC7538, April 2015,
+              <http://www.rfc-editor.org/info/rfc7538>.
+
+   [RFC7613]  Saint-Andre, P. and A. Melnikov, "Preparation,
+              Enforcement, and Comparison of Internationalized Strings
+              Representing Usernames and Passwords", RFC 7613,
+              DOI 10.17487/RFC7613, August 2015,
+              <http://www.rfc-editor.org/info/rfc7613>.
+
+   [RFC7643]  Hunt, P., Ed., Grizzle, K., Wahlstroem, E., and
+              C. Mortimore, "System for Cross-domain Identity
+              Management: Core Schema", RFC 7643, DOI 10.17487/RFC7643,
+              September 2015, <http://www.rfc-editor.org/info/rfc7643>.
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 86]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+9.2.  Informative References
+
+   [HTTP-BASIC-AUTH]
+              Reschke, J., "The 'Basic' HTTP Authentication Scheme",
+              Work in Progress, draft-ietf-httpauth-basicauth-update-07,
+              February 2015.
+
+   [OAuth-PoP-Arch]
+              Hunt, P., Ed., Richer, J., Mills, W., Mishra, P., and H.
+              Tschofenig, "OAuth 2.0 Proof-of-Possession (PoP) Security
+              Architecture", Work in Progress,
+              draft-ietf-oauth-pop-architecture-02, July 2015.
+
+   [OpenSearch]
+              Clinton, D., "OpenSearch Protocol 1.1, Draft 5",
+              December 2005, <http://www.opensearch.org/Specifications/
+              OpenSearch/1.1>.
+
+   [RFC6265]  Barth, A., "HTTP State Management Mechanism", RFC 6265,
+              DOI 10.17487/RFC6265, April 2011,
+              <http://www.rfc-editor.org/info/rfc6265>.
+
+   [RFC6819]  Lodderstedt, T., Ed., McGloin, M., and P. Hunt, "OAuth 2.0
+              Threat Model and Security Considerations", RFC 6819,
+              DOI 10.17487/RFC6819, January 2013,
+              <http://www.rfc-editor.org/info/rfc6819>.
+
+   [RFC6902]  Bryan, P., Ed., and M. Nottingham, Ed., "JavaScript Object
+              Notation (JSON) Patch", RFC 6902, DOI 10.17487/RFC6902,
+              April 2013, <http://www.rfc-editor.org/info/rfc6902>.
+
+   [RFC7486]  Farrell, S., Hoffman, P., and M. Thomas, "HTTP Origin-
+              Bound Authentication (HOBA)", RFC 7486,
+              DOI 10.17487/RFC7486, March 2015,
+              <http://www.rfc-editor.org/info/rfc7486>.
+
+   [RFC7521]  Campbell, B., Mortimore, C., Jones, M., and Y. Goland,
+              "Assertion Framework for OAuth 2.0 Client Authentication
+              and Authorization Grants", RFC 7521, DOI 10.17487/RFC7521,
+              May 2015, <http://www.rfc-editor.org/info/rfc7521>.
+
+   [RFC7525]  Sheffer, Y., Holz, R., and P. Saint-Andre,
+              "Recommendations for Secure Use of Transport Layer
+              Security (TLS) and Datagram Transport Layer Security
+              (DTLS)", BCP 195, RFC 7525, DOI 10.17487/RFC7525,
+              May 2015, <http://www.rfc-editor.org/info/rfc7525>.
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 87]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+   [RFC7564]  Saint-Andre, P. and M. Blanchet, "PRECIS Framework:
+              Preparation, Enforcement, and Comparison of
+              Internationalized Strings in Application Protocols",
+              RFC 7564, DOI 10.17487/RFC7564, May 2015,
+              <http://www.rfc-editor.org/info/rfc7564>.
+
+   [XML-Schema]
+              Biron, P. and A. Malhotra, "XML Schema Part 2: Datatypes
+              Second Edition", W3C Recommendation, October 2004,
+              <http://www.w3.org/TR/xmlschema-2/>.
+
+Acknowledgements
+
+   The editor would like to acknowledge the contribution and work of the
+   editors of draft versions of this document:
+
+      Trey Drake, UnboundID
+
+      Chuck Mortimore, Salesforce
+
+   The editor would like to thank the participants in the SCIM working
+   group for their support of this specification.
+
+Contributors
+
+   Samuel Erdtman (samuel@erdtman.se)
+
+   Patrick Harding (pharding@pingidentity.com)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 88]
+
+RFC 7644               SCIM Protocol Specification        September 2015
+
+
+Authors' Addresses
+
+   Phil Hunt (editor)
+   Oracle Corporation
+
+   Email: phil.hunt@yahoo.com
+
+
+   Kelly Grizzle
+   SailPoint
+
+   Email: kelly.grizzle@sailpoint.com
+
+
+   Morteza Ansari
+   Cisco
+
+   Email: morteza.ansari@cisco.com
+
+
+   Erik Wahlstroem
+   Nexus Technology
+
+   Email: erik.wahlstrom@nexusgroup.com
+
+
+   Chuck Mortimore
+   Salesforce.com
+
+   Email: cmortimore@salesforce.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hunt, et al.                 Standards Track                   [Page 89]
+

--- a/docs/event-specs/rfc9967.txt
+++ b/docs/event-specs/rfc9967.txt
@@ -1,0 +1,1577 @@
+﻿
+
+
+
+Internet Engineering Task Force (IETF)                      P. Hunt, Ed.
+Request for Comments: 9967                                Independent Id
+Updates: 7643, 7644                                        N. Cam-Winget
+Category: Standards Track                                  Cisco Systems
+ISSN: 2070-1721                                                 M. Kiser
+                                                               Sailpoint
+                                                            J. Schreiber
+                                                                 Workday
+                                                                May 2026
+
+
+System for Cross-Domain Identity Management (SCIM) Profile for Security
+                          Event Tokens (SETs)
+
+Abstract
+
+   This specification defines a set of System for Cross-domain Identity
+   Management (SCIM) Security Events using the Security Event Token
+   (SET) specification (RFC 8417) to enable the asynchronous exchange of
+   messages between SCIM service providers and receivers.
+
+   This specification updates RFC 7643 by defining additional attributes
+   for the "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"
+   schema, and it updates RFC 7644 with an optional new asynchronous
+   SCIM request capability.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   https://www.rfc-editor.org/info/rfc9967.
+
+Copyright Notice
+
+   Copyright (c) 2026 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Revised BSD License text as described in Section 4.e of the
+   Trust Legal Provisions and are provided without warranty as described
+   in the Revised BSD License.
+
+Table of Contents
+
+   1.  Introduction and Overview
+     1.1.  Requirements Language
+     1.2.  Notational Conventions
+     1.3.  Definitions
+   2.  SCIM Events
+     2.1.  Identifying the Subject of an Event
+     2.2.  Common Event Attributes
+     2.3.  SCIM Feed Events
+       2.3.1.  urn:ietf:params:scim:event:feed:add
+       2.3.2.  urn:ietf:params:scim:event:feed:remove
+     2.4.  SCIM Provisioning Events
+       2.4.1.  urn:ietf:params:scim:event:prov:create:{notice|full}
+       2.4.2.  urn:ietf:params:scim:event:prov:patch:{notice|full}
+       2.4.3.  urn:ietf:params:scim:event:prov:put:{notice|full}
+       2.4.4.  urn:ietf:params:scim:event:prov:delete
+       2.4.5.  urn:ietf:params:scim:event:prov:activate
+       2.4.6.  urn:ietf:params:scim:event:prov:deactivate
+     2.5.  Miscellaneous Events
+       2.5.1.  Asynchronous Events
+   3.  Set-Txn HTTP Response Header for Asynchronous Requests
+   4.  Events Discovery Schema for Service Provider Configuration
+   5.  Security Considerations
+   6.  Privacy Considerations
+   7.  IANA Considerations
+     7.1.  SCIM Asynchronous Set-Txn Header Registration
+     7.2.  Registering Event Capability with SCIM Service Provider
+           Configuration
+     7.3.  Creation of the SCIM Event URIs Registry
+     7.4.  Initial Contents of the SCIM Event URIs Registry
+   8.  References
+     8.1.  Normative References
+     8.2.  Informative References
+   Appendix A.  Use Cases
+     A.1.  Domain-Based Replication
+     A.2.  Coordinated Provisioning
+   Acknowledgements
+   Authors' Addresses
+
+1.  Introduction and Overview
+
+   This specification defines Security Events for SCIM service providers
+   and receivers as specified by Security Event Tokens (SETs) [RFC8417].
+   In this specification, SCIM Security Events include asynchronous
+   request completion, resource replication, and provisioning
+   coordination.
+
+   This specification defines the use of the HTTP header "Prefer:
+   respond-async" [RFC7240] to allow a SCIM client [RFC7644] to request
+   an asynchronous response (see Section 2.5.1.1).
+
+   Using the HTTP protocol, a SCIM client issues commands to a SCIM
+   service provider using HTTP methods such as POST, PATCH, and DELETE
+   [RFC7644] that cause a state change to a SCIM resource.  When
+   multiple independent SCIM clients update SCIM resources, individual
+   clients become out of date as state changes occur.  Some clients may
+   need to be informed of these changes for coordination or
+   reconciliation purposes.  This could be done using periodic SCIM GET
+   requests over time, but this rapidly becomes problematic as the
+   number of changes and the number of resources increases.
+
+   SCIM Events can be shared over an established event feed enabling
+   receivers to monitor and trigger independent asynchronous action.
+   This approach enables greater scale and timeliness, where only
+   changed information is exchanged between parties.
+
+   A SET conveys information about a state change that has occurred at a
+   SCIM service provider.  That SET may be of interest to one or more
+   receivers.  But instead of interpreting SETs as commands, each Event
+   Receiver is able to determine the best local follow-up action to take
+   within its own context.  For example, a receiver can reconcile schema
+   and resource type differences between domains.
+
+1.1.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+1.2.  Notational Conventions
+
+   Throughout this document, all figures may contain spaces and extra
+   line wrapping for readability and space limitations.  Similarly, some
+   URIs contained within examples have been shortened for space and
+   readability reasons.
+
+1.3.  Definitions
+
+   This specification uses definitions from the following
+   specifications:
+
+   *  "JSON Web Token (JWT)" [RFC7519],
+
+   *  "Security Event Token (SET)" [RFC8417], and
+
+   *  "System for Cross-domain Identity Management: Protocol" [RFC7644].
+
+   In JSON Web Tokens (JWTs) and Security Event Tokens, the term "claim"
+   refers to JSON attribute values contained in a JWT [RFC7519]
+   structure.  The term "claim" in tokens is used to indicate that an
+   attribute value may not be verified and its accuracy can be
+   questioned.  In the context of SCIM, this distinction is not made.
+   For this specification, the terms "claims" and "attributes" are
+   interchangeable.  For consistency, JWT and SET attributes registered
+   by IANA will continue to be called "claims", while event information
+   attributes (i.e., those in an event payload) will be referred to as
+   "attributes".
+
+   Additionally, the following terms are defined:
+
+   Attributes and Claims:
+      The JWT specification [RFC7519], upon which SET is based, uses the
+      term "claims" to refer to attributes in a JSON Web Token.  In
+      contrast, SCIM uses the term "attributes" to refer to JSON
+      attributes.  For the purposes of this document, the terms
+      "attributes" and "claims" are equivalent.
+
+   Coordinated Provisioning (CP):
+      As defined in Appendix A.2, in CP relationships, an Event
+      Publisher and Receiver typically exchange resource change events
+      without exchanging data (see Section 2.4).  For a receiver to know
+      the value of the data, the Event Receiver usually calls back to
+      the SCIM Event Publisher domain to receive a new copy of data
+      (e.g., uses a SCIM GET request).
+
+   Domain-Based Replication (DBR):
+      As defined in Appendix A.1, in the DBR mode, there is an
+      administrative relationship spanning multiple operational domains;
+      data shared in Events typically uses the "full" mode variation of
+      change events (see Section 2.4) including the "data" payload
+      attribute.  This eliminates the need for a callback to retrieve
+      additional data.
+
+   Event Feed / Event Stream:
+      An event feed (or equivalently an event stream) is a logical
+      series of events shared with a unique receiving client.  A SET
+      transfer (see [RFC8935] and [RFC8936]) service provider may offer
+      to allow Event Receivers to "subscribe" to specific event types or
+      events about specific resources (see feed events in Section 2.3).
+
+   Event Receiver:
+      An entity typically receives events as described in [RFC8935] and
+      [RFC8936] or via HTTP GET (see Section 2.5.1.1).  In the case of
+      push-based SET delivery [RFC8935], the Event Receiver is an HTTP
+      endpoint that receives requests.  In the case of poll-based SET
+      delivery [RFC8936], the receiver is an HTTP client that initiates
+      HTTP requests to an Event Publisher endpoint.
+
+   Event Publisher:
+      A system that issues SETs based on a resource state change that
+      has occurred at a SCIM service provider.  For example, events may
+      be the result of a SCIM Create, Modify, or Delete operation as
+      defined in Section 3 of [RFC7644].  A SCIM service provider may be
+      an Event Publisher or an independent service that aggregates
+      events into Event Receiver feeds.  As described above, when using
+      [RFC8935], the Event Publisher is an HTTP client that initiates
+      HTTP POST requests to a defined Event Receiver endpoint.  When
+      using [RFC8936], the Event Publisher provides an HTTP endpoint,
+      which a receiver may use to "poll" for Security Events.
+
+   SCIM Client:
+      An HTTP client that initiates SCIM protocol [RFC7644] requests and
+      receives responses that may cause SCIM Events to be issued by the
+      SCIM service provider.  A SCIM client may also be an Event
+      Receiver, typically when making an asynchronous SCIM request (see
+      Section 2.5.1.1).
+
+   SCIM Service Provider:
+      An HTTP server that implements the SCIM protocol [RFC7644] and
+      SCIM schema [RFC7643].  Upon processing a state change to a SCIM
+      resource, it issues a SCIM Event or causes an Event Publisher to
+      issue a SCIM Event.
+
+   Security Event Token (SET):
+      As defined in [RFC8417].
+
+2.  SCIM Events
+
+   A SCIM Event is a signal, in the form of a Security Event Token
+   [RFC8417], that describes some event that has occurred.  A SET event
+   consists of a set of standard JWT "top-level" claims and an "events"
+   claim that contains one or more event URI subclaims (JSON attributes)
+   each with a JSON object containing relevant event information.
+
+   This specification defines the new URI prefix
+   "urn:ietf:params:scim:event", which is used as the prefix for the
+   defined SCIM Events (see Section 7.3).  Events are grouped into one
+   of two sub-namespaces: "feed" (feed control notices) or "prov"
+   (provisioning).
+
+2.1.  Identifying the Subject of an Event
+
+   SCIM Events MUST use the "sub_id" claim, defined by [RFC9493], to
+   identify the subject of events.  The "sub_id" claim MUST be contained
+   within the main JWT claims body and MUST NOT be located within an
+   event payload within the "events" claim.  A SET with multiple event
+   URIs indicates that the events arise from the same transaction or
+   resource state change for a single resource or subject.
+
+   The JWT "sub" claim MUST NOT be used to identify subjects to prevent
+   confusion with JWT authorization tokens (originally recommended in
+   Section 3 of [RFC8417]).
+
+   {
+        "iss": "issuer.example.com",
+        "iat": 1508184845,
+        "aud": "aud.example.com",
+        "sub_id": {
+           "format": "scim",
+           "uri": "/Users/2b2f880af6674ac284bae9381673d462",
+           "externalId": "alice@example.com"
+        },
+        "events": {
+          ...
+        }
+   }
+
+                     Figure 1: Example SCIM Subject Id
+
+   Instead of "sub", the top-level claim "sub_id" SHALL be used.
+   "sub_id" contains the subclaim attribute "format" set to "scim" to
+   indicate that the attributes present in the "sub_id" object are SCIM
+   attributes.  The following "sub_id" attributes are defined:
+
+   uri:
+      The SCIM relative path for the resource that usually consists of
+      the resource type endpoint plus the resource "id" (see Section 3.2
+      of [RFC7644]), for example,
+      "/Users/2b2f880af6674ac284bae9381673d462".  This attribute MUST be
+      provided in a SCIM Event "sub_id" claim.  Note that the relative
+      path is the path component after the SCIM service provider Base
+      URI as defined in Section 1.3 of [RFC7644].  In cases where the
+      Event Receiver is unable to match a URI, the Event Receiver MAY
+      issue a callback to a previously agreed SCIM service provider Base
+      URI plus the relative "uri" value and perform a SCIM GET request
+      per Section 3.4.1 of [RFC7644].
+
+   externalId:
+      If known, the "externalId" value (defined in Section 3.1 of
+      [RFC7643]) of the SCIM resource that MAY be used by a receiver to
+      identify the corresponding resource in the Event Receiver's
+      domain.
+
+   id:
+      The SCIM "id" attribute (defined in Section 3.1 of [RFC7643]) MAY
+      be used for backwards compatibility reasons in addition to the
+      "uri" claim.
+
+   In cases where SCIM identifiers ("id" and "externalId") are not
+   enough to identify a common resource between an Event Publisher and
+   Event Receiver, the "sub_id" object MAY contain attributes whose SCIM
+   attribute types have "uniqueness" set to "server" or "global" as per
+   Section 7 of [RFC7643].  For example, attributes such as "emails" or
+   "userName" (defined in Section 4 of [RFC7643]) are unique within a
+   SCIM service provider.  Such attributes should allow an Event
+   Publisher and Event Receiver to identify a commonly understood
+   subject resource of an event.
+
+2.2.  Common Event Attributes
+
+   The following attributes are available for all events defined.  Some
+   attributes are defined as SET/JWT claims, while others are "event
+   payload" claims as defined in Section 1.2 of [RFC8417].  Only one of
+   the claims, "data" or "attributes", MUST be provided depending on the
+   event definition.
+
+   txn:
+      A SET-defined claim with a STRING value (see Section 2.2 of
+      [RFC8417]) that uniquely identifies a transaction originating at a
+      SCIM service provider and/or its underlying data repository or
+      database where one or more SCIM Events may be subsequently issued.
+      In contrast to a "jti" claim (see Section 4.1.7 of [RFC7519]),
+      which uniquely identifies a token, the "txn" remains the same when
+      one or more SETs are generated for various purposes such as
+      retransmission, publication to multiple receivers, etc.  A
+      distinct state change or transaction within a SCIM service
+      provider MAY result in multiple SETs issued each with distinct
+      "jit" values and a common "txn" value. "txn" is REQUIRED to
+      support asynchronous SCIM requests, CP, and replication to
+      disambiguate or detect duplicate SETs regarding the same
+      underlying transaction.
+
+   version:
+      The ETag version of the resource as a result of the event.
+      Corresponds to the ETag response header described in Section 3.14
+      of [RFC7644].
+
+   data:
+      An event payload attribute that contains information described in
+      the SCIM Bulk Operations "data" attribute in Section 3.7 of
+      [RFC7644].  The JSON object contains the equivalent SCIM command
+      processed by the SCIM service provider.  For example, after
+      processing a SCIM Create operation, the data contained includes
+      the final representation of the entity created by the SCIM service
+      provider including the assigned "id" value.
+
+   attributes:
+      A payload that contains an array of attributes that were added,
+      revised, or removed.  Names of modified attributes SHOULD conform
+      to the ABNF syntax rule for "path" (Section 3.5.2 of [RFC7644]).
+      For example: "attributes":
+      ["userName","emails","name.familyName"].
+
+2.3.  SCIM Feed Events
+
+   This section defines events related to changes in the content of an
+   event feed such as SCIM resources that are being added or removed
+   from an event feed or events used in Coordinated Provisioning
+   scenarios where only a subset of entities are shared across an event
+   feed.  The URI prefix for these events is
+   "urn:ietf:params:scim:event:feed".
+
+2.3.1.  urn:ietf:params:scim:event:feed:add
+
+   The specified resource has been added to the event feed.  A
+   "feed:add" does not indicate that a resource is new or has been
+   recently created.  For example, an existing user has had a new role
+   (e.g., CRM_User) added to their profile, which has caused their
+   resource to join a feed.
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "txn": "b7b953f11cc6489bbfb87834747cc4c1",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2b2f880af6674ac284bae9381673d462",
+       "externalId": "jdoe"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:feed:add": {}
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                   Figure 2: Example SCIM Feed Add Event
+
+2.3.2.  urn:ietf:params:scim:event:feed:remove
+
+   The specified resource has been removed from the feed.  Removal does
+   not indicate that the resource was deleted or otherwise deactivated.
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2b2f880af6674ac284bae9381673d462",
+       "externalId": "jdoe",
+     },
+     "events":{
+       "urn:ietf:params:scim:event:feed:remove": {}
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                  Figure 3: Example SCIM Feed Remove Event
+
+2.4.  SCIM Provisioning Events
+
+   This section defines resource changes that have occurred within a
+   SCIM service provider.  These events are used in both Domain-Based
+   Replication (DBR) and Coordinated Provisioning (CP) mode.  The URI
+   prefix for these events is "urn:ietf:params:scim:event:prov".
+
+   When the "data" payload attribute is included for each of the
+   following events, the event URI MUST end with "full"; otherwise, the
+   event URI ends with "notice".  In "full" mode, the set of values
+   reflecting the final representation of the resource (such as would be
+   returned in a SCIM protocol response) at the service provider are
+   provided using the "data" attribute (see Figure 4).  In "notice"
+   mode, the "attributes" attribute is returned and lists the set of
+   attributes created or modified in the request (see Figure 5).
+   Exactly one of the payload attributes, "data" or "attributes", MUST
+   be present.  Both MUST NOT be present simultaneously.
+
+2.4.1.  urn:ietf:params:scim:event:prov:create:{notice|full}
+
+   The specified resource indicates that a new SCIM resource has been
+   created by the SCIM service provider and has been added to the event
+   feed.  Note that because the event may be used for replication, the
+   "id" attribute that was assigned by the SCIM service provider is
+   shared so that all replicas in the domain MAY use the same resource
+   identifier.
+
+   {
+     "jti": "4d3559ec67504aaba65d40b0363faad8",
+     "iat": 1458496404,
+     "iss":"https://scim.example.com",
+     "aud":[
+       "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754",
+       "https://scim.example.com/Feeds/5d7604516b1d08641d7676ee7"
+     ],
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/44f6142df96bd6ab61e7521d9",
+        "externalId":"jdoe"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:create:full":{
+         "data":{
+           "schemas":[ "urn:ietf:params:scim:schemas:core:2.0:User"],
+           "emails":[
+             {"type":"work","value":"jdoe@example.com"}
+           ],
+           "userName":"jdoe",
+           "name":{
+             "givenName":"John",
+             "familyName":"Doe"
+           }
+         }
+       }
+     }
+   }
+
+                 Figure 4: Example SCIM Create Event (Full)
+
+   {
+     "jti": "4d3559ec67504aaba65d40b0363faad8",
+     "iat": 1458496404,
+     "iss":"https://scim.example.com",
+     "aud":[
+       "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754",
+       "https://scim.example.com/Feeds/5d7604516b1d08641d7676ee7"
+     ],
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/44f6142df96bd6ab61e7521d9",
+       "externalId": "jdoe"
+     },
+     "events": {
+       "urn:ietf:params:scim:event:prov:create:notice": {
+         "attributes": [
+           "id",
+           "name",
+           "userName",
+           "password",
+           "emails"
+         ]
+       }
+     }
+   }
+
+                Figure 5: Example SCIM Create Event (Notice)
+
+   The event shown in Figure 5 notifies the Event Receiver of which
+   attributes have changed, but it does not convey the actual
+   information.  The Event Receiver MAY retrieve that information by
+   performing a SCIM GET based on the "sub_id" value provided.
+
+2.4.2.  urn:ietf:params:scim:event:prov:patch:{notice|full}
+
+   The specified resource has been updated using SCIM PATCH.  In "full"
+   mode, the "data" payload attribute is included (see Figure 6).  When
+   the event URI ends with "notice", the list of modified attributes is
+   provided (see Figure 7).
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Groups/176f397ec4c44b94b2cfcb759780b8c2",
+       "externalId": "crmUsers"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:patch:full": {
+         "version": "a330bc54f0671c9",
+         "data": {
+           "schemas":
+         ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+           "Operations":[{
+             "op":"add",
+             "path":"members",
+             "value":[{
+                "display": "Babs Jensen",
+                "$ref": "/Users/2819c223...413861904646",
+                "value": "2819c223-7f76-453a-919d-413861904646"
+             }]
+           }]
+         }
+       }
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                 Figure 6: Example SCIM Patch Event (Full)
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Groups/176f397ec4c44b94b2cfcb759780b8c2",
+       "externalId": "crmUsers"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:patch:notice": {
+         "attributes": ["members"],
+         "version": "a330bc54f0671c9"
+       }
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                Figure 7: Example SCIM Patch Event (Notice)
+
+2.4.3.  urn:ietf:params:scim:event:prov:put:{notice|full}
+
+   The specified resource has been updated (e.g., one or more attributes
+   has changed).  In "full" mode, the SCIM PUT request body is included
+   in the "data" attribute (see Figure 8).  In "notice" mode, the
+   modified attributes are listed using "attributes" (see Figure 9).
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2819c223-7f76-453a-919d-413861904646"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:put:full": {
+         "version": "a330bc54f0671c9",
+         "data": {
+           "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+           "userName":"jdoe",
+           "externalId":"jdoe",
+           "name":{
+              "formatted":"Mr. Jon Jack Doe III",
+              "familyName":"Doe",
+              "givenName":"Jon",
+              "middleName":"Jack"
+           },
+           "roles":[],
+           "emails":[
+             {"value":"jdoe@example.com"},
+             {"value":"anon@jdoe.org"}
+           ]
+         }
+       }
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                  Figure 8: Example SCIM Put Event (Full)
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2819c223-7f76-453a-919d-413861904646"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:put:notice": {
+         "version": "a330bc54f0671c9",
+         "attributes": ["userName","externalId","name","roles","emails"]
+       }
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                 Figure 9: Example SCIM Put Event (Notice)
+
+2.4.4.  urn:ietf:params:scim:event:prov:delete
+
+   The specified resource has been deleted from the SCIM service
+   provider.  The resource is also removed from the feed.  When a DELETE
+   is sent, a corresponding "feedRemove" SHALL NOT be issued.  A delete
+   event has no payload attributes.  Note that because the delete event
+   has no attributes, the qualifiers "full" and "notice" SHALL NOT be
+   used.
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2b2f880af6674ac284bae9381673d462",
+       "externalId": "jDoe"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:delete": {}
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                    Figure 10: Example SCIM Delete Event
+
+2.4.5.  urn:ietf:params:scim:event:prov:activate
+
+   The specified resource (e.g., User) has been "activated".  This does
+   not necessarily reflect any particular state change at the SCIM
+   service provider but may simply indicate that the account defined by
+   the SCIM resource is ready for use as agreed upon by the Event
+   Publisher and Event Receiver.  For example, an activated resource can
+   represent an account that may be logged in.
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2b2f880af6674ac284bae9381673d462"
+     },
+     "events":{
+       "urn:ietf:params:scim:event:prov:activate": {}
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+                   Figure 11: Example SCIM Activate Event
+
+2.4.6.  urn:ietf:params:scim:event:prov:deactivate
+
+   The specified resource (e.g., User) has been deactivated and
+   disabled.  The exact meaning SHOULD be agreed to by the Event
+   Publisher and its corresponding Event Receiver.  Typically, this
+   means the subject may no longer have an active security session.
+
+2.5.  Miscellaneous Events
+
+   This section defines related miscellaneous events such as
+   asynchronous request completion that has occurred within a SCIM
+   service provider.  The URI prefix for these events is
+   "urn:ietf:params:scim:event:misc".
+
+2.5.1.  Asynchronous Events
+
+2.5.1.1.  Making an Asynchronous SCIM Request
+
+   A SCIM client making SCIM HTTP requests defined in Section 3 of
+   [RFC7644] MAY request asynchronous processing using the "Prefer" HTTP
+   header as defined in Section 4.1 of [RFC7240].  The client may do
+   this for a number of reasons such as avoiding holding HTTP
+   connections open during long requests because the result of the
+   request is not needed or the result is delivered to another entity
+   for further action for coordination reasons.
+
+   To initiate an asynchronous SCIM request, a normal SCIM protocol
+   POST, PUT, PATCH, or DELETE request is performed with the HTTP
+   "Prefer" header set to "respond-async" (Section 4.1 of [RFC7240]).
+   The HTTP "Accept" header MUST be ignored for purposes of an
+   asynchronous response.  Additionally, per Section 4.3 of [RFC7240],
+   the "wait" preference SHOULD be supported to establish a maximum time
+   before a SCIM service provider MAY choose to respond asynchronously.
+
+   In response, the SCIM service provider returns either a normal SCIM
+   response or HTTP status code 202 (Accepted).  The asynchronous
+   response MUST contain no response body.  To enable correlation of the
+   future event, the HTTP response header "Set-Txn" (see Section 3) is
+   returned with a value that MUST match the "txn" claim in a subsequent
+   Security Event Token.  Per [RFC7240], Section 3, the response will
+   also include the "Preference-Applied" header.  The "Location" header
+   value MUST be one of the following: (a) a URI where the completion
+   SCIM Event Token MAY be retrieved using HTTP GET or (b) the normal
+   SCIM location header response specified by [RFC7644].
+
+   In the following non-normative example, a "Prefer" header is set to
+   "respond-async":
+
+   PUT /Users/2819c223-7f76-453a-919d-413861904646
+   Host: scim.example.com
+   Prefer: respond-async
+   Content-Type: application/scim+json
+   Authorization: Bearer h480djs93hd8
+
+   {
+     "schemas":["urn:ietf:params:scim:schemas:core:2.0:User"],
+     "id":"2819c223-7f76-453a-919d-413861904646",
+     "userName":"bjensen",
+     "externalId":"bjensen",
+     "name":{
+       "formatted":"Ms. Barbara J Jensen III"
+     },
+     "roles":[],
+     "emails":[
+       {
+           "value":"bjensen@example.com"
+       }
+     ]
+   }
+
+           Figure 12: Example Asynchronous SCIM Protocol Request
+
+   The SCIM service provider responds with HTTP status code 202
+   (Accepted) and includes the Set-Txn header:
+
+   HTTP/1.1 202 Accepted
+   Set-Txn: 734f0614e3274f288f93ac74119dcf78
+   Preference-Applied: respond-async
+   Location:
+     "/Users/2819c223-7f76-453a-919d-413861904646"
+
+              Figure 13: Async SCIM Request with Prefer Header
+
+2.5.1.2.  Asynchronous Bulk Endpoint Requests
+
+   Section 3.7 of [RFC7644] provides the ability to submit multiple SCIM
+   operations in a single "bulk" request.  When an asynchronous response
+   is requested, a single Asynchronous Request Completion Event MUST be
+   generated for each requested operation.  For example, if a single
+   "bulk" request had 10 operations, then 10 Asynchronous Event
+   completion events would be generated.
+
+   The "txn" claim MUST be set to the value originally returned to the
+   requesting SCIM client (see Section 2.5.1.1) appended with a colon
+   ":" and the zero-based array index of the operation expressed in the
+   "Operations" attribute of the original bulk request.  The "bulkId"
+   parameter MUST NOT be used for this purpose as it is a temporary
+   identifier and is not required for every operation.
+
+   For example, if a SCIM service provider received a bulk request with
+   two or more operations, and had a "txn" claim value of
+   "2d80e537a3f64622b0347b641ebc8f44", then the first Asynchronous
+   Response Event Token representing the first operation has a "txn"
+   claim value of "2d80e537a3f64622b0347b641ebc8f44:0", the second
+   operation has a value of "2d80e537a3f64622b0347b641ebc8f44:1", and so
+   on.
+
+   If a SCIM service provider optimizes the sequence of operations (per
+   Section 3.7 of [RFC7644]), the Asynchronous Request Completion Events
+   MAY be generated out of sequence from the original request.  In this
+   case, the "txn" claims in those events MUST use operation numbers
+   that correspond to the order in the original request.
+
+2.5.1.3.  urn:ietf:params:scim:event:misc:asyncresp
+
+   The Asynchronous Response Event signals the completion of a SCIM
+   request.  The event payload contains the attributes defined in
+   Section 3.7 of [RFC7644] and is the same as a single SCIM Bulk
+   Response Operation as per Section 3.7.3 of [RFC7644].  In the event,
+   the "txn" claim MUST be set to the value originally returned to the
+   requesting SCIM client (see Section 2.5.1.1).
+
+   {
+     "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/2819c223-7f76-453a-919d-413861904646"
+     },
+     "txn": "734f0614e3274f288f93ac74119dcf78",
+     "events":{
+       "urn:ietf:params:scim:event:misc:asyncresp": {
+           "method": "PUT",
+           "version": "W\/\"huJj29dMNgu3WXPD\"",
+           "status": "200"
+       }
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+            Figure 14: Example SCIM Asynchronous Response Event
+
+   If an error occurs during asynchronous processing, the event
+   operation MUST include a "response" attribute indicating a non-
+   200-series HTTP status as defined in Section 3.7 of [RFC7644], and
+   that "response" attribute MUST contain the sub-attributes defined in
+   Section 3.12 of [RFC7644].  The "status" attribute of the event
+   operation typically matches the "status" attribute of the response.
+
+   {
+    "jti": "6164f3bbf6ff41a88dc94f18cb0620e8",
+    "sub_id": {
+      "format": "scim",
+      "uri": "/Users/2819c223-7f76-453a-919d-413861904646"
+    },
+    "txn": "734f0614e3274f288f93ac74119dcf78",
+    "events":{
+      "urn:ietf:params:scim:event:misc:asyncresp": {
+          "method": "PUT",
+          "version": "W\/\"huJj29dMNgu3WXPD\"",
+          "status": "400",
+          "response": {
+              "schemas": [
+                  "urn:ietf:params:scim:api:messages:2.0:Error"
+              ],
+              "scimType":"invalidSyntax",
+              "detail": "Request is unparsable",
+              "status":"400"
+          }
+      }
+    },
+    "iat": 1458505044,
+    "iss":"https://scim.example.com",
+    "aud":[
+     "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+    ]
+   }
+
+         Figure 15: Example SCIM Asynchronous Error Response Event
+
+   The following four figures show asynchronous completion events for
+   the example in Section 3.7.3 of [RFC7644].
+
+   {
+     "jti": "dbae9d7506b34329aa7f2f0d3827848b",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/92b725cd-9465-4e7d-8c16-01f8e146b87a"
+     },
+     "txn": "2d80e537a3f64622b0347b641ebc8f44:1",
+     "events":{
+       "urn:ietf:params:scim:event:misc:asyncresp": {
+            "method": "POST",
+            "bulkId": "qwerty",
+            "version": "W\/\"oY4m4wn58tkVjJxK\"",
+            "status": "201"
+       }
+     },
+     "iat": 1458505044,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+      Figure 16: Example SCIM Asynchronous Response Event Operation (1
+                                   of 4)
+
+   {
+     "jti": "ca977d05ba5c43929e3a69023d5392a9",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/b7c14771-226c-4d05-8860-134711653041"
+     },
+     "txn": "2d80e537a3f64622b0347b641ebc8f44:2",
+     "events":{
+       "urn:ietf:params:scim:event:misc:asyncresp": {
+             "method": "PUT",
+             "version": "W\/\"huJj29dMNgu3WXPD\"",
+             "status": "200"
+       }
+     },
+     "iat": 1458505045,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+      Figure 17: Example SCIM Asynchronous Response Event Operation (2
+                                   of 4)
+
+   {
+     "jti": "4bb87d70a4ab463bbdcd1f99111cbbf1",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/5d8d29d3-342c-4b5f-8683-a3cb6763ffcc"
+     },
+     "txn": "2d80e537a3f64622b0347b641ebc8f44:3",
+     "events":{
+       "urn:ietf:params:scim:event:misc:asyncresp": {
+             "method": "PATCH",
+             "version": "W\/\"huJj29dMNgu3WXPD\"",
+             "status": "200"
+       }
+     },
+     "iat": 1458505046,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+      Figure 18: Example SCIM Asynchronous Response Event Operation (3
+                                   of 4)
+
+   {
+     "jti": "6a7843a7f5244d0eb62ca38b641d9139",
+     "sub_id": {
+       "format": "scim",
+       "uri": "/Users/e9025315-6bea-44e1-899c-1e07454e468b"
+     },
+     "txn": "2d80e537a3f64622b0347b641ebc8f44:4",
+     "events":{
+       "urn:ietf:params:scim:event:misc:asyncresp": {
+             "method": "DELETE",
+             "status": "204"
+       }
+     },
+     "iat": 1458505047,
+     "iss":"https://scim.example.com",
+     "aud":[
+      "https://scim.example.com/Feeds/98d52461fa5bbc879593b7754"
+     ]
+   }
+
+      Figure 19: Example SCIM Asynchronous Response Event Operation (4
+                                   of 4)
+
+3.  Set-Txn HTTP Response Header for Asynchronous Requests
+
+   This specification defines a new HTTP header field, "Set-Txn", which
+   serves the purpose of conveying request completion information to
+   SCIM HTTP clients that request an asynchronous response as described
+   in Section 2.5.1.1.  The header field MUST be used in SCIM responses
+   when HTTP status code 202 (Accepted) is being returned with no
+   message body.
+
+   The "Set-Txn" HTTP header field value is a unique STRING (e.g., a
+   Globally Unique Identifier (GUID)) used by the SCIM HTTP client to
+   look for a matching SET event with a matching "txn" claim (see
+   Section 2 of [RFC8417]) confirming the request completion status as
+   described in Section 2.5.1.1.
+
+   Intermediaries SHOULD NOT insert, modify, or delete the field's
+   value.
+
+   SCIM clients MAY ignore the header in cases where confirmation of
+   completion is not required.  For example, a SCIM client may simply
+   not want to wait for synchronous completion.
+
+4.  Events Discovery Schema for Service Provider Configuration
+
+   Section 5 of [RFC7643] defines SCIM service provider configuration
+   schemas.  This section defines additional attributes that enable a
+   SCIM client to discover the additional capabilities defined by this
+   specification.
+
+   securityEvents:
+      A SCIM complex attribute that specifies the available capabilities
+      related to asynchronous Security Events based on [RFC8417].  This
+      attribute is OPTIONAL, and when absent, it indicates the SCIM
+      service provider does not support or is not currently configured
+      for Security Events.  The following sub-attributes are defined:
+
+      asyncRequest:
+         A case-insensitive string value specifying one of the
+         following:
+
+         *  "none" indicates that asynchronous SCIM requests defined in
+            Section 2.5.1.1 are not supported;
+
+         *  "long" indicates that the server completes requests
+            asynchronously at the server's discretion (e.g., based on a
+            max wait time); and
+
+         *  "request" indicates that the server completes requests
+            asynchronously when requested by the SCIM client.
+
+      eventUris:
+         A multivalued string listing the SET Event URIs (defined in
+         [RFC8417]) that the server is capable of generating and
+         delivering via a SET Stream (see [RFC8935] and [RFC8936]).
+         This information is informational only.  Stream registration
+         and configuration are out of scope of this specification.
+
+5.  Security Considerations
+
+   As this specification is based upon the SETs specification and the
+   associated delivery specifications, the following security
+   considerations are also applicable to this specification:
+
+   *  Section 5 of [RFC8417] (Security Event Token)
+
+   *  Section 5 of [RFC8935] (Push-Based SET Delivery Using HTTP)
+
+   *  Section 4 of [RFC8936] (Poll-Based SET Delivery Using HTTP)
+
+   SETs may contain sensitive information, including Personally
+   Identifiable Information (PII).  In such cases, SET Transmitters and
+   SET Recipients MUST protect the confidentiality of the SET contents
+   in transit using TLS [BCP195].
+
+   When coordinating provisioning between entities, the long-term series
+   of changes may be critical to the information integrity and recovery
+   requirements of both sides.  To address this, Event Publishers can
+   make events available for receivers for longer periods of time than
+   might typically be used for recovering from momentary delivery
+   failures and retries per [RFC8935] or [RFC8936].  Similarly, Event
+   Receivers MUST ensure events are persisted directly or indirectly to
+   meet local recovery needs before acknowledging the SET Events were
+   received.
+
+   An attacker might leverage transaction and/or signal information
+   contained in a SET Event Publisher or Receiver system.  To mitigate
+   this, access to event recovery and forwarding MUST be limited to the
+   parties needed to support recovery or SET forwarding.
+
+   When SET Events are transferred in such a way that the Event
+   Publisher is not communicating directly to the Event Receiver, it may
+   become possible for an attacker or other system to insert an event.
+   To mitigate, Event Receivers MUST verify the originator of a SET
+   using JSON Web Signature (JWS) [RFC7515] signatures when the Event
+   Publisher is not communicating directly with the Event Receiver.
+   Validating event signatures may also be useful for auditing purposes
+   as signed SET Events are protected from tampering in the event that
+   an intermediate system, such as a TLS-terminating proxy, decrypts the
+   SET payload before sending it onward to its intended recipient.
+
+   In operation, some SCIM resources such as SCIM Groups may have a high
+   rate of change.  For example, groups with more than a few thousand
+   member values could lead to excessive change rates, which could lead
+   to a loss of SET Events between Event Publishers and Event Receivers.
+   To mitigate this risk, consider the following to help with throughput
+   issues:
+
+   *  The use of SCIM PUT (Section 3.5.1 of [RFC7644]), particularly
+      with large SCIM Groups, can result in excessive data being
+      conveyed in Security Event payloads.  Instead, it is RECOMMENDED
+      to use SCIM PATCH (Section 3.5.2 of [RFC7644]) to focus on
+      updating and notifying about changed information.  Alternatively,
+      use SCIM PUT Event Notice
+      (urn:ietf:params:scim:event:prov:put:notice) as a trigger to later
+      retrieve the full information when needed.
+
+   *  Use SCIM Patch Event Notice
+      (urn:ietf:params:scim:event:prov:patch:notice) to reduce event
+      content combined with periodic SCIM GETs (see Section 3.4 of
+      [RFC7644]) to retrieve current group state.
+
+   *  Aggregate multiple PATCH Events into a single event.  If providing
+      the exact date of each membership change is not critical, consider
+      using a PATCH to aggregate multiple membership changes into a
+      single event.
+
+   When using asynchronous SCIM requests (see Section 2.5.1.1), a SCIM
+   service provider returns a SCIM Accepted response with a URI for
+   retrieving the event result.  An unauthorized entity or attacker
+   could obtain Asynchronous Request Completion Event information by
+   querying the asynchronous operation result endpoint used by a SCIM
+   service provider.  To mitigate, the returned URI endpoint MUST be
+   protected and requires an HTTP Authorization header or some other
+   form of client authentication.
+
+6.  Privacy Considerations
+
+   As this specification is based upon the SET specification and the
+   associated delivery specifications, the following privacy
+   considerations are also applicable to this specification:
+
+   *  Section 6 of [RFC8417] (Security Event Token)
+
+   *  Section 6 of [RFC8935] (Push-Based SET Delivery Using HTTP)
+
+   *  Section 5 of [RFC8936] (Poll-Based SET Delivery Using HTTP)
+
+   This specification enables the sharing of information between
+   domains; therefore, it is assumed that implementers and deployers are
+   operating under one of the following scenarios:
+
+   *  A common administrative domain where there is one administrative
+      owner of the data.  In these cases, the goal is to protect privacy
+      and security of the owner and user data by keeping information
+      systems coordinated and up to date.  For example, the domains
+      decide to use DBR mode to keep employee information synchronized.
+
+   *  In a cooperative or coordinated relationship, parties have decided
+      to share a limited amount of data and/or signals for the benefits
+      of their users.  Depending on end-user consent, information is
+      shared on an as-authorized and/or as-needed basis.  For example,
+      the domains agree to use CP mode that exchanges things such as
+      account status or specific minimal attribute information that must
+      be fetched on request after receiving notice of a change.  This
+      enables authorization to be verified each time data is
+      transferred.
+
+   In general, the sharing of SCIM Event information falls within a pre-
+   existing SCIM client and service provider relationship and carries no
+   additional personal information.
+
+7.  IANA Considerations
+
+7.1.  SCIM Asynchronous Set-Txn Header Registration
+
+   This specification registers the HTTP "Set-Txn" field name in the
+   "Hypertext Transfer Protocol (HTTP) Field Name Registry" defined in
+   Section 16.3.1 of [RFC9110].
+
+   Field name:  Set-Txn
+   Status:  permanent
+   Reference:  Section 3 of RFC 9967.
+
+7.2.  Registering Event Capability with SCIM Service Provider
+      Configuration
+
+   A reference to Section 4 of this document has been added to the
+   "urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig" entry
+   in the "SCIM Server-Related Schema URIs" registry (Section 10.4 of
+   [RFC7643]) under the "System for Cross-domain Identity Management
+   (SCIM) Schema URIs" registry group.
+
+7.3.  Creation of the SCIM Event URIs Registry
+
+   IANA has created a new registry called "SCIM Event URIs" under the
+   "System for Cross-domain Identity Management (SCIM) Schema URIs"
+   registry group (Section 10.1 of [RFC7643]) at
+   <https://www.iana.org/assignments/scim>.
+
+   The registration procedure is Expert Review [RFC8126].  New
+   registrations for this registry are evaluated by designated expert(s)
+   for relevance to SCIM-based systems and to avoid possible duplication
+   or conflict with other event definitions that may lie outside SCIM
+   (e.g., Shared Signals [SSF]).
+
+   Namespace ID:
+      The sub-namespace ID of "event" is assigned within the "scim"
+      namespace.
+
+   Syntactic Structure:
+      The Namespace Specific String (NSS) of all URNs that use the
+      "event" Namespace ID has the following structure:
+
+      "urn:ietf:params:scim:event:{class}:{name}:{other}"
+
+      The keywords have the following meaning:
+
+      class
+         The class of events, which is one of: "feed", "prov", or
+         "misc".
+
+      name
+         An ASCII string that conforms to URN syntax requirements (see
+         [RFC8141]) and defines a descriptive event name (e.g.,
+         "create").
+
+      other
+         An optional ASCII string that conforms to URN syntax
+         requirements (see [RFC8141]) and serves as an additional sub-
+         category or qualifier, for example, "full" and "notice".
+
+   Identifier Uniqueness Considerations:
+      The designated contact is responsible for reviewing and enforcing
+      uniqueness.
+
+   Identifier Persistence Considerations:
+      Once a name has been allocated, it MUST NOT be reallocated for a
+      different purpose.  The rules provided for the assignment of
+      values within a sub-namespace MUST be constructed so that the
+      meaning of values cannot change.  This registration mechanism is
+      not appropriate for naming values whose meaning may change over
+      time.
+
+   Registration Format:
+      An event registration MUST include the following fields:
+
+      *  Event URI
+
+      *  Descriptive name
+
+      *  Reference to event definition
+
+7.4.  Initial Contents of the SCIM Event URIs Registry
+
+   IANA has added the following initial entries to the "SCIM Event URIs"
+   registry:
+
+   +==========================================+==============+=========+
+   |Event URI                                 |Name          |Reference|
+   +==========================================+==============+=========+
+   |urn:ietf:params:scim:event:feed:add       |Resource      |Section  |
+   |                                          |added to Feed |2.3.1 of |
+   |                                          |Event         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:feed:remove    |Remove        |Section  |
+   |                                          |resource from |2.3.2 of |
+   |                                          |Feed Event    |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:create:   |New Resource  |Section  |
+   |notice                                    |Event (notice |2.4.1 of |
+   |                                          |only)         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:create:   |New Resource  |Section  |
+   |full                                      |Event (full   |2.4.1 of |
+   |                                          |data)         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:patch:    |Resource      |Section  |
+   |notice                                    |Patch Event   |2.4.2 of |
+   |                                          |(notice only) |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:patch:    |Resource      |Section  |
+   |full                                      |Patch Event   |2.4.2 of |
+   |                                          |(full data)   |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:put:      |Resource Put  |Section  |
+   |notice                                    |Event (notice |2.4.3 of |
+   |                                          |only)         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:put:full  |Resource Put  |Section  |
+   |                                          |Event (full   |2.4.3 of |
+   |                                          |data)         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:delete    |Resource      |Section  |
+   |                                          |Deleted Event |2.4.4 of |
+   |                                          |              |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:activate  |Resource      |Section  |
+   |                                          |Activated     |2.4.5 of |
+   |                                          |Event         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:prov:deactivate|Resource      |Section  |
+   |                                          |Deactivated   |2.4.6 of |
+   |                                          |Event         |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+   |urn:ietf:params:scim:event:misc:asyncresp |Asynchronous  |Section  |
+   |                                          |Request       |2.5.1 of |
+   |                                          |Completion    |RFC 9967 |
+   +------------------------------------------+--------------+---------+
+
+                                  Table 1
+
+8.  References
+
+8.1.  Normative References
+
+   [BCP195]   Best Current Practice 195,
+              <https://www.rfc-editor.org/info/bcp195>.
+              At the time of writing, this BCP comprises the following:
+
+              Moriarty, K. and S. Farrell, "Deprecating TLS 1.0 and TLS
+              1.1", BCP 195, RFC 8996, DOI 10.17487/RFC8996, March 2021,
+              <https://www.rfc-editor.org/info/rfc8996>.
+
+              Sheffer, Y., Saint-Andre, P., and T. Fossati,
+              "Recommendations for Secure Use of Transport Layer
+              Security (TLS) and Datagram Transport Layer Security
+              (DTLS)", BCP 195, RFC 9325, DOI 10.17487/RFC9325, November
+              2022, <https://www.rfc-editor.org/info/rfc9325>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC7240]  Snell, J., "Prefer Header for HTTP", RFC 7240,
+              DOI 10.17487/RFC7240, June 2014,
+              <https://www.rfc-editor.org/info/rfc7240>.
+
+   [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
+              Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
+              2015, <https://www.rfc-editor.org/info/rfc7515>.
+
+   [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
+              (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
+              <https://www.rfc-editor.org/info/rfc7519>.
+
+   [RFC7643]  Hunt, P., Ed., Grizzle, K., Wahlstroem, E., and C.
+              Mortimore, "System for Cross-domain Identity Management:
+              Core Schema", RFC 7643, DOI 10.17487/RFC7643, September
+              2015, <https://www.rfc-editor.org/info/rfc7643>.
+
+   [RFC7644]  Hunt, P., Ed., Grizzle, K., Ansari, M., Wahlstroem, E.,
+              and C. Mortimore, "System for Cross-domain Identity
+              Management: Protocol", RFC 7644, DOI 10.17487/RFC7644,
+              September 2015, <https://www.rfc-editor.org/info/rfc7644>.
+
+   [RFC8141]  Saint-Andre, P. and J. Klensin, "Uniform Resource Names
+              (URNs)", RFC 8141, DOI 10.17487/RFC8141, April 2017,
+              <https://www.rfc-editor.org/info/rfc8141>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC8417]  Hunt, P., Ed., Jones, M., Denniss, W., and M. Ansari,
+              "Security Event Token (SET)", RFC 8417,
+              DOI 10.17487/RFC8417, July 2018,
+              <https://www.rfc-editor.org/info/rfc8417>.
+
+   [RFC8935]  Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari,
+              M., and A. Nadalin, "Push-Based Security Event Token (SET)
+              Delivery Using HTTP", RFC 8935, DOI 10.17487/RFC8935,
+              November 2020, <https://www.rfc-editor.org/info/rfc8935>.
+
+   [RFC8936]  Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari,
+              M., and A. Nadalin, "Poll-Based Security Event Token (SET)
+              Delivery Using HTTP", RFC 8936, DOI 10.17487/RFC8936,
+              November 2020, <https://www.rfc-editor.org/info/rfc8936>.
+
+   [RFC9110]  Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke,
+              Ed., "HTTP Semantics", STD 97, RFC 9110,
+              DOI 10.17487/RFC9110, June 2022,
+              <https://www.rfc-editor.org/info/rfc9110>.
+
+   [RFC9493]  Backman, A., Ed., Scurtescu, M., and P. Jain, "Subject
+              Identifiers for Security Event Tokens", RFC 9493,
+              DOI 10.17487/RFC9493, December 2023,
+              <https://www.rfc-editor.org/info/rfc9493>.
+
+8.2.  Informative References
+
+   [RFC8126]  Cotton, M., Leiba, B., and T. Narten, "Guidelines for
+              Writing an IANA Considerations Section in RFCs", BCP 26,
+              RFC 8126, DOI 10.17487/RFC8126, June 2017,
+              <https://www.rfc-editor.org/info/rfc8126>.
+
+   [SCIM-EVENT-EXT]
+              Hunt, P., Ed., Denniss, W., and M. Ansari, "SCIM Event
+              Extension", Work in Progress, Internet-Draft, draft-hunt-
+              idevent-scim-00, 20 March 2016,
+              <https://datatracker.ietf.org/doc/html/draft-hunt-idevent-
+              scim-00>.
+
+   [SSF]      Tulshibagwale, A., Cappalli, T., Scurtescu, M., Backman,
+              A., Bradley, J., and S. Miel, "OpenID Shared Signals
+              Framework Specification 1.0", 29 August 2025,
+              <https://openid.net/specs/openid-sharedsignals-framework-
+              1_0.html>.
+
+Appendix A.  Use Cases
+
+   SCIM Events may be used in a number of ways.  The following non-
+   normative sections describe some of the expected uses.
+
+A.1.  Domain-Based Replication
+
+   The objective of DBR events is to synchronize resource changes
+   between SCIM service providers in a common administrative domain.  In
+   this mode, complete information about modified resources are shared
+   between replicas for immediate processing.
+
+  +-------------+   +---------------------+   +------------------------+
+  |SCIM Client A|   |SCIM Service Provider|   |Service Provider Replica|
+  +-------------+   +---------------------+   +------------------------+
+         |                     |                           |
+         | [1] SCIM Operation  |                           |
+         |-------------------->|                           |
+         | [2] SCIM Response   |                           |
+         |<--------------------|                           |
+         |                     |                           |
+         |                     | [3] Event SCIM:prov:<op>  |
+         |                     |          id:xyz           |
+         |                     |- - - - - - - - - - - - - >|
+         |                     |                           |
+         |                     |     [4] Update local node |--+
+         |                     |                           |  |
+         |                     |                           |<-+
+         |                     |                           |
+         v                     v                           v
+
+               Figure 20: Domain-Based Replication Sequence
+
+   From a security perspective, it is assumed that servers sharing DBR
+   events are secured by a common access policy and all servers are
+   required to be up to date.  From a privacy perspective, because all
+   servers are in the same administrative domain, the primary objective
+   is to keep individual service provider nodes or clusters
+   synchronized.
+
+A.2.  Coordinated Provisioning
+
+   In CP, SCIM resource change events perform the function of change
+   notification without the need to provide raw data.  In any Event
+   Publisher and Receiver relationship, the set of SCIM resources (e.g.,
+   Users) that are linked or coordinated is managed within the context
+   of an event feed and may be a subset of the total set of resources on
+   either side.  For example, an event feed could be limited to users
+   who have consented to the sharing of information between domains.  To
+   support capability, "feed" specific events are defined to indicate
+   the addition and removal of SCIM resources from a feed.  For example,
+   when a user consents to the sharing of information between domains,
+   events about the User may be added to the feed between the Event
+   Publisher and Receiver.
+
++-----------+  +---------------+  +-----------------+  +---------------+
+|SCIM Client|  | SCIM Service  |  | Event Receiver  |  | Coord. Action |
+|           |  |   Provider    |  |                 |  |   Endpoint    |
++-----------+  +---------------+  +-----------------+  +---------------+
+      |                |                   |                   |
+      | [1] SCIM       |                   |                   |
+      |     Operation  |                   |                   |
+      |--------------->|                   |                   |
+      |                |                   |                   |
+      | [2] SCIM       |                   |                   |
+      |     Response   |                   |                   |
+      |<---------------|                   |                   |
+      |                |                   |                   |
+      |                +=== loop ==========+===================+
+      |                |                   |                   |
+      |                | [3] Event         |                   |
+      |                | SCIM:prov:<op>    |                   |
+      |                | id:xyz            |                   |
+      |                |- - - - - - - - - >|                   |
+      |                |                   |                   |
+      |                |                   | Note: Receiver    |
+      |                |                   | may accumulate    |
+      |                |                   | events for        |
+      |                |                   | periodic action.  |
+      |                |                   |                   |
+      |                | [4] SCIM GET <id> |                   |
+      |                |<------------------|                   |
+      |                |                   |                   |
+      |                | [5] Filtered      |                   |
+      |                |     Resource      |                   |
+      |                |     Response      |                   |
+      |                |------------------>|                   |
+      |                |                   |                   |
+      |                |                   | [6] Coordinated   |
+      |                |                   |     Action        |
+      |                |                   |------------------>|
+      |                |                   |                   |
+      |                +=== end loop ======+===================+
+      v                v                   v                   v
+
+             Figure 21: Coordinated Provisioning Sequence
+
+   In CP mode, the receiver of an event must call back to the
+   originating SCIM service provider (e.g., using a SCIM GET request) to
+   reconcile the newly changed resource in order to obtain the changes.
+
+   CP has the following benefits:
+
+   *  Differences in schema (e.g., attributes) between domains.  For
+      example, a receiving domain may only be interested in or allowed
+      to access to a few attributes (e.g., role-based access data) to
+      enable access to an application.
+
+   *  Different Event Receivers may have differing needs when accessing
+      information and thus may be assigned varying access rights.
+      Minimal information events combined with callbacks for data allows
+      data filtering to be applied.
+
+   *  Receivers can take independent action such as deciding which
+      attributes or resource life cycle changes to accept.  For example,
+      in the case of a conflict, a receiver can prioritize one domain
+      source over another.
+
+   *  A receiver may throttle or buffer changes rather than act
+      immediately on a notification.  For example, for a frequently
+      changing resource, the receiver may choose to make a scheduled
+      SCIM GET for resources that have been marked "dirty" by events
+      received in the last scheduled cycle.
+
+   A disadvantage of the CP approach is that it may be considered costly
+   in the sense that each event received might trigger a callback to the
+   event issuer.  This cost should be weighed against the cost producing
+   filtered information in each event for each receiver.  Furthermore, a
+   receiver is not required to make a callback on every provisioning
+   event.
+
+   It is assumed that an underlying relationship between domains exists
+   that permits the exchange of personal information and credentials.
+   For example, in a cross-domain scenario, a SCIM service provider
+   would have been previously authorized to perform SCIM provisioning
+   operations and publish change events.  As such, appropriate
+   confidentiality and privacy agreements should be in place between the
+   domains.
+
+   When sharing information between parties, CP Events minimize the
+   information shared in each message and require the Security Event
+   Receiver to receive more information from the Event Publisher as
+   needed.  In this way, the Event Receiver is able to have regular
+   access to information through normal SCIM protocol access
+   restrictions.  The Event Receiver and Publisher may agree to
+   communicate these updates through a variety of transmission methods
+   such as push- and pull-based HTTP [RFC8935] [RFC8936] or HTTP GET
+   (see Section 2.5.1.1); streaming technologies (e.g., Kafka or
+   Kinesis); or webhooks such as in the Shared Signals Framework [SSF].
+
+Acknowledgements
+
+   The authors would like to thank the following contributors:
+
+   *  Morteza Ansari and William Denniss, who contributed significantly
+      to [SCIM-EVENT-EXT] upon which this document is based.
+
+   *  The participants of the SCIM Working Group and the IETF id-event
+      mailing list for their support of this specification.
+
+   *  Deb Cooley, Dean Saxe, Elliot Lear, Pamela Dingle, Mark
+      Nottingham, R Gideon, Paulo Jorge Correia, Shuping Peng, Elwyn
+      Davies, Luigi Lannone, Mohamed Boucadair, Roman Danyliw, Ketan
+      Talaulikar, Mahesh Jethanandani, and Mike Bishop for their write-
+      ups and reviews.
+
+Authors' Addresses
+
+   Phil Hunt (editor)
+   Independent Identity Inc
+   Email: phil.hunt@independentid.com
+
+
+   Nancy Cam-Winget
+   Cisco Systems
+   Email: ncamwing@cisco.com
+
+
+   Mike Kiser
+   Sailpoint Technologies
+   Email: mike.kiser@sailpoint.com
+
+
+   Jen Schreiber
+   Workday, Inc.
+   Email: jwschreib@gmail.com

--- a/i2scim-core/src/main/java/com/independentid/scim/protocol/RequestCtx.java
+++ b/i2scim-core/src/main/java/com/independentid/scim/protocol/RequestCtx.java
@@ -137,6 +137,14 @@ public class RequestCtx {
     private boolean isReplicaOp = false;
 
     /**
+     * Snapshot of the resource as it existed <em>before</em> the operation. Populated by the
+     * backend provider during {@code patch}/{@code put}/{@code delete} from the resource it
+     * already loads — no extra backend round-trip — and read by the event-derivation path
+     * (e.g. RISC mapping). See {@code docs/adr/0001-pre-image-on-requestctx-for-event-derivation.md}.
+     */
+    private com.independentid.scim.resource.ScimResource preImageResource = null;
+
+    /**
      * Used to create a request context that exists within a single SCIM Bulk operation
      * @param bulkReqOp     A parsed JSON structure representing a single SCIM bulk operation
      * @param schemaManager A pointer to the server ConfigMgr object (for schema)
@@ -921,6 +929,22 @@ public class RequestCtx {
 
     public boolean isReplicaOp() {
         return this.isReplicaOp;
+    }
+
+    /**
+     * @return the pre-operation snapshot of the resource, or {@code null} if none was captured.
+     */
+    public com.independentid.scim.resource.ScimResource getPreImageResource() {
+        return this.preImageResource;
+    }
+
+    /**
+     * Stores the pre-operation snapshot of the resource. Called by backend providers from the
+     * resource already loaded for the operation; consumed by the event-derivation path.
+     * @param preImageResource the resource as it existed before the operation.
+     */
+    public void setPreImageResource(com.independentid.scim.resource.ScimResource preImageResource) {
+        this.preImageResource = preImageResource;
     }
 
     static Instant parseHttpDate(String httpdate) {

--- a/i2scim-server/src/main/java/com/independentid/scim/backend/memory/MemoryProvider.java
+++ b/i2scim-server/src/main/java/com/independentid/scim/backend/memory/MemoryProvider.java
@@ -516,6 +516,10 @@ public class MemoryProvider implements IScimProvider {
             return new ScimResponse(new PreconditionFailException(
                     "Predcondition does not match"));
 
+        // Retain the unmodified resource as the pre-image so event derivation
+        // (e.g. RISC Account Enabled/Disabled) can diff against it — ADR-0001.
+        // origRes is not mutated here; the copy below is.
+        ctx.setPreImageResource(origRes);
         ScimResource temp;
         try {
             temp = origRes.copy(null);
@@ -541,6 +545,10 @@ public class MemoryProvider implements IScimProvider {
         if (origRes.checkModPreConditionFail(ctx))
             return new ScimResponse(new PreconditionFailException(
                     "Predcondition does not match"));
+        // Retain the unmodified resource as the pre-image so event derivation
+        // (e.g. RISC Account Enabled/Disabled) can diff against it — ADR-0001.
+        // origRes is not mutated here; the copy below is.
+        ctx.setPreImageResource(origRes);
         ScimResource temp;
         try {
             temp = origRes.copy(null);

--- a/i2scim-server/src/main/java/com/independentid/scim/backend/memory/MemoryProvider.java
+++ b/i2scim-server/src/main/java/com/independentid/scim/backend/memory/MemoryProvider.java
@@ -627,6 +627,9 @@ public class MemoryProvider implements IScimProvider {
 
         if (res == null)
             return new ScimResponse(ScimResponse.ST_NOTFOUND, null, null);
+        // Retain the removed resource as the pre-image so event derivation (e.g. RISC
+        // Account Purged) has subject material — ADR-0001. No extra backend read.
+        ctx.setPreImageResource(res);
         deIndexResource(res);
         String type = ctx.getResourceContainer();
         this.containerMaps.get(type).remove(ctx.getPathId());

--- a/i2scim-server/src/main/java/com/independentid/scim/backend/mongo/MongoProvider.java
+++ b/i2scim-server/src/main/java/com/independentid/scim/backend/mongo/MongoProvider.java
@@ -472,7 +472,15 @@ public class MongoProvider implements IScimProvider {
 		if (origRes.checkModPreConditionFail(ctx))
 			return new ScimResponse(new PreconditionFailException(
 					"Predcondition does not match"));
-		origRes.replaceResAttributes(replaceResource, ctx);  
+		// Snapshot the pre-image before replaceResAttributes mutates origRes, so
+		// event derivation (e.g. RISC Account Enabled/Disabled) can diff against
+		// the prior state — ADR-0001. Best-effort: a copy failure must not fail the PUT.
+		try {
+			ctx.setPreImageResource(origRes.copy(null));
+		} catch (ScimException | ParseException e) {
+			logger.warn("Could not capture pre-image for PUT " + ctx.getPath() + ": " + e.getMessage());
+		}
+		origRes.replaceResAttributes(replaceResource, ctx);
 		return this.putResource(origRes, ctx);
 	}
 
@@ -484,6 +492,13 @@ public class MongoProvider implements IScimProvider {
 		if (mres.checkModPreConditionFail(ctx))
 			return new ScimResponse(new PreconditionFailException(
 					"Predcondition does not match"));
+		// Snapshot the pre-image before modifyResource mutates mres — ADR-0001.
+		// Best-effort: a copy failure must not fail the PATCH.
+		try {
+			ctx.setPreImageResource(mres.copy(null));
+		} catch (ScimException | ParseException e) {
+			logger.warn("Could not capture pre-image for PATCH " + ctx.getPath() + ": " + e.getMessage());
+		}
 		mres.modifyResource(req, ctx);
 		// Modify resource will update the meta.revision
 		return this.putResource(mres, ctx);

--- a/i2scim-server/src/main/java/com/independentid/scim/backend/mongo/MongoProvider.java
+++ b/i2scim-server/src/main/java/com/independentid/scim/backend/mongo/MongoProvider.java
@@ -531,6 +531,15 @@ public class MongoProvider implements IScimProvider {
 
 		//col.remove(res, WriteConcern.ACKNOWLEDGED);
 
+		// Retain the removed resource as the pre-image so event derivation (e.g. RISC
+		// Account Purged) has subject material — ADR-0001. Best-effort: a mapping
+		// failure must not fail the delete, which has already succeeded.
+		try {
+			ctx.setPreImageResource(mapUtil.mapScimResource(res, type));
+		} catch (ScimException | BackendException e) {
+			logger.warn("Could not map pre-image for deleted resource " + id + ": " + e.getMessage());
+		}
+
 		// return success
 		return new ScimResponse(ScimResponse.ST_NOCONTENT, null, null);
 	}

--- a/i2scim-server/src/main/java/com/independentid/set/SubjectIdentifier.java
+++ b/i2scim-server/src/main/java/com/independentid/set/SubjectIdentifier.java
@@ -30,7 +30,8 @@ public class SubjectIdentifier {
 
     @JsonProperty("id")
     public String id;  // OpaqueIdentifier
-    @JsonProperty("phoneNumber")
+    // Serialized as "phone_number" (RFC 9493 phone_number format), matching toJsonNode().
+    @JsonProperty("phone_number")
     public String phoneNumber;
     @JsonProperty("url")
     public String url;  // DecentralizedId
@@ -67,6 +68,35 @@ public class SubjectIdentifier {
         SubjectIdentifier sid = new SubjectIdentifier();
         sid.format = format;
         return sid;
+    }
+
+    /**
+     * Builds a subject identifier in one of the RISC-configurable formats
+     * ({@code email}, {@code username}, {@code phone}). Slice 4 (#90).
+     *
+     * @param format the subject format.
+     * @param value  the identifier value to carry.
+     * @return the subject identifier, or {@code null} when the format is not one
+     *         of the supported value-bearing formats or {@code value} is null —
+     *         allowing the caller to fall back to a {@code scim} subject.
+     */
+    public static SubjectIdentifier forFormat(String format, String value) {
+        if (value == null) return null;
+        SubjectIdentifier sid = new SubjectIdentifier();
+        sid.format = format;
+        switch (format == null ? "" : format) {
+            case "email":
+                sid.email = value;
+                return sid;
+            case "username":
+                sid.username = value;
+                return sid;
+            case "phone":
+                sid.phoneNumber = value;
+                return sid;
+            default:
+                return null;
+        }
     }
 
     @JsonSetter("format")

--- a/i2scim-server/src/main/java/com/independentid/signals/IdentifierExtractor.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/IdentifierExtractor.java
@@ -1,0 +1,66 @@
+package com.independentid.signals;
+
+import com.independentid.scim.resource.ComplexValue;
+import com.independentid.scim.resource.MultiValue;
+import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.resource.StringValue;
+import com.independentid.scim.resource.Value;
+import com.independentid.scim.schema.SchemaException;
+
+/**
+ * Extracts a {@code User}'s primary login-identifier value from a
+ * {@link ScimResource}. A pure transformation — no I/O — so it can be
+ * unit-tested directly. Slice 3 (#89).
+ */
+public final class IdentifierExtractor {
+
+    private IdentifierExtractor() {
+    }
+
+    /**
+     * @param res      a SCIM resource (may be {@code null}).
+     * @param attrName an identifier attribute name, e.g. {@code userName} or {@code emails}.
+     * @return the primary scalar value of that identifier, or {@code null} when absent.
+     */
+    public static String primaryValue(ScimResource res, String attrName) {
+        if (res == null) return null;
+        try {
+            Value v = res.getValue(attrName);
+            if (v instanceof StringValue) {
+                return (String) v.getRawValue();
+            }
+            if (v instanceof MultiValue) {
+                return primaryOf((MultiValue) v);
+            }
+        } catch (SchemaException e) {
+            // attribute undefined for this resource — identifier absent
+        }
+        return null;
+    }
+
+    /**
+     * @return the {@code value} sub-attribute of the multi-value's primary entry.
+     *         An entry flagged {@code primary} wins; absent any such flag, a lone
+     *         entry is treated as primary. Returns {@code null} otherwise.
+     */
+    private static String primaryOf(MultiValue mv) {
+        ComplexValue lone = null;
+        int count = 0;
+        for (Value entry : mv.values()) {
+            if (!(entry instanceof ComplexValue)) continue;
+            ComplexValue cv = (ComplexValue) entry;
+            if (cv.isPrimary()) {
+                return subValue(cv, "value");
+            }
+            lone = cv;
+            count++;
+        }
+        return (count == 1) ? subValue(lone, "value") : null;
+    }
+
+    /** @return the named sub-attribute of a complex value as a string, or {@code null}. */
+    private static String subValue(ComplexValue cv, String subName) {
+        Value sub = cv.getValue(subName);
+        return (sub instanceof StringValue) ? (String) sub.getRawValue() : null;
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscConfig.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscConfig.java
@@ -1,0 +1,42 @@
+package com.independentid.signals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolved {@code scim.signals.risc.*} settings, as a plain value object so
+ * {@link RiscEventMapper} can be unit-tested without MicroProfile config.
+ */
+public class RiscConfig {
+
+    private final boolean enable;
+    private final boolean allTypes;
+    private final List<String> enabledTypes = new ArrayList<>();
+
+    /**
+     * @param enable {@code scim.signals.risc.enable} — RISC emission master switch.
+     * @param types  {@code scim.signals.risc.types} — short names (e.g. {@code account-purged})
+     *               of the RISC event types to emit; a single {@code *} (or empty) means all.
+     */
+    public RiscConfig(boolean enable, List<String> types) {
+        this.enable = enable;
+        if (types == null || types.isEmpty() || (types.size() == 1 && "*".equals(types.get(0)))) {
+            this.allTypes = true;
+        } else {
+            this.allTypes = false;
+            this.enabledTypes.addAll(types);
+        }
+    }
+
+    public boolean isEnabled() {
+        return this.enable;
+    }
+
+    /**
+     * @param shortName a RISC event-type short name, e.g. {@code account-purged}.
+     * @return true if this event type is configured for emission.
+     */
+    public boolean emits(String shortName) {
+        return this.allTypes || this.enabledTypes.contains(shortName);
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscConfig.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscConfig.java
@@ -12,11 +12,15 @@ public class RiscConfig {
     /** Default identifier attributes inspected for Identifier Changed (slice 3, #89). */
     public static final List<String> DEFAULT_IDENTIFIER_ATTRS = List.of("userName", "emails");
 
+    /** Default RISC subject identifier format — the stable {@code scim} subject (slice 4, #90). */
+    public static final String DEFAULT_SUBJECT_FORMAT = "scim";
+
     private final boolean enable;
     private final boolean allTypes;
     private final List<String> enabledTypes = new ArrayList<>();
     private final List<String> identifierAttrs = new ArrayList<>();
     private final boolean addRemoveIsChange;
+    private final String subjectFormat;
 
     /**
      * @param enable {@code scim.signals.risc.enable} — RISC emission master switch.
@@ -37,6 +41,22 @@ public class RiscConfig {
      */
     public RiscConfig(boolean enable, List<String> types,
                       List<String> identifierAttrs, boolean addRemoveIsChange) {
+        this(enable, types, identifierAttrs, addRemoveIsChange, DEFAULT_SUBJECT_FORMAT);
+    }
+
+    /**
+     * @param enable            {@code scim.signals.risc.enable} — RISC emission master switch.
+     * @param types             {@code scim.signals.risc.types} — RISC event-type short names; {@code *} means all.
+     * @param identifierAttrs   {@code scim.signals.risc.identifier.attrs} — attributes whose
+     *                          primary value drives Identifier Changed.
+     * @param addRemoveIsChange {@code scim.signals.risc.identifier.addRemoveIsChange} — whether a
+     *                          pure add or removal of an identifier value counts as a change.
+     * @param subjectFormat     {@code scim.signals.risc.subject.format} — the subject identifier
+     *                          format ({@code scim}/{@code email}/{@code username}/{@code phone})
+     *                          used for all RISC events.
+     */
+    public RiscConfig(boolean enable, List<String> types,
+                      List<String> identifierAttrs, boolean addRemoveIsChange, String subjectFormat) {
         this.enable = enable;
         if (types == null || types.isEmpty() || (types.size() == 1 && "*".equals(types.get(0)))) {
             this.allTypes = true;
@@ -50,6 +70,8 @@ public class RiscConfig {
             this.identifierAttrs.addAll(identifierAttrs);
         }
         this.addRemoveIsChange = addRemoveIsChange;
+        this.subjectFormat = (subjectFormat == null || subjectFormat.isBlank())
+                ? DEFAULT_SUBJECT_FORMAT : subjectFormat;
     }
 
     public boolean isEnabled() {
@@ -72,5 +94,10 @@ public class RiscConfig {
     /** @return whether a pure add or removal of an identifier value counts as a change. */
     public boolean isAddRemoveChange() {
         return this.addRemoveIsChange;
+    }
+
+    /** @return the RISC subject identifier format used for all RISC events. */
+    public String getSubjectFormat() {
+        return this.subjectFormat;
     }
 }

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscConfig.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscConfig.java
@@ -9,9 +9,14 @@ import java.util.List;
  */
 public class RiscConfig {
 
+    /** Default identifier attributes inspected for Identifier Changed (slice 3, #89). */
+    public static final List<String> DEFAULT_IDENTIFIER_ATTRS = List.of("userName", "emails");
+
     private final boolean enable;
     private final boolean allTypes;
     private final List<String> enabledTypes = new ArrayList<>();
+    private final List<String> identifierAttrs = new ArrayList<>();
+    private final boolean addRemoveIsChange;
 
     /**
      * @param enable {@code scim.signals.risc.enable} — RISC emission master switch.
@@ -19,6 +24,19 @@ public class RiscConfig {
      *               of the RISC event types to emit; a single {@code *} (or empty) means all.
      */
     public RiscConfig(boolean enable, List<String> types) {
+        this(enable, types, DEFAULT_IDENTIFIER_ATTRS, true);
+    }
+
+    /**
+     * @param enable            {@code scim.signals.risc.enable} — RISC emission master switch.
+     * @param types             {@code scim.signals.risc.types} — RISC event-type short names; {@code *} means all.
+     * @param identifierAttrs   {@code scim.signals.risc.identifier.attrs} — attributes whose
+     *                          primary value drives Identifier Changed.
+     * @param addRemoveIsChange {@code scim.signals.risc.identifier.addRemoveIsChange} — whether a
+     *                          pure add or removal of an identifier value counts as a change.
+     */
+    public RiscConfig(boolean enable, List<String> types,
+                      List<String> identifierAttrs, boolean addRemoveIsChange) {
         this.enable = enable;
         if (types == null || types.isEmpty() || (types.size() == 1 && "*".equals(types.get(0)))) {
             this.allTypes = true;
@@ -26,6 +44,12 @@ public class RiscConfig {
             this.allTypes = false;
             this.enabledTypes.addAll(types);
         }
+        if (identifierAttrs == null || identifierAttrs.isEmpty()) {
+            this.identifierAttrs.addAll(DEFAULT_IDENTIFIER_ATTRS);
+        } else {
+            this.identifierAttrs.addAll(identifierAttrs);
+        }
+        this.addRemoveIsChange = addRemoveIsChange;
     }
 
     public boolean isEnabled() {
@@ -38,5 +62,15 @@ public class RiscConfig {
      */
     public boolean emits(String shortName) {
         return this.allTypes || this.enabledTypes.contains(shortName);
+    }
+
+    /** @return the attribute names whose primary value drives Identifier Changed. */
+    public List<String> getIdentifierAttrs() {
+        return this.identifierAttrs;
+    }
+
+    /** @return whether a pure add or removal of an identifier value counts as a change. */
+    public boolean isAddRemoveChange() {
+        return this.addRemoveIsChange;
     }
 }

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
@@ -1,6 +1,8 @@
 package com.independentid.signals;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.independentid.scim.backend.IIdentifierGenerator;
+import com.independentid.scim.core.err.ScimException;
 import com.independentid.scim.op.Operation;
 import com.independentid.scim.op.PatchOp;
 import com.independentid.scim.protocol.JsonPatchOp;
@@ -15,9 +17,11 @@ import com.independentid.set.SecurityEventToken;
 import com.independentid.set.SubjectIdentifier;
 import org.jose4j.jwt.NumericDate;
 
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Derives OpenID RISC {@link SecurityEventToken}s from a completed SCIM
@@ -59,18 +63,25 @@ public class RiscEventMapper {
         } else if ("PUT".equals(op.getScimType())) {
             ScimResource preImage = ctx.getPreImageResource();
             if (isUser(preImage)) {
+                ScimResource postImage = op.getTransactionResource();
                 boolean before = isActive(preImage);
-                boolean after = isActive(op.getTransactionResource());
+                boolean after = isActive(postImage);
                 if (before != after) {
                     addActiveEvent(events, op, preImage, activeEventType(after));
                 }
+                addIdentifierEvents(events, op, preImage, postImage);
             }
         } else if ("PAT".equals(op.getScimType()) && op instanceof PatchOp) {
             ScimResource preImage = ctx.getPreImageResource();
             if (isUser(preImage)) {
-                Boolean signal = activeSignalFromPatch((PatchOp) op);
+                PatchOp pop = (PatchOp) op;
+                Boolean signal = activeSignalFromPatch(pop);
                 if (signal != null) {
                     addActiveEvent(events, op, preImage, activeEventType(signal));
+                }
+                ScimResource postImage = applyPatch(preImage, pop, ctx);
+                if (postImage != null) {
+                    addIdentifierEvents(events, op, preImage, postImage);
                 }
             }
         }
@@ -138,6 +149,23 @@ public class RiscEventMapper {
         return null;
     }
 
+    /**
+     * Derives a PATCH post-image by applying the patch to a copy of the
+     * pre-image — a pure, in-memory transformation (no backend I/O).
+     * @return the post-image, or {@code null} if it cannot be derived.
+     */
+    private ScimResource applyPatch(ScimResource preImage, PatchOp op, RequestCtx ctx) {
+        JsonPatchRequest req = op.getPatchRequest();
+        if (req == null) return null;
+        try {
+            ScimResource postImage = preImage.copy(null);
+            postImage.modifyResource(req, ctx);
+            return postImage;
+        } catch (ScimException | ParseException e) {
+            return null;
+        }
+    }
+
     /** @return the bare attribute name from a patch path (strips any schema URN prefix). */
     private String attrName(String path) {
         if (path == null) return null;
@@ -155,14 +183,56 @@ public class RiscEventMapper {
 
     /** Builds a RISC account-level SET sharing the operation's txn and toe. */
     private SecurityEventToken buildAccountEvent(Operation op, ScimResource subject, String eventTypeUri) {
+        SecurityEventToken event = newEvent(op, subject);
+        // Account events omit the optional RISC "reason" attribute.
+        event.AddEventPayload(eventTypeUri, JsonUtil.getMapper().createObjectNode());
+        return event;
+    }
+
+    /**
+     * Emits an Identifier Changed SET for each configured identifier attribute
+     * whose primary value differs between the pre- and post-image.
+     */
+    private void addIdentifierEvents(List<SecurityEventToken> events, Operation op,
+                                     ScimResource preImage, ScimResource postImage) {
+        if (!config.emits(RiscEventTypes.shortName(RiscEventTypes.IDENTIFIER_CHANGED))) return;
+        for (String attr : config.getIdentifierAttrs()) {
+            String before = IdentifierExtractor.primaryValue(preImage, attr);
+            String after = IdentifierExtractor.primaryValue(postImage, attr);
+            if (isIdentifierChange(before, after)) {
+                events.add(buildIdentifierEvent(op, preImage, after));
+            }
+        }
+    }
+
+    /**
+     * @return true when {@code before}→{@code after} is an identifier change.
+     *         A pure add or removal (one side {@code null}) counts only when
+     *         {@code addRemoveIsChange} is configured.
+     */
+    private boolean isIdentifierChange(String before, String after) {
+        if (Objects.equals(before, after)) return false;
+        if (before == null || after == null) return config.isAddRemoveChange();
+        return true;
+    }
+
+    /** Builds a RISC Identifier Changed SET carrying the new value in {@code new-value}. */
+    private SecurityEventToken buildIdentifierEvent(Operation op, ScimResource subject, String newValue) {
+        SecurityEventToken event = newEvent(op, subject);
+        ObjectNode payload = JsonUtil.getMapper().createObjectNode();
+        if (newValue != null) payload.put("new-value", newValue);
+        event.AddEventPayload(RiscEventTypes.IDENTIFIER_CHANGED, payload);
+        return event;
+    }
+
+    /** Builds a bare RISC SET — subject, distinct jti, and the operation's shared txn/toe. */
+    private SecurityEventToken newEvent(Operation op, ScimResource subject) {
         SecurityEventToken event = new SecurityEventToken();
         event.SetSubjectIdentifier(new SubjectIdentifier(subject));
         String txn = op.getRequestCtx().getTranId();
         if (txn != null) event.setTxn(txn);
         event.setJti(idGen.getNewIdentifier());
         event.setToe(NumericDate.fromMilliseconds(op.getStats().getFinishDate().getTime()));
-        // Account events omit the optional RISC "reason" attribute.
-        event.AddEventPayload(eventTypeUri, JsonUtil.getMapper().createObjectNode());
         return event;
     }
 }

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
@@ -228,11 +228,43 @@ public class RiscEventMapper {
     /** Builds a bare RISC SET — subject, distinct jti, and the operation's shared txn/toe. */
     private SecurityEventToken newEvent(Operation op, ScimResource subject) {
         SecurityEventToken event = new SecurityEventToken();
-        event.SetSubjectIdentifier(new SubjectIdentifier(subject));
+        event.SetSubjectIdentifier(buildSubject(subject));
         String txn = op.getRequestCtx().getTranId();
         if (txn != null) event.setTxn(txn);
         event.setJti(idGen.getNewIdentifier());
         event.setToe(NumericDate.fromMilliseconds(op.getStats().getFinishDate().getTime()));
         return event;
+    }
+
+    /**
+     * Builds the RISC subject identifier in the configured
+     * {@code scim.signals.risc.subject.format}. A non-{@code scim} format
+     * carries the primary value of the matching {@code User} attribute (for
+     * Identifier Changed this resource is the pre-image, so that value is the
+     * prior identifier). Falls back to the stable {@code scim} subject when the
+     * configured format cannot be satisfied for the resource.
+     */
+    private SubjectIdentifier buildSubject(ScimResource res) {
+        String format = config.getSubjectFormat();
+        if (!"scim".equals(format)) {
+            String value = IdentifierExtractor.primaryValue(res, attrForFormat(format));
+            SubjectIdentifier sid = SubjectIdentifier.forFormat(format, value);
+            if (sid != null) return sid;
+        }
+        return new SubjectIdentifier(res);
+    }
+
+    /** @return the {@code User} attribute backing a subject format, or {@code null} for {@code scim}. */
+    private static String attrForFormat(String format) {
+        switch (format == null ? "" : format) {
+            case "email":
+                return "emails";
+            case "username":
+                return "userName";
+            case "phone":
+                return "phoneNumbers";
+            default:
+                return null;
+        }
     }
 }

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
@@ -1,0 +1,68 @@
+package com.independentid.signals;
+
+import com.independentid.scim.backend.IIdentifierGenerator;
+import com.independentid.scim.op.Operation;
+import com.independentid.scim.protocol.RequestCtx;
+import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.serializer.JsonUtil;
+import com.independentid.set.SecurityEventToken;
+import com.independentid.set.SubjectIdentifier;
+import org.jose4j.jwt.NumericDate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Derives OpenID RISC {@link SecurityEventToken}s from a completed SCIM
+ * {@link Operation}. A pure transformation — no I/O, no Quarkus lookups — so it
+ * can be unit-tested directly. Slice 1 (#87) derives Account Purged from a
+ * {@code User} DELETE.
+ */
+public class RiscEventMapper {
+
+    private final RiscConfig config;
+    private final IIdentifierGenerator idGen;
+
+    public RiscEventMapper(RiscConfig config, IIdentifierGenerator idGen) {
+        this.config = config;
+        this.idGen = idGen;
+    }
+
+    /**
+     * Maps a completed operation to the RISC events it implies.
+     * @param op a completed SCIM operation.
+     * @return the derived RISC SETs; empty when no RISC event applies.
+     */
+    public List<SecurityEventToken> mapToRiscEvents(Operation op) {
+        List<SecurityEventToken> events = new ArrayList<>();
+        if (op == null || !config.isEnabled()) return events;
+        RequestCtx ctx = op.getRequestCtx();
+        if (ctx == null) return events;
+
+        if ("DEL".equals(op.getScimType())) {
+            ScimResource preImage = ctx.getPreImageResource();
+            if (isUser(preImage) && config.emits(RiscEventTypes.shortName(RiscEventTypes.ACCOUNT_PURGED))) {
+                events.add(buildAccountEvent(op, preImage, RiscEventTypes.ACCOUNT_PURGED));
+            }
+        }
+        return events;
+    }
+
+    /** RISC events are emitted only for {@code User} resources. */
+    private boolean isUser(ScimResource res) {
+        return res != null && "User".equals(res.getResourceType());
+    }
+
+    /** Builds a RISC account-level SET sharing the operation's txn and toe. */
+    private SecurityEventToken buildAccountEvent(Operation op, ScimResource subject, String eventTypeUri) {
+        SecurityEventToken event = new SecurityEventToken();
+        event.SetSubjectIdentifier(new SubjectIdentifier(subject));
+        String txn = op.getRequestCtx().getTranId();
+        if (txn != null) event.setTxn(txn);
+        event.setJti(idGen.getNewIdentifier());
+        event.setToe(NumericDate.fromMilliseconds(op.getStats().getFinishDate().getTime()));
+        // Account events omit the optional RISC "reason" attribute.
+        event.AddEventPayload(eventTypeUri, JsonUtil.getMapper().createObjectNode());
+        return event;
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscEventMapper.java
@@ -2,14 +2,21 @@ package com.independentid.signals;
 
 import com.independentid.scim.backend.IIdentifierGenerator;
 import com.independentid.scim.op.Operation;
+import com.independentid.scim.op.PatchOp;
+import com.independentid.scim.protocol.JsonPatchOp;
+import com.independentid.scim.protocol.JsonPatchRequest;
 import com.independentid.scim.protocol.RequestCtx;
+import com.independentid.scim.resource.BooleanValue;
 import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.resource.Value;
+import com.independentid.scim.schema.SchemaException;
 import com.independentid.scim.serializer.JsonUtil;
 import com.independentid.set.SecurityEventToken;
 import com.independentid.set.SubjectIdentifier;
 import org.jose4j.jwt.NumericDate;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -44,6 +51,28 @@ public class RiscEventMapper {
             if (isUser(preImage) && config.emits(RiscEventTypes.shortName(RiscEventTypes.ACCOUNT_PURGED))) {
                 events.add(buildAccountEvent(op, preImage, RiscEventTypes.ACCOUNT_PURGED));
             }
+        } else if ("ADD".equals(op.getScimType())) {
+            ScimResource postImage = op.getTransactionResource();
+            if (isUser(postImage)) {
+                addActiveEvent(events, op, postImage, activeEventType(isActive(postImage)));
+            }
+        } else if ("PUT".equals(op.getScimType())) {
+            ScimResource preImage = ctx.getPreImageResource();
+            if (isUser(preImage)) {
+                boolean before = isActive(preImage);
+                boolean after = isActive(op.getTransactionResource());
+                if (before != after) {
+                    addActiveEvent(events, op, preImage, activeEventType(after));
+                }
+            }
+        } else if ("PAT".equals(op.getScimType()) && op instanceof PatchOp) {
+            ScimResource preImage = ctx.getPreImageResource();
+            if (isUser(preImage)) {
+                Boolean signal = activeSignalFromPatch((PatchOp) op);
+                if (signal != null) {
+                    addActiveEvent(events, op, preImage, activeEventType(signal));
+                }
+            }
         }
         return events;
     }
@@ -51,6 +80,77 @@ public class RiscEventMapper {
     /** RISC events are emitted only for {@code User} resources. */
     private boolean isUser(ScimResource res) {
         return res != null && "User".equals(res.getResourceType());
+    }
+
+    /** @return the RISC event-type URI for the given {@code active} state. */
+    private String activeEventType(boolean active) {
+        return active ? RiscEventTypes.ACCOUNT_ENABLED : RiscEventTypes.ACCOUNT_DISABLED;
+    }
+
+    /** Reads a User's {@code active} state; an absent {@code active} is treated as enabled. */
+    private boolean isActive(ScimResource res) {
+        if (res == null) return true;
+        try {
+            Value v = res.getValue("active");
+            if (v instanceof BooleanValue) {
+                Boolean b = ((BooleanValue) v).getRawValue();
+                return b == null || b;
+            }
+        } catch (SchemaException e) {
+            // active is undefined for this resource — treat as enabled
+        }
+        return true;
+    }
+
+    /**
+     * Inspects a JSON Patch request for operations that set the {@code active}
+     * attribute. The last such operation wins.
+     * @return the resulting {@code active} state, or {@code null} if no patch
+     *         operation touched {@code active}.
+     */
+    private Boolean activeSignalFromPatch(PatchOp op) {
+        Boolean signal = null;
+        JsonPatchRequest req = op.getPatchRequest();
+        if (req == null) return null;
+        for (Iterator<JsonPatchOp> it = req.iterator(); it.hasNext(); ) {
+            Boolean s = activeFromPatchOp(it.next());
+            if (s != null) signal = s;
+        }
+        return signal;
+    }
+
+    /** @return the {@code active} state implied by one patch op, or {@code null} if it does not touch {@code active}. */
+    private Boolean activeFromPatchOp(JsonPatchOp patchOp) {
+        boolean targetsActive = "active".equalsIgnoreCase(attrName(patchOp.path));
+        if (JsonPatchOp.OP_ACTION_REMOVE.equals(patchOp.op)) {
+            // Removing active reverts it to the schema default — enabled.
+            return targetsActive ? Boolean.TRUE : null;
+        }
+        // add or replace: the new value is taken directly as the signal.
+        if (targetsActive) {
+            return patchOp.jsonValue != null && patchOp.jsonValue.asBoolean();
+        }
+        // A path-less value object may carry active among other attributes.
+        if (patchOp.path == null && patchOp.jsonValue != null
+                && patchOp.jsonValue.isObject() && patchOp.jsonValue.has("active")) {
+            return patchOp.jsonValue.get("active").asBoolean();
+        }
+        return null;
+    }
+
+    /** @return the bare attribute name from a patch path (strips any schema URN prefix). */
+    private String attrName(String path) {
+        if (path == null) return null;
+        int colon = path.lastIndexOf(':');
+        return colon < 0 ? path : path.substring(colon + 1);
+    }
+
+    /** Adds the given account-state RISC event when its type is configured for emission. */
+    private void addActiveEvent(List<SecurityEventToken> events, Operation op,
+                                ScimResource subject, String eventTypeUri) {
+        if (config.emits(RiscEventTypes.shortName(eventTypeUri))) {
+            events.add(buildAccountEvent(op, subject, eventTypeUri));
+        }
     }
 
     /** Builds a RISC account-level SET sharing the operation's txn and toe. */

--- a/i2scim-server/src/main/java/com/independentid/signals/RiscEventTypes.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/RiscEventTypes.java
@@ -1,0 +1,27 @@
+package com.independentid.signals;
+
+/**
+ * OpenID RISC event-type URIs (OpenID RISC Profile 1.0), parallel to {@link EventTypes}.
+ * The last path segment of each URI is the short name used in the
+ * {@code scim.signals.risc.types} configuration list.
+ */
+public class RiscEventTypes {
+
+    public final static String ACCOUNT_PURGED =
+            "https://schemas.openid.net/secevent/risc/event-type/account-purged";
+    public final static String ACCOUNT_DISABLED =
+            "https://schemas.openid.net/secevent/risc/event-type/account-disabled";
+    public final static String ACCOUNT_ENABLED =
+            "https://schemas.openid.net/secevent/risc/event-type/account-enabled";
+    public final static String IDENTIFIER_CHANGED =
+            "https://schemas.openid.net/secevent/risc/event-type/identifier-changed";
+
+    /**
+     * @param eventTypeUri a RISC event-type URI
+     * @return the short name (last path segment), e.g. {@code account-purged}.
+     */
+    public static String shortName(String eventTypeUri) {
+        int slash = eventTypeUri.lastIndexOf('/');
+        return slash < 0 ? eventTypeUri : eventTypeUri.substring(slash + 1);
+    }
+}

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -85,6 +85,12 @@ public class SignalsEventHandler implements IEventHandler {
     @ConfigProperty(name = "scim.signals.risc.types", defaultValue = "*")
     Optional<List<String>> riscTypes;
 
+    @ConfigProperty(name = "scim.signals.risc.identifier.attrs", defaultValue = "userName,emails")
+    Optional<List<String>> riscIdentifierAttrs;
+
+    @ConfigProperty(name = "scim.signals.risc.identifier.addRemoveIsChange", defaultValue = "true")
+    boolean riscIdentifierAddRemoveIsChange;
+
     @ConfigProperty(name = "scim.signals.test", defaultValue = "false")
     boolean isTest;
 
@@ -179,8 +185,10 @@ public class SignalsEventHandler implements IEventHandler {
             all.add("*");
             return all;
         });
+        List<String> riscIdAttrs = riscIdentifierAttrs.orElse(RiscConfig.DEFAULT_IDENTIFIER_ATTRS);
         this.riscMapper = new RiscEventMapper(
-                new RiscConfig(riscEnabled, riscCfgTypes), InjectionManager.getInstance().getGenerator());
+                new RiscConfig(riscEnabled, riscCfgTypes, riscIdAttrs, riscIdentifierAddRemoveIsChange),
+                InjectionManager.getInstance().getGenerator());
 
         try {
             if (isTest)

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -79,6 +79,12 @@ public class SignalsEventHandler implements IEventHandler {
     @ConfigProperty(name = "scim.signals.rcv.types", defaultValue = "*")
     Optional<List<String>> rcvTypes;
 
+    @ConfigProperty(name = "scim.signals.risc.enable", defaultValue = "false")
+    boolean riscEnabled;
+
+    @ConfigProperty(name = "scim.signals.risc.types", defaultValue = "*")
+    Optional<List<String>> riscTypes;
+
     @ConfigProperty(name = "scim.signals.test", defaultValue = "false")
     boolean isTest;
 
@@ -118,6 +124,8 @@ public class SignalsEventHandler implements IEventHandler {
     SsfHandler ssfClient;
 
     SignalsEventMapper mapper;
+
+    RiscEventMapper riscMapper;
 
     StreamMaintenanceScheduler scheduler;
 
@@ -165,6 +173,14 @@ public class SignalsEventHandler implements IEventHandler {
         }
 
         this.mapper = new SignalsEventMapper(pubCfgTypes, rcvCfgTypes, InjectionManager.getInstance().getGenerator());
+
+        List<String> riscCfgTypes = riscTypes.orElseGet(() -> {
+            List<String> all = new ArrayList<>();
+            all.add("*");
+            return all;
+        });
+        this.riscMapper = new RiscEventMapper(
+                new RiscConfig(riscEnabled, riscCfgTypes), InjectionManager.getInstance().getGenerator());
 
         try {
             if (isTest)
@@ -446,8 +462,12 @@ public class SignalsEventHandler implements IEventHandler {
         PushStream push = ssfClient.getPushStream();
         if (push == null) return;
 
-        List<SecurityEventToken> events = mapper.MapOperationToSet(op);
-        if (events == null || events.isEmpty()) return;
+        List<SecurityEventToken> events = new ArrayList<>();
+        List<SecurityEventToken> scimEvents = mapper.MapOperationToSet(op);
+        if (scimEvents != null) events.addAll(scimEvents);
+        // RISC events derived from the same operation ride the same push stream.
+        if (riscMapper != null) events.addAll(riscMapper.mapToRiscEvents(op));
+        if (events.isEmpty()) return;
 
         for (SecurityEventToken token : events) {
             attemptInlineAndEnqueueOnFailure(push, pendingPushStore, token, op);

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -91,6 +91,9 @@ public class SignalsEventHandler implements IEventHandler {
     @ConfigProperty(name = "scim.signals.risc.identifier.addRemoveIsChange", defaultValue = "true")
     boolean riscIdentifierAddRemoveIsChange;
 
+    @ConfigProperty(name = "scim.signals.risc.subject.format", defaultValue = "scim")
+    String riscSubjectFormat;
+
     @ConfigProperty(name = "scim.signals.test", defaultValue = "false")
     boolean isTest;
 
@@ -187,7 +190,8 @@ public class SignalsEventHandler implements IEventHandler {
         });
         List<String> riscIdAttrs = riscIdentifierAttrs.orElse(RiscConfig.DEFAULT_IDENTIFIER_ATTRS);
         this.riscMapper = new RiscEventMapper(
-                new RiscConfig(riscEnabled, riscCfgTypes, riscIdAttrs, riscIdentifierAddRemoveIsChange),
+                new RiscConfig(riscEnabled, riscCfgTypes, riscIdAttrs,
+                        riscIdentifierAddRemoveIsChange, riscSubjectFormat),
                 InjectionManager.getInstance().getGenerator());
 
         try {

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/IdentifierExtractorTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/IdentifierExtractorTest.java
@@ -1,0 +1,91 @@
+package com.independentid.scim.test.events;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.schema.SchemaManager;
+import com.independentid.scim.serializer.JsonUtil;
+import com.independentid.signals.IdentifierExtractor;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Unit tests for {@link IdentifierExtractor} — the pure extraction of a
+ * {@code User}'s primary login identifier value from a {@link ScimResource}.
+ * Slice 3 (#89).
+ */
+@QuarkusTest
+@TestProfile(RiscMapperTestProfile.class)
+public class IdentifierExtractorTest {
+    private final static Logger logger = LoggerFactory.getLogger(IdentifierExtractorTest.class);
+
+    @Inject
+    SchemaManager schemaManager;
+
+    /** Builds a User {@link ScimResource} from a JSON document. */
+    private ScimResource user(String json) throws Exception {
+        JsonNode node = JsonUtil.getJsonTree(json);
+        return new ScimResource(schemaManager, node, "Users");
+    }
+
+    @Test
+    public void singularUserNameExtracted() {
+        logger.info("IdentifierExtractor: singular userName");
+        try {
+            ScimResource res = user("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\"],"
+                    + "\"userName\":\"alice@example.com\"}");
+            assertThat(IdentifierExtractor.primaryValue(res, "userName"))
+                    .as("Singular userName extracted").isEqualTo("alice@example.com");
+        } catch (Exception e) {
+            fail("Error extracting singular userName: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void absentIdentifierReturnsNull() {
+        logger.info("IdentifierExtractor: an absent identifier");
+        try {
+            ScimResource res = user("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\"],"
+                    + "\"userName\":\"alice@example.com\"}");
+            assertThat(IdentifierExtractor.primaryValue(res, "emails"))
+                    .as("Absent emails identifier extracts as null").isNull();
+        } catch (Exception e) {
+            fail("Error extracting absent identifier: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void loneEmailTreatedAsPrimary() {
+        logger.info("IdentifierExtractor: a lone email with no primary flag");
+        try {
+            ScimResource res = user("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\"],"
+                    + "\"userName\":\"alice@example.com\","
+                    + "\"emails\":[{\"value\":\"only@example.com\",\"type\":\"work\"}]}");
+            assertThat(IdentifierExtractor.primaryValue(res, "emails"))
+                    .as("Lone email value treated as primary").isEqualTo("only@example.com");
+        } catch (Exception e) {
+            fail("Error extracting lone email: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void multiValuedEmailsPrimaryExtracted() {
+        logger.info("IdentifierExtractor: emails with an explicit primary");
+        try {
+            ScimResource res = user("{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:User\"],"
+                    + "\"userName\":\"alice@example.com\","
+                    + "\"emails\":[{\"value\":\"home@example.com\",\"type\":\"home\"},"
+                    + "{\"value\":\"work@example.com\",\"type\":\"work\",\"primary\":true}]}");
+            assertThat(IdentifierExtractor.primaryValue(res, "emails"))
+                    .as("Primary email value extracted").isEqualTo("work@example.com");
+        } catch (Exception e) {
+            fail("Error extracting primary email: " + e.getMessage(), e);
+        }
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/MockSignalsServer.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/MockSignalsServer.java
@@ -73,6 +73,9 @@ public class MockSignalsServer {
     static int miscErrs = 0;
     static Map<String, SecurityEventToken> pollEvents = new HashMap<>();
     static Map<String, SecurityEventToken> ackEvents = new HashMap<>();
+    // Non-draining record of every SET received via push — survives poll drain so
+    // tests can inspect what was pushed regardless of receiver timing.
+    static final List<SecurityEventToken> allReceived = new ArrayList<>();
     static int ackedCnt = 0;
     static int sent = 0;
 
@@ -298,6 +301,7 @@ public class MockSignalsServer {
             SecurityEventToken token = new SecurityEventToken(eventString, publicKey, null);
             logger.info("Received event:\n" + token.toPrettyString());
             pollEvents.put(token.getJti(), token);
+            allReceived.add(token);
             received++;
             return Response.accepted().build();
         } catch (InvalidJwtException | JoseException e) {
@@ -426,6 +430,23 @@ public class MockSignalsServer {
 
     public static int getPendingPollCnt() {
         return pollEvents.size();
+    }
+
+    /**
+     * Clears all accumulated counters and event stores. The counters are JVM-static
+     * and survive Quarkus restarts between test profiles, so any test that asserts on
+     * exact counts must call this at its start to baseline itself against other
+     * tests that push to this mock.
+     */
+    public static void reset() {
+        received = 0;
+        jwtErrs = 0;
+        miscErrs = 0;
+        ackedCnt = 0;
+        sent = 0;
+        pollEvents.clear();
+        ackEvents.clear();
+        allReceived.clear();
     }
 
     public static void addPollEvents(List<SecurityEventToken> events) {

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventHandlerTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventHandlerTest.java
@@ -1,12 +1,18 @@
 package com.independentid.scim.test.events;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.independentid.scim.core.ConfigMgr;
 import com.independentid.scim.core.PoolManager;
 import com.independentid.scim.op.CreateOp;
 import com.independentid.scim.op.DeleteOp;
 import com.independentid.scim.op.Operation;
+import com.independentid.scim.op.PatchOp;
+import com.independentid.scim.protocol.JsonPatchOp;
+import com.independentid.scim.protocol.JsonPatchRequest;
 import com.independentid.scim.protocol.RequestCtx;
+import com.independentid.scim.resource.BooleanValue;
+import com.independentid.scim.schema.Attribute;
 import com.independentid.scim.schema.SchemaManager;
 import com.independentid.scim.serializer.JsonUtil;
 import com.independentid.set.SecurityEventToken;
@@ -105,6 +111,65 @@ public class RiscEventHandlerTest {
                     .isEqualTo(scimDelete.getTxn());
         } catch (Exception e) {
             fail("Error in RISC end-to-end test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void accountDisabledPushedEndToEnd() {
+        logger.info("=== RISC Account Disabled end-to-end push ===");
+        try {
+            utils.resetMemDirectory();
+            Operation.initialize(configMgr);
+            MockSignalsServer.reset();
+
+            // Create an (enabled) User. Drop the sample's fixed id/externalId and
+            // give it a unique userName so it never collides with the bjensen used
+            // by accountPurgedPushedEndToEnd, regardless of test order.
+            InputStream userStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+            assertThat(userStream).isNotNull();
+            ObjectNode node = (ObjectNode) JsonUtil.getJsonTree(userStream);
+            node.remove("id");
+            node.remove("externalId");
+            node.put("userName", "risc-disable-" + java.util.UUID.randomUUID() + "@example.com");
+            RequestCtx createCtx = new RequestCtx("Users", null, null, schemaManager);
+            CreateOp createOp = new CreateOp(node, createCtx, null, 0);
+            poolManager.addJobAndWait(createOp);
+            assertThat(createOp.isError()).as("User create succeeded").isFalse();
+            String id = createOp.getResourceId();
+
+            // ...then disable it with a PATCH of active=false.
+            Attribute activeAttr = schemaManager.findAttribute("User:active", null);
+            JsonPatchRequest jpr = new JsonPatchRequest();
+            jpr.addOperation(new JsonPatchOp(JsonPatchOp.OP_ACTION_REPLACE, "active",
+                    new BooleanValue(activeAttr, false)));
+            RequestCtx patchCtx = new RequestCtx("Users", id, null, schemaManager);
+            PatchOp patchOp = new PatchOp(jpr.toJsonNode(), patchCtx, null, 0);
+            poolManager.addJobAndWait(patchOp);
+            assertThat(patchOp.isError()).as("User patch succeeded").isFalse();
+
+            // Event publication is async — wait for the Account Disabled SET.
+            SecurityEventToken disabled = null;
+            for (int i = 0; i < 15 && disabled == null; i++) {
+                disabled = findReceivedEvent(RiscEventTypes.ACCOUNT_DISABLED);
+                if (disabled == null) Thread.sleep(1000);
+            }
+            assertThat(disabled)
+                    .as("Account Disabled SET pushed to the receiver").isNotNull();
+            assertThat(disabled.GetEvents().size())
+                    .as("One event per SET").isEqualTo(1);
+
+            SecurityEventToken scimPatch = findReceivedEvent(EventTypes.PROV_PATCH_FULL);
+            assertThat(scimPatch)
+                    .as("SCIM patch SET also pushed to the receiver").isNotNull();
+            assertThat(scimPatch.getJti())
+                    .as("RISC and SCIM SETs are distinct").isNotEqualTo(disabled.getJti());
+
+            assertThat(disabled.getTxn())
+                    .as("RISC SET shares txn with the SCIM patch event")
+                    .isNotNull()
+                    .isEqualTo(scimPatch.getTxn());
+        } catch (Exception e) {
+            fail("Error in RISC Account Disabled end-to-end test: " + e.getMessage(), e);
         }
     }
 }

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventHandlerTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventHandlerTest.java
@@ -12,6 +12,7 @@ import com.independentid.scim.protocol.JsonPatchOp;
 import com.independentid.scim.protocol.JsonPatchRequest;
 import com.independentid.scim.protocol.RequestCtx;
 import com.independentid.scim.resource.BooleanValue;
+import com.independentid.scim.resource.StringValue;
 import com.independentid.scim.schema.Attribute;
 import com.independentid.scim.schema.SchemaManager;
 import com.independentid.scim.serializer.JsonUtil;
@@ -170,6 +171,66 @@ public class RiscEventHandlerTest {
                     .isEqualTo(scimPatch.getTxn());
         } catch (Exception e) {
             fail("Error in RISC Account Disabled end-to-end test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void identifierChangedPushedEndToEnd() {
+        logger.info("=== RISC Identifier Changed end-to-end push ===");
+        try {
+            utils.resetMemDirectory();
+            Operation.initialize(configMgr);
+            MockSignalsServer.reset();
+
+            // Create a User with a unique userName.
+            InputStream userStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+            assertThat(userStream).isNotNull();
+            ObjectNode node = (ObjectNode) JsonUtil.getJsonTree(userStream);
+            node.remove("id");
+            node.remove("externalId");
+            node.put("userName", "risc-idchg-" + java.util.UUID.randomUUID() + "@example.com");
+            RequestCtx createCtx = new RequestCtx("Users", null, null, schemaManager);
+            CreateOp createOp = new CreateOp(node, createCtx, null, 0);
+            poolManager.addJobAndWait(createOp);
+            assertThat(createOp.isError()).as("User create succeeded").isFalse();
+            String id = createOp.getResourceId();
+
+            // ...then change its login identifier with a PATCH of userName.
+            Attribute userNameAttr = schemaManager.findAttribute("User:userName", null);
+            String newName = "risc-renamed-" + java.util.UUID.randomUUID() + "@example.com";
+            JsonPatchRequest jpr = new JsonPatchRequest();
+            jpr.addOperation(new JsonPatchOp(JsonPatchOp.OP_ACTION_REPLACE, "userName",
+                    new StringValue(userNameAttr, newName)));
+            RequestCtx patchCtx = new RequestCtx("Users", id, null, schemaManager);
+            PatchOp patchOp = new PatchOp(jpr.toJsonNode(), patchCtx, null, 0);
+            poolManager.addJobAndWait(patchOp);
+            assertThat(patchOp.isError()).as("User patch succeeded").isFalse();
+
+            // Event publication is async — wait for the Identifier Changed SET.
+            SecurityEventToken changed = null;
+            for (int i = 0; i < 15 && changed == null; i++) {
+                changed = findReceivedEvent(RiscEventTypes.IDENTIFIER_CHANGED);
+                if (changed == null) Thread.sleep(1000);
+            }
+            assertThat(changed)
+                    .as("Identifier Changed SET pushed to the receiver").isNotNull();
+            assertThat(changed.GetEvents().size())
+                    .as("One event per SET").isEqualTo(1);
+            assertThat(changed.GetEvent(RiscEventTypes.IDENTIFIER_CHANGED).get("new-value").asText())
+                    .as("Payload carries the new identifier value").isEqualTo(newName);
+
+            SecurityEventToken scimPatch = findReceivedEvent(EventTypes.PROV_PATCH_FULL);
+            assertThat(scimPatch)
+                    .as("SCIM patch SET also pushed to the receiver").isNotNull();
+            assertThat(scimPatch.getJti())
+                    .as("RISC and SCIM SETs are distinct").isNotEqualTo(changed.getJti());
+
+            assertThat(changed.getTxn())
+                    .as("RISC SET shares txn with the SCIM patch event")
+                    .isNotNull()
+                    .isEqualTo(scimPatch.getTxn());
+        } catch (Exception e) {
+            fail("Error in RISC Identifier Changed end-to-end test: " + e.getMessage(), e);
         }
     }
 }

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventHandlerTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventHandlerTest.java
@@ -1,0 +1,110 @@
+package com.independentid.scim.test.events;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.core.ConfigMgr;
+import com.independentid.scim.core.PoolManager;
+import com.independentid.scim.op.CreateOp;
+import com.independentid.scim.op.DeleteOp;
+import com.independentid.scim.op.Operation;
+import com.independentid.scim.protocol.RequestCtx;
+import com.independentid.scim.schema.SchemaManager;
+import com.independentid.scim.serializer.JsonUtil;
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.EventTypes;
+import com.independentid.signals.RiscEventTypes;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * End-to-end test: a SCIM {@code User} delete drives an OpenID RISC Account
+ * Purged Security Event Token onto the push stream, observed at the receiver,
+ * sharing {@code txn} with the SCIM delete event. Slice 1 (#87).
+ */
+@QuarkusTest
+@TestProfile(RiscEventTestProfile.class)
+public class RiscEventHandlerTest {
+    private final static Logger logger = LoggerFactory.getLogger(RiscEventHandlerTest.class);
+
+    private static final String testUserFile1 = "classpath:/data/TestUser-bjensen.json";
+
+    @Inject
+    PoolManager poolManager;
+
+    @Inject
+    ConfigMgr configMgr;
+
+    @Inject
+    SchemaManager schemaManager;
+
+    @Inject
+    TestUtils utils;
+
+    /** Scans the SETs received by the mock for one carrying the given event URI. */
+    private SecurityEventToken findReceivedEvent(String eventUri) {
+        for (SecurityEventToken token : MockSignalsServer.allReceived) {
+            JsonNode events = token.GetEvents();
+            if (events != null && events.has(eventUri))
+                return token;
+        }
+        return null;
+    }
+
+    @Test
+    public void accountPurgedPushedEndToEnd() {
+        logger.info("=== RISC Account Purged end-to-end push ===");
+        try {
+            utils.resetMemDirectory();
+            Operation.initialize(configMgr);
+            MockSignalsServer.reset();
+
+            // Create a User...
+            InputStream userStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+            assertThat(userStream).isNotNull();
+            JsonNode node = JsonUtil.getJsonTree(userStream);
+            RequestCtx createCtx = new RequestCtx("Users", null, null, schemaManager);
+            CreateOp createOp = new CreateOp(node, createCtx, null, 0);
+            poolManager.addJobAndWait(createOp);
+            assertThat(createOp.isError()).as("User create succeeded").isFalse();
+            String id = createOp.getResourceId();
+
+            // ...then delete it.
+            RequestCtx deleteCtx = new RequestCtx("Users", id, null, schemaManager);
+            DeleteOp deleteOp = new DeleteOp(deleteCtx, null, 0);
+            poolManager.addJobAndWait(deleteOp);
+            assertThat(deleteOp.isError()).as("User delete succeeded").isFalse();
+
+            // Event publication is async — wait for the Account Purged SET to be pushed.
+            SecurityEventToken purged = null;
+            for (int i = 0; i < 15 && purged == null; i++) {
+                purged = findReceivedEvent(RiscEventTypes.ACCOUNT_PURGED);
+                if (purged == null) Thread.sleep(1000);
+            }
+            assertThat(purged)
+                    .as("Account Purged SET pushed to the receiver").isNotNull();
+            assertThat(purged.GetEvents().size())
+                    .as("One event per SET").isEqualTo(1);
+
+            SecurityEventToken scimDelete = findReceivedEvent(EventTypes.PROV_DELETE);
+            assertThat(scimDelete)
+                    .as("SCIM delete SET also pushed to the receiver").isNotNull();
+            assertThat(scimDelete.getJti())
+                    .as("RISC and SCIM SETs are distinct").isNotEqualTo(purged.getJti());
+
+            assertThat(purged.getTxn())
+                    .as("RISC SET shares txn with the SCIM delete event")
+                    .isNotNull()
+                    .isEqualTo(scimDelete.getTxn());
+        } catch (Exception e) {
+            fail("Error in RISC end-to-end test: " + e.getMessage(), e);
+        }
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
@@ -1,0 +1,224 @@
+package com.independentid.scim.test.events;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.backend.memory.MemoryProvider;
+import com.independentid.scim.core.ConfigMgr;
+import com.independentid.scim.core.InjectionManager;
+import com.independentid.scim.core.PoolManager;
+import com.independentid.scim.core.err.ScimException;
+import com.independentid.scim.op.CreateOp;
+import com.independentid.scim.op.DeleteOp;
+import com.independentid.scim.op.Operation;
+import com.independentid.scim.protocol.RequestCtx;
+import com.independentid.scim.protocol.ScimResponse;
+import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.schema.SchemaManager;
+import com.independentid.scim.serializer.JsonUtil;
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.RiscConfig;
+import com.independentid.signals.RiscEventMapper;
+import com.independentid.signals.RiscEventTypes;
+import com.independentid.signals.SignalsEventMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/**
+ * Unit tests for {@link RiscEventMapper} — the pure transformation from a
+ * completed {@link Operation} to RISC {@link SecurityEventToken}s. Slice 1
+ * (#87) covers DELETE → Account Purged.
+ */
+@QuarkusTest
+@TestProfile(RiscMapperTestProfile.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class RiscEventMapperTest {
+    private final static Logger logger = LoggerFactory.getLogger(RiscEventMapperTest.class);
+
+    private static final String testUserFile1 = "classpath:/data/TestUser-bjensen.json";
+
+    @Inject
+    SchemaManager schemaManager;
+
+    @Inject
+    TestUtils testUtils;
+
+    @Inject
+    MemoryProvider provider;
+
+    @Inject
+    PoolManager poolManager;
+
+    @Inject
+    ConfigMgr configMgr;
+
+    private RiscEventMapper newMapper(RiscConfig config) {
+        return new RiscEventMapper(config, InjectionManager.getInstance().getGenerator());
+    }
+
+    /** Creates a User in the memory backend and returns its generated id. */
+    private String createUser(String userFile) throws ScimException, IOException, ParseException {
+        InputStream userStream = ConfigMgr.findClassLoaderResource(userFile);
+        assertThat(userStream).isNotNull();
+        JsonNode node = JsonUtil.getJsonTree(userStream);
+        RequestCtx ctx = new RequestCtx("Users", null, null, schemaManager);
+        CreateOp op = new CreateOp(node, ctx, null, 0);
+        poolManager.addJobAndWait(op);
+        assertThat(op.isError()).as("User create succeeded").isFalse();
+        return op.getResourceId();
+    }
+
+    /** Deletes the resource at the given container/id and returns the completed op. */
+    private DeleteOp deleteResource(String container, String id) throws ScimException {
+        RequestCtx ctx = new RequestCtx(container, id, null, schemaManager);
+        DeleteOp op = new DeleteOp(ctx, null, 0);
+        poolManager.addJobAndWait(op);
+        return op;
+    }
+
+    @Test
+    public void a_accountPurgedOnUserDelete() {
+        logger.info("A. Account Purged on User delete");
+        try {
+            testUtils.resetMemDirectory();
+            Operation.initialize(configMgr);
+
+            String id = createUser(testUserFile1);
+            DeleteOp delOp = deleteResource("Users", id);
+            assertThat(delOp.isError()).as("User delete succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(delOp);
+
+            assertThat(events).as("One RISC event for a User delete").hasSize(1);
+            SecurityEventToken event = events.get(0);
+            assertThat(event.GetEvent(RiscEventTypes.ACCOUNT_PURGED))
+                    .as("SET carries the Account Purged event").isNotNull();
+            assertThat(event.getJti()).as("SET has a jti").isNotBlank();
+            assertThat(event.getSubjectIdentifier().id)
+                    .as("Subject id is the deleted User").isEqualTo(id);
+        } catch (Exception e) {
+            fail("Error in Account Purged test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void b_accountPurgedSharesTxnAndToe() {
+        logger.info("B. Account Purged shares txn + toe with the SCIM delete event");
+        try {
+            String id = createUser(testUserFile1);
+            DeleteOp delOp = deleteResource("Users", id);
+            assertThat(delOp.isError()).as("User delete succeeded").isFalse();
+
+            SignalsEventMapper scimMapper = new SignalsEventMapper(
+                    new ArrayList<>(), new ArrayList<>(), InjectionManager.getInstance().getGenerator());
+            List<SecurityEventToken> scimEvents = scimMapper.MapOperationToSet(delOp);
+            assertThat(scimEvents).as("SCIM delete event present").hasSize(1);
+            SecurityEventToken scimEvent = scimEvents.get(0);
+
+            RiscEventMapper riscMapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> riscEvents = riscMapper.mapToRiscEvents(delOp);
+            assertThat(riscEvents).as("RISC event present").hasSize(1);
+            SecurityEventToken riscEvent = riscEvents.get(0);
+
+            assertThat(riscEvent.getJti())
+                    .as("RISC SET has its own jti").isNotEqualTo(scimEvent.getJti());
+            assertThat(riscEvent.getTxn())
+                    .as("RISC SET shares the SCIM event's txn")
+                    .isNotNull()
+                    .isEqualTo(scimEvent.getTxn());
+            assertThat(riscEvent.getToe())
+                    .as("RISC SET shares the SCIM event's toe")
+                    .isEqualTo(scimEvent.getToe());
+        } catch (Exception e) {
+            fail("Error in txn/toe sharing test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void c_nonUserDeleteEmitsNothing() {
+        logger.info("C. Non-User delete emits no RISC event");
+        try {
+            String groupJson = "{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:Group\"],"
+                    + "\"displayName\":\"RISC Test Group\"}";
+            JsonNode node = JsonUtil.getJsonTree(groupJson);
+            RequestCtx createCtx = new RequestCtx("Groups", null, null, schemaManager);
+            CreateOp createOp = new CreateOp(node, createCtx, null, 0);
+            poolManager.addJobAndWait(createOp);
+            assertThat(createOp.isError()).as("Group create succeeded").isFalse();
+
+            DeleteOp delOp = deleteResource("Groups", createOp.getResourceId());
+            assertThat(delOp.isError()).as("Group delete succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            assertThat(mapper.mapToRiscEvents(delOp))
+                    .as("No RISC event for a non-User resource").isEmpty();
+        } catch (Exception e) {
+            fail("Error in non-User test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void d_disabledConfigEmitsNothing() {
+        logger.info("D. RISC disabled emits no event");
+        try {
+            String id = createUser(testUserFile1);
+            DeleteOp delOp = deleteResource("Users", id);
+            assertThat(delOp.isError()).as("User delete succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(false, List.of("*")));
+            assertThat(mapper.mapToRiscEvents(delOp))
+                    .as("No RISC event when RISC emission is disabled").isEmpty();
+        } catch (Exception e) {
+            fail("Error in disabled-config test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void e_accountPurgedTypeFilteredOut() {
+        logger.info("E. account-purged excluded from types emits no event");
+        try {
+            String id = createUser(testUserFile1);
+            DeleteOp delOp = deleteResource("Users", id);
+            assertThat(delOp.isError()).as("User delete succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("account-disabled")));
+            assertThat(mapper.mapToRiscEvents(delOp))
+                    .as("No Account Purged when account-purged is filtered out").isEmpty();
+        } catch (Exception e) {
+            fail("Error in type-filter test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void f_memoryProviderCapturesPreImage() {
+        logger.info("F. MemoryProvider.delete() captures the pre-image on RequestCtx");
+        try {
+            String id = createUser(testUserFile1);
+            RequestCtx ctx = new RequestCtx("Users", id, null, schemaManager);
+            ScimResponse resp = provider.delete(ctx);
+            assertThat(resp.getStatus())
+                    .as("Delete succeeded").isEqualTo(ScimResponse.ST_NOCONTENT);
+
+            ScimResource preImage = ctx.getPreImageResource();
+            assertThat(preImage).as("Pre-image captured by delete()").isNotNull();
+            assertThat(preImage.getId())
+                    .as("Pre-image is the deleted User").isEqualTo(id);
+        } catch (Exception e) {
+            fail("Error in memory pre-image test: " + e.getMessage(), e);
+        }
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
@@ -18,6 +18,7 @@ import com.independentid.scim.protocol.RequestCtx;
 import com.independentid.scim.protocol.ScimResponse;
 import com.independentid.scim.resource.BooleanValue;
 import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.resource.StringValue;
 import com.independentid.scim.resource.Value;
 import com.independentid.scim.schema.Attribute;
 import com.independentid.scim.schema.SchemaException;
@@ -486,6 +487,191 @@ public class RiscEventMapperTest {
                     .as("No RISC event for a non-User create").isEmpty();
         } catch (Exception e) {
             fail("Error in non-User create test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void q_identifierChangedOnPutUserName() {
+        logger.info("Q. Identifier Changed on PUT changing userName");
+        try {
+            CreateOp createOp = createUserOp(loadTestUser());
+            String id = createOp.getResourceId();
+            RequestCtx readCtx = new RequestCtx("Users", id, null, schemaManager);
+            ObjectNode body = (ObjectNode) createOp.getTransactionResource().toJsonNode(readCtx);
+            body.put("userName", "renamed-" + java.util.UUID.randomUUID() + "@example.com");
+
+            PutOp op = putResource(id, body);
+            assertThat(op.isError()).as("Put succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the userName change").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.IDENTIFIER_CHANGED))
+                    .as("PUT changing userName → Identifier Changed").isNotNull();
+        } catch (Exception e) {
+            fail("Error in put-userName test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void r_identifierChangedOnPatchUserName() {
+        logger.info("R. Identifier Changed on PATCH replacing userName");
+        try {
+            String id = createUser(testUserFile1);
+            Attribute unAttr = schemaManager.findAttribute("User:userName", null);
+            JsonPatchRequest jpr = new JsonPatchRequest();
+            String newName = "patched-" + java.util.UUID.randomUUID() + "@example.com";
+            jpr.addOperation(new JsonPatchOp(JsonPatchOp.OP_ACTION_REPLACE, "userName",
+                    new StringValue(unAttr, newName)));
+
+            PatchOp op = patchResource(id, jpr);
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the userName change").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.IDENTIFIER_CHANGED))
+                    .as("PATCH replacing userName → Identifier Changed").isNotNull();
+        } catch (Exception e) {
+            fail("Error in patch-userName test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void s_identifierChangedOnPatchPrimaryEmail() {
+        logger.info("S. Identifier Changed on PATCH changing the primary email");
+        try {
+            String id = createUser(testUserFile1); // bjensen primary email bjensen@example.com
+            String newEmail = "newprimary-" + java.util.UUID.randomUUID() + "@example.com";
+            String patchJson = "{\"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"],"
+                    + "\"Operations\":[{\"op\":\"add\",\"path\":\"emails\","
+                    + "\"value\":{\"value\":\"" + newEmail + "\",\"type\":\"work\",\"primary\":true}}]}";
+            PatchOp op = patchResourceRaw(id, JsonUtil.getJsonTree(patchJson));
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the primary-email change").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.IDENTIFIER_CHANGED))
+                    .as("PATCH changing the primary email → Identifier Changed").isNotNull();
+        } catch (Exception e) {
+            fail("Error in patch-primary-email test: " + e.getMessage(), e);
+        }
+    }
+
+    /** A PATCH that removes the whole {@code emails} attribute. */
+    private PatchOp removeEmailsPatch(String id) throws ScimException, IOException {
+        String patchJson = "{\"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"],"
+                + "\"Operations\":[{\"op\":\"remove\",\"path\":\"emails\"}]}";
+        return patchResourceRaw(id, JsonUtil.getJsonTree(patchJson));
+    }
+
+    @Test
+    public void t_identifierAttrSetHonored() {
+        logger.info("T. Only configured identifier attributes drive Identifier Changed");
+        try {
+            String id = createUser(testUserFile1);
+            String newEmail = "newprimary-" + java.util.UUID.randomUUID() + "@example.com";
+            String patchJson = "{\"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"],"
+                    + "\"Operations\":[{\"op\":\"add\",\"path\":\"emails\","
+                    + "\"value\":{\"value\":\"" + newEmail + "\",\"type\":\"work\",\"primary\":true}}]}";
+            PatchOp op = patchResourceRaw(id, JsonUtil.getJsonTree(patchJson));
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            // emails is not in the configured identifier set — only userName is.
+            RiscEventMapper mapper = newMapper(
+                    new RiscConfig(true, List.of("*"), List.of("userName"), true));
+            assertThat(mapper.mapToRiscEvents(op))
+                    .as("Email change ignored when emails is not a configured identifier").isEmpty();
+        } catch (Exception e) {
+            fail("Error in identifier-attr-set test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void u_pureRemovalEmitsWhenAddRemoveIsChange() {
+        logger.info("U. Pure removal of an identifier emits when addRemoveIsChange=true");
+        try {
+            String id = createUser(testUserFile1);
+            PatchOp op = removeEmailsPatch(id);
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(
+                    new RiscConfig(true, List.of("*"), List.of("userName", "emails"), true));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the email removal").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.IDENTIFIER_CHANGED))
+                    .as("Pure removal → Identifier Changed when addRemoveIsChange=true").isNotNull();
+        } catch (Exception e) {
+            fail("Error in pure-removal-true test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void v_pureRemovalSuppressedWhenNotAddRemoveChange() {
+        logger.info("V. Pure removal of an identifier is suppressed when addRemoveIsChange=false");
+        try {
+            String id = createUser(testUserFile1);
+            PatchOp op = removeEmailsPatch(id);
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(
+                    new RiscConfig(true, List.of("*"), List.of("userName", "emails"), false));
+            assertThat(mapper.mapToRiscEvents(op))
+                    .as("No Identifier Changed for a pure removal when addRemoveIsChange=false").isEmpty();
+        } catch (Exception e) {
+            fail("Error in pure-removal-false test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void w_identifierEventSubjectPayloadTxnToe() {
+        logger.info("W. Identifier Changed SET — scim subject, new-value payload, shared txn/toe");
+        try {
+            CreateOp createOp = createUserOp(loadTestUser());
+            String id = createOp.getResourceId();
+            RequestCtx readCtx = new RequestCtx("Users", id, null, schemaManager);
+            ObjectNode body = (ObjectNode) createOp.getTransactionResource().toJsonNode(readCtx);
+            String newName = "renamed-" + java.util.UUID.randomUUID() + "@example.com";
+            body.put("userName", newName);
+
+            PutOp op = putResource(id, body);
+            assertThat(op.isError()).as("Put succeeded").isFalse();
+
+            SignalsEventMapper scimMapper = new SignalsEventMapper(
+                    new ArrayList<>(), new ArrayList<>(), InjectionManager.getInstance().getGenerator());
+            List<SecurityEventToken> scimEvents = scimMapper.MapOperationToSet(op);
+            assertThat(scimEvents).as("SCIM put event present").isNotEmpty();
+            SecurityEventToken scimEvent = scimEvents.get(0);
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+            assertThat(events).as("One RISC event").hasSize(1);
+            SecurityEventToken event = events.get(0);
+
+            assertThat(event.getSubjectIdentifier().format)
+                    .as("scim subject format").isEqualTo("scim");
+            assertThat(event.getSubjectIdentifier().id)
+                    .as("Subject carries the stable id").isEqualTo(id);
+            assertThat(event.getSubjectIdentifier().uri)
+                    .as("Subject carries the stable uri").isEqualTo("/Users/" + id);
+            assertThat(event.GetEvent(RiscEventTypes.IDENTIFIER_CHANGED).get("new-value").asText())
+                    .as("Payload carries the new identifier value").isEqualTo(newName);
+
+            assertThat(event.getJti())
+                    .as("RISC SET has its own jti").isNotEqualTo(scimEvent.getJti());
+            assertThat(event.getTxn())
+                    .as("RISC SET shares the SCIM event's txn")
+                    .isNotNull().isEqualTo(scimEvent.getTxn());
+            assertThat(event.getToe())
+                    .as("RISC SET shares the SCIM event's toe")
+                    .isEqualTo(scimEvent.getToe());
+        } catch (Exception e) {
+            fail("Error in identifier subject/payload test: " + e.getMessage(), e);
         }
     }
 

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
@@ -25,6 +25,7 @@ import com.independentid.scim.schema.SchemaException;
 import com.independentid.scim.schema.SchemaManager;
 import com.independentid.scim.serializer.JsonUtil;
 import com.independentid.set.SecurityEventToken;
+import com.independentid.set.SubjectIdentifier;
 import com.independentid.signals.RiscConfig;
 import com.independentid.signals.RiscEventMapper;
 import com.independentid.signals.RiscEventTypes;
@@ -672,6 +673,135 @@ public class RiscEventMapperTest {
                     .isEqualTo(scimEvent.getToe());
         } catch (Exception e) {
             fail("Error in identifier subject/payload test: " + e.getMessage(), e);
+        }
+    }
+
+    /** A RiscConfig emitting all types with the given subject format. */
+    private RiscConfig configWithSubjectFormat(String format) {
+        return new RiscConfig(true, List.of("*"), RiscConfig.DEFAULT_IDENTIFIER_ATTRS, true, format);
+    }
+
+    @Test
+    public void x_emailSubjectFormatOnAccountEvent() {
+        logger.info("X. email subject format — Account Purged subject carries the primary email");
+        try {
+            String id = createUser(testUserFile1); // bjensen primary email bjensen@example.com
+            DeleteOp delOp = deleteResource("Users", id);
+            assertThat(delOp.isError()).as("User delete succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(configWithSubjectFormat("email"));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(delOp);
+
+            assertThat(events).as("One RISC event for a User delete").hasSize(1);
+            SubjectIdentifier subject = events.get(0).getSubjectIdentifier();
+            assertThat(subject.format).as("email subject format").isEqualTo("email");
+            assertThat(subject.email)
+                    .as("Subject carries the primary email").isEqualTo("bjensen@example.com");
+        } catch (Exception e) {
+            fail("Error in email-subject-format test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void y_usernameSubjectFormatOnAccountEvent() {
+        logger.info("Y. username subject format — account event subject carries userName");
+        try {
+            ObjectNode user = loadTestUser();
+            String userName = user.get("userName").asText();
+            CreateOp op = createUserOp(user); // bjensen active=true → Account Enabled
+
+            RiscEventMapper mapper = newMapper(configWithSubjectFormat("username"));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for a User create").hasSize(1);
+            SubjectIdentifier subject = events.get(0).getSubjectIdentifier();
+            assertThat(subject.format).as("username subject format").isEqualTo("username");
+            assertThat(subject.username)
+                    .as("Subject carries the userName").isEqualTo(userName);
+        } catch (Exception e) {
+            fail("Error in username-subject-format test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void z_phoneSubjectFormatOnAccountEvent() {
+        logger.info("Z. phone subject format — account event subject carries the primary phone");
+        try {
+            ObjectNode user = loadTestUser();
+            // bjensen's sample phoneNumbers has two entries and no primary flag;
+            // give it a single entry so it has an unambiguous primary value.
+            user.set("phoneNumbers",
+                    JsonUtil.getJsonTree("[{\"value\":\"555-0100\",\"type\":\"work\"}]"));
+            CreateOp op = createUserOp(user);
+
+            RiscEventMapper mapper = newMapper(configWithSubjectFormat("phone"));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for a User create").hasSize(1);
+            SubjectIdentifier subject = events.get(0).getSubjectIdentifier();
+            assertThat(subject.format).as("phone subject format").isEqualTo("phone");
+            assertThat(subject.phoneNumber)
+                    .as("Subject carries the primary phone number").isEqualTo("555-0100");
+        } catch (Exception e) {
+            fail("Error in phone-subject-format test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void za_identifierChangedCarriesPriorValueUnderEmailFormat() {
+        logger.info("ZA. email format — Identifier Changed subject carries the prior email");
+        try {
+            CreateOp createOp = createUserOp(loadTestUser()); // primary email bjensen@example.com
+            String id = createOp.getResourceId();
+            RequestCtx readCtx = new RequestCtx("Users", id, null, schemaManager);
+            ObjectNode body = (ObjectNode) createOp.getTransactionResource().toJsonNode(readCtx);
+            String newName = "renamed-" + java.util.UUID.randomUUID() + "@example.com";
+            body.put("userName", newName);
+
+            PutOp op = putResource(id, body);
+            assertThat(op.isError()).as("Put succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(configWithSubjectFormat("email"));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the userName change").hasSize(1);
+            SecurityEventToken event = events.get(0);
+            SubjectIdentifier subject = event.getSubjectIdentifier();
+            assertThat(subject.format).as("email subject format").isEqualTo("email");
+            assertThat(subject.email)
+                    .as("Subject carries the prior (pre-image) email")
+                    .isEqualTo("bjensen@example.com");
+            assertThat(event.GetEvent(RiscEventTypes.IDENTIFIER_CHANGED).get("new-value").asText())
+                    .as("Payload carries the new identifier value").isEqualTo(newName);
+        } catch (Exception e) {
+            fail("Error in email-format identifier-changed test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void zb_subjectFormatFallsBackToScimWhenUnsatisfiable() {
+        logger.info("ZB. email format but no email — subject falls back to scim, event still emitted");
+        try {
+            ObjectNode user = loadTestUser();
+            user.remove("emails"); // no email — the email subject format cannot be satisfied
+            String id = createUserOp(user).getResourceId();
+            DeleteOp delOp = deleteResource("Users", id);
+            assertThat(delOp.isError()).as("User delete succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(configWithSubjectFormat("email"));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(delOp);
+
+            assertThat(events).as("Event still emitted despite the unsatisfiable format").hasSize(1);
+            SecurityEventToken event = events.get(0);
+            assertThat(event.GetEvent(RiscEventTypes.ACCOUNT_PURGED))
+                    .as("SET carries the Account Purged event").isNotNull();
+            SubjectIdentifier subject = event.getSubjectIdentifier();
+            assertThat(subject.format)
+                    .as("Falls back to the scim subject format").isEqualTo("scim");
+            assertThat(subject.id)
+                    .as("Fallback scim subject carries the stable id").isEqualTo(id);
+        } catch (Exception e) {
+            fail("Error in subject-format fallback test: " + e.getMessage(), e);
         }
     }
 

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
@@ -806,6 +806,43 @@ public class RiscEventMapperTest {
     }
 
     @Test
+    public void zc_memoryProviderCapturesPutPatchPreImage() {
+        logger.info("ZC. MemoryProvider.put()/patch() capture the pre-image on RequestCtx");
+        try {
+            CreateOp createOp = createUserOp(loadTestUser());
+            String id = createOp.getResourceId();
+
+            // PUT replaces the resource — the pre-image must be the prior state.
+            RequestCtx readCtx = new RequestCtx("Users", id, null, schemaManager);
+            ObjectNode body = (ObjectNode) createOp.getTransactionResource().toJsonNode(readCtx);
+            body.put("title", "Changed Title");
+            ScimResource replacement = new ScimResource(schemaManager, body, "Users");
+            RequestCtx putCtx = new RequestCtx("Users", id, null, schemaManager);
+            ScimResponse putResp = provider.put(putCtx, replacement);
+            assertThat(putResp.getStatus()).as("PUT succeeded").isLessThan(300);
+            assertThat(putCtx.getPreImageResource())
+                    .as("Pre-image captured by MemoryProvider.put()").isNotNull();
+            assertThat(putCtx.getPreImageResource().getId())
+                    .as("PUT pre-image is the prior User").isEqualTo(id);
+
+            // PATCH mutates the resource — the pre-image must be the prior state.
+            Attribute titleAttr = schemaManager.findAttribute("User:title", null);
+            JsonPatchRequest jpr = new JsonPatchRequest();
+            jpr.addOperation(new JsonPatchOp(JsonPatchOp.OP_ACTION_REPLACE, "title",
+                    new StringValue(titleAttr, "Patched Title")));
+            RequestCtx patchCtx = new RequestCtx("Users", id, null, schemaManager);
+            ScimResponse patchResp = provider.patch(patchCtx, jpr);
+            assertThat(patchResp.getStatus()).as("PATCH succeeded").isLessThan(300);
+            assertThat(patchCtx.getPreImageResource())
+                    .as("Pre-image captured by MemoryProvider.patch()").isNotNull();
+            assertThat(patchCtx.getPreImageResource().getId())
+                    .as("PATCH pre-image is the prior User").isEqualTo(id);
+        } catch (Exception e) {
+            fail("Error in memory put/patch pre-image test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
     public void f_memoryProviderCapturesPreImage() {
         logger.info("F. MemoryProvider.delete() captures the pre-image on RequestCtx");
         try {

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventMapperTest.java
@@ -1,6 +1,7 @@
 package com.independentid.scim.test.events;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.independentid.scim.backend.memory.MemoryProvider;
 import com.independentid.scim.core.ConfigMgr;
 import com.independentid.scim.core.InjectionManager;
@@ -9,9 +10,17 @@ import com.independentid.scim.core.err.ScimException;
 import com.independentid.scim.op.CreateOp;
 import com.independentid.scim.op.DeleteOp;
 import com.independentid.scim.op.Operation;
+import com.independentid.scim.op.PatchOp;
+import com.independentid.scim.op.PutOp;
+import com.independentid.scim.protocol.JsonPatchOp;
+import com.independentid.scim.protocol.JsonPatchRequest;
 import com.independentid.scim.protocol.RequestCtx;
 import com.independentid.scim.protocol.ScimResponse;
+import com.independentid.scim.resource.BooleanValue;
 import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.resource.Value;
+import com.independentid.scim.schema.Attribute;
+import com.independentid.scim.schema.SchemaException;
 import com.independentid.scim.schema.SchemaManager;
 import com.independentid.scim.serializer.JsonUtil;
 import com.independentid.set.SecurityEventToken;
@@ -73,12 +82,70 @@ public class RiscEventMapperTest {
     private String createUser(String userFile) throws ScimException, IOException, ParseException {
         InputStream userStream = ConfigMgr.findClassLoaderResource(userFile);
         assertThat(userStream).isNotNull();
-        JsonNode node = JsonUtil.getJsonTree(userStream);
+        return createUserOp(uniquify((ObjectNode) JsonUtil.getJsonTree(userStream))).getResourceId();
+    }
+
+    /** Loads the bjensen test User as a mutable, uniquely-identified JSON object. */
+    private ObjectNode loadTestUser() throws IOException {
+        InputStream userStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+        assertThat(userStream).isNotNull();
+        return uniquify((ObjectNode) JsonUtil.getJsonTree(userStream));
+    }
+
+    /**
+     * Makes a test User unique so creations do not collide. The bjensen sample
+     * carries a fixed {@code id}, {@code externalId} and {@code userName} — all
+     * uniqueness-constrained — and the in-memory backend's map persists across
+     * tests in this class.
+     */
+    private ObjectNode uniquify(ObjectNode user) {
+        user.remove("id");
+        user.remove("externalId");
+        user.put("userName", "risc-user-" + java.util.UUID.randomUUID() + "@example.com");
+        return user;
+    }
+
+    /** Creates a User from the given JSON and returns the completed CreateOp. */
+    private CreateOp createUserOp(JsonNode node) throws ScimException {
         RequestCtx ctx = new RequestCtx("Users", null, null, schemaManager);
         CreateOp op = new CreateOp(node, ctx, null, 0);
         poolManager.addJobAndWait(op);
-        assertThat(op.isError()).as("User create succeeded").isFalse();
-        return op.getResourceId();
+        assertThat(op.getScimResponse().getStatus())
+                .as("User create returned 201").isEqualTo(ScimResponse.ST_CREATED);
+        return op;
+    }
+
+    /** Patches the User at the given id and returns the completed PatchOp. */
+    private PatchOp patchResource(String id, JsonPatchRequest jpr) throws ScimException {
+        RequestCtx ctx = new RequestCtx("Users", id, null, schemaManager);
+        PatchOp op = new PatchOp(jpr.toJsonNode(), ctx, null, 0);
+        poolManager.addJobAndWait(op);
+        return op;
+    }
+
+    /** Patches the User with a raw PatchOp JSON document and returns the completed PatchOp. */
+    private PatchOp patchResourceRaw(String id, JsonNode patchNode) throws ScimException {
+        RequestCtx ctx = new RequestCtx("Users", id, null, schemaManager);
+        PatchOp op = new PatchOp(patchNode, ctx, null, 0);
+        poolManager.addJobAndWait(op);
+        return op;
+    }
+
+    /** A single-op JSON Patch request on the User {@code active} attribute. */
+    private JsonPatchRequest activePatch(String action, Boolean value) throws SchemaException {
+        Attribute activeAttr = schemaManager.findAttribute("User:active", null);
+        JsonPatchRequest jpr = new JsonPatchRequest();
+        Value v = (value == null) ? null : new BooleanValue(activeAttr, value);
+        jpr.addOperation(new JsonPatchOp(action, "active", v));
+        return jpr;
+    }
+
+    /** Replaces the User at the given id and returns the completed PutOp. */
+    private PutOp putResource(String id, JsonNode node) throws ScimException {
+        RequestCtx ctx = new RequestCtx("Users", id, null, schemaManager);
+        PutOp op = new PutOp(node, ctx, null, 0);
+        poolManager.addJobAndWait(op);
+        return op;
     }
 
     /** Deletes the resource at the given container/id and returns the completed op. */
@@ -200,6 +267,225 @@ public class RiscEventMapperTest {
                     .as("No Account Purged when account-purged is filtered out").isEmpty();
         } catch (Exception e) {
             fail("Error in type-filter test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void g_accountEnabledOnCreateActiveAbsent() {
+        logger.info("G. Account Enabled on User create when active is absent");
+        try {
+            testUtils.resetMemDirectory();
+            Operation.initialize(configMgr);
+
+            ObjectNode user = loadTestUser();
+            user.remove("active");
+            CreateOp op = createUserOp(user);
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for a User create").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_ENABLED))
+                    .as("Absent active → Account Enabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in create-active-absent test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void h_accountDisabledOnCreateActiveFalse() {
+        logger.info("H. Account Disabled on User create when active is false");
+        try {
+            ObjectNode user = loadTestUser();
+            user.put("active", false);
+            CreateOp op = createUserOp(user);
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for a User create").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_DISABLED))
+                    .as("active=false → Account Disabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in create-active-false test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void i_accountDisabledOnPatchReplaceActiveFalse() {
+        logger.info("I. Account Disabled on PATCH replace active=false");
+        try {
+            String id = createUser(testUserFile1);
+            PatchOp op = patchResource(id, activePatch(JsonPatchOp.OP_ACTION_REPLACE, false));
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the active PATCH").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_DISABLED))
+                    .as("PATCH replace active=false → Account Disabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in patch-replace test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void j_accountDisabledOnPatchPathlessValueObject() {
+        logger.info("J. Account Disabled on PATCH path-less value object {active:false}");
+        try {
+            String id = createUser(testUserFile1);
+            String patchJson = "{\"schemas\":[\"urn:ietf:params:scim:api:messages:2.0:PatchOp\"],"
+                    + "\"Operations\":[{\"op\":\"add\",\"value\":{\"active\":false}}]}";
+            PatchOp op = patchResourceRaw(id, JsonUtil.getJsonTree(patchJson));
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the path-less PATCH").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_DISABLED))
+                    .as("Path-less value object with active=false → Account Disabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in patch-pathless test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void k_accountEnabledOnPatchRemoveActive() {
+        logger.info("K. Account Enabled on PATCH remove active");
+        try {
+            ObjectNode user = loadTestUser();
+            user.put("active", false);
+            String id = createUserOp(user).getResourceId();
+
+            PatchOp op = patchResource(id, activePatch(JsonPatchOp.OP_ACTION_REMOVE, null));
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the active PATCH remove").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_ENABLED))
+                    .as("PATCH remove active → Account Enabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in patch-remove test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void l_accountDisabledOnPutActiveChange() {
+        logger.info("L. Account Disabled on PUT changing active true→false");
+        try {
+            CreateOp createOp = createUserOp(loadTestUser()); // bjensen active=true
+            String id = createOp.getResourceId();
+            RequestCtx readCtx = new RequestCtx("Users", id, null, schemaManager);
+            ObjectNode body = (ObjectNode) createOp.getTransactionResource().toJsonNode(readCtx);
+            body.put("active", false);
+
+            PutOp op = putResource(id, body);
+            assertThat(op.isError()).as("Put succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for the active change").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_DISABLED))
+                    .as("PUT active true→false → Account Disabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in put-change test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void m_putWithoutActiveChangeEmitsNothing() {
+        logger.info("M. PUT not changing active emits no RISC event");
+        try {
+            CreateOp createOp = createUserOp(loadTestUser()); // active=true
+            String id = createOp.getResourceId();
+            RequestCtx readCtx = new RequestCtx("Users", id, null, schemaManager);
+            ObjectNode body = (ObjectNode) createOp.getTransactionResource().toJsonNode(readCtx);
+            body.put("title", "Changed Title"); // change something other than active
+
+            PutOp op = putResource(id, body);
+            assertThat(op.isError()).as("Put succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            assertThat(mapper.mapToRiscEvents(op))
+                    .as("No RISC event when active is unchanged by a PUT").isEmpty();
+        } catch (Exception e) {
+            fail("Error in put-no-change test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void n_activeEventSharesTxnAndToe() {
+        logger.info("N. Account Disabled SET shares txn + toe with the SCIM patch event");
+        try {
+            String id = createUser(testUserFile1);
+            PatchOp op = patchResource(id, activePatch(JsonPatchOp.OP_ACTION_REPLACE, false));
+            assertThat(op.isError()).as("Patch succeeded").isFalse();
+
+            SignalsEventMapper scimMapper = new SignalsEventMapper(
+                    new ArrayList<>(), new ArrayList<>(), InjectionManager.getInstance().getGenerator());
+            List<SecurityEventToken> scimEvents = scimMapper.MapOperationToSet(op);
+            assertThat(scimEvents).as("SCIM patch event present").isNotEmpty();
+            SecurityEventToken scimEvent = scimEvents.get(0);
+
+            RiscEventMapper riscMapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> riscEvents = riscMapper.mapToRiscEvents(op);
+            assertThat(riscEvents).as("RISC event present").hasSize(1);
+            SecurityEventToken riscEvent = riscEvents.get(0);
+
+            assertThat(riscEvent.getJti())
+                    .as("RISC SET has its own jti").isNotEqualTo(scimEvent.getJti());
+            assertThat(riscEvent.getTxn())
+                    .as("RISC SET shares the SCIM event's txn")
+                    .isNotNull().isEqualTo(scimEvent.getTxn());
+            assertThat(riscEvent.getToe())
+                    .as("RISC SET shares the SCIM event's toe")
+                    .isEqualTo(scimEvent.getToe());
+        } catch (Exception e) {
+            fail("Error in txn/toe sharing test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void o_accountEnabledOnCreateActiveTrue() {
+        logger.info("O. Account Enabled on User create when active is true");
+        try {
+            ObjectNode user = loadTestUser();
+            user.put("active", true);
+            CreateOp op = createUserOp(user);
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            List<SecurityEventToken> events = mapper.mapToRiscEvents(op);
+
+            assertThat(events).as("One RISC event for a User create").hasSize(1);
+            assertThat(events.get(0).GetEvent(RiscEventTypes.ACCOUNT_ENABLED))
+                    .as("active=true → Account Enabled").isNotNull();
+        } catch (Exception e) {
+            fail("Error in create-active-true test: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    public void p_nonUserCreateEmitsNothing() {
+        logger.info("P. Non-User create emits no RISC event");
+        try {
+            String groupJson = "{\"schemas\":[\"urn:ietf:params:scim:schemas:core:2.0:Group\"],"
+                    + "\"displayName\":\"RISC Test Group " + java.util.UUID.randomUUID() + "\"}";
+            JsonNode node = JsonUtil.getJsonTree(groupJson);
+            RequestCtx ctx = new RequestCtx("Groups", null, null, schemaManager);
+            CreateOp op = new CreateOp(node, ctx, null, 0);
+            poolManager.addJobAndWait(op);
+            assertThat(op.isError()).as("Group create succeeded").isFalse();
+
+            RiscEventMapper mapper = newMapper(new RiscConfig(true, List.of("*")));
+            assertThat(mapper.mapToRiscEvents(op))
+                    .as("No RISC event for a non-User create").isEmpty();
+        } catch (Exception e) {
+            fail("Error in non-User create test: " + e.getMessage(), e);
         }
     }
 

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventTestProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscEventTestProfile.java
@@ -1,0 +1,23 @@
+package com.independentid.scim.test.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test profile for RISC end-to-end push tests: the {@link SignalsEventTestProfile}
+ * signals setup with RISC emission enabled.
+ */
+public class RiscEventTestProfile extends SignalsEventTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> map = new HashMap<>(super.getConfigOverrides());
+        map.put("scim.signals.risc.enable", "true");
+        return map;
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "RiscEventTestProfile";
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscMapperTestProfile.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/RiscMapperTestProfile.java
@@ -1,0 +1,27 @@
+package com.independentid.scim.test.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test profile for {@link RiscEventMapperTest}: the memory-backend setup of
+ * {@link SignalsEventTestProfile} but with signals and event publication
+ * disabled. The mapper is exercised directly, so the test must not also push
+ * SETs to the shared {@link MockSignalsServer} (which would pollute the static
+ * counters other event tests assert on).
+ */
+public class RiscMapperTestProfile extends SignalsEventTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> map = new HashMap<>(super.getConfigOverrides());
+        map.put("scim.signals.enable", "false");
+        map.put("scim.event.enable", "false");
+        return map;
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "RiscMapperTestProfile";
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/SignalsEventHandlerTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/SignalsEventHandlerTest.java
@@ -54,6 +54,9 @@ public class SignalsEventHandlerTest {
     @Test
     public void a_TestHello() {
         utils.resetMemDirectory();
+        // Baseline the mock's JVM-static counters — other test classes (e.g.
+        // RiscEventHandlerTest) push to the same mock within this JVM.
+        MockSignalsServer.reset();
 
         try (CloseableHttpClient client = HttpClients.createDefault()) {
             HttpGet get = new HttpGet("http://localhost:8081/signals/hello");

--- a/i2scim-server/src/test/java/com/independentid/scim/test/events/SubjectIdentifierFormatTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/events/SubjectIdentifierFormatTest.java
@@ -1,0 +1,48 @@
+package com.independentid.scim.test.events;
+
+import com.independentid.set.SubjectIdentifier;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SubjectIdentifier#forFormat} — building RISC subject
+ * identifiers in the {@code email}, {@code username} and {@code phone} formats.
+ * A pure transformation, so plain JUnit (no Quarkus). Slice 4 (#90).
+ */
+public class SubjectIdentifierFormatTest {
+
+    @Test
+    public void emailFormatSubjectBuilt() {
+        SubjectIdentifier sid = SubjectIdentifier.forFormat("email", "bjensen@example.com");
+        assertThat(sid).as("email format subject built").isNotNull();
+        assertThat(sid.format).as("format is email").isEqualTo("email");
+        assertThat(sid.email).as("email value carried").isEqualTo("bjensen@example.com");
+    }
+
+    @Test
+    public void usernameFormatSubjectBuilt() {
+        SubjectIdentifier sid = SubjectIdentifier.forFormat("username", "bjensen");
+        assertThat(sid).as("username format subject built").isNotNull();
+        assertThat(sid.format).as("format is username").isEqualTo("username");
+        assertThat(sid.username).as("username value carried").isEqualTo("bjensen");
+    }
+
+    @Test
+    public void phoneFormatSubjectBuilt() {
+        SubjectIdentifier sid = SubjectIdentifier.forFormat("phone", "555-555-5555");
+        assertThat(sid).as("phone format subject built").isNotNull();
+        assertThat(sid.format).as("format is phone").isEqualTo("phone");
+        assertThat(sid.phoneNumber).as("phone value carried").isEqualTo("555-555-5555");
+    }
+
+    @Test
+    public void unsatisfiableFormatReturnsNull() {
+        assertThat(SubjectIdentifier.forFormat("email", null))
+                .as("null value → no subject").isNull();
+        assertThat(SubjectIdentifier.forFormat("scim", "x"))
+                .as("scim is not a value-bearing format here → no subject").isNull();
+        assertThat(SubjectIdentifier.forFormat("bogus", "x"))
+                .as("unknown format → no subject").isNull();
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/mongo/RiscMongoPreImageTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/mongo/RiscMongoPreImageTest.java
@@ -1,0 +1,73 @@
+package com.independentid.scim.test.mongo;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.independentid.scim.backend.mongo.MongoProvider;
+import com.independentid.scim.core.ConfigMgr;
+import com.independentid.scim.core.InjectionManager;
+import com.independentid.scim.protocol.RequestCtx;
+import com.independentid.scim.protocol.ScimResponse;
+import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.schema.SchemaManager;
+import com.independentid.scim.serializer.JsonUtil;
+import com.independentid.scim.test.misc.TestUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Confirms {@link MongoProvider#delete} captures the removed resource as the
+ * pre-image on {@link RequestCtx} (ADR-0001) so RISC Account Purged has
+ * subject material. Slice 1 (#87).
+ */
+@QuarkusTest
+@TestProfile(ScimMongoTestProfile.class)
+public class RiscMongoPreImageTest {
+    private static final Logger logger = LoggerFactory.getLogger(RiscMongoPreImageTest.class);
+
+    private static final String testUserFile1 = "classpath:/schema/TestUser-bjensen.json";
+
+    @Inject
+    SchemaManager smgr;
+
+    @Inject
+    TestUtils testUtils;
+
+    @Test
+    public void mongoDeleteCapturesPreImage() throws Exception {
+        logger.info("========== MongoProvider pre-image capture (RISC) ==========");
+        testUtils.resetProvider(true);
+        MongoProvider mp = (MongoProvider) InjectionManager.getInstance().getProvider();
+        assertThat(mp).isNotNull();
+        assertThat(mp.ready()).isTrue();
+
+        InputStream userStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+        assertThat(userStream).isNotNull();
+        JsonNode node = JsonUtil.getJsonTree(userStream);
+        ScimResource user = new ScimResource(smgr, node, "Users");
+        user.setId(null);  // Mongo issues its own id
+
+        RequestCtx createCtx = new RequestCtx("/Users", null, null, smgr);
+        ScimResponse createResp = mp.create(createCtx, user);
+        assertThat(createResp.getStatus())
+                .as("User created").isEqualTo(ScimResponse.ST_CREATED);
+        String userUrl = createResp.getLocation();
+
+        RequestCtx deleteCtx = new RequestCtx(userUrl, null, null, smgr);
+        ScimResponse delResp = mp.delete(deleteCtx);
+        assertThat(delResp.getStatus())
+                .as("User deleted").isEqualTo(ScimResponse.ST_NOCONTENT);
+
+        ScimResource preImage = deleteCtx.getPreImageResource();
+        assertThat(preImage)
+                .as("Pre-image captured by MongoProvider.delete()").isNotNull();
+        assertThat(preImage.getResourceType())
+                .as("Pre-image is the deleted User").isEqualTo("User");
+    }
+}

--- a/i2scim-server/src/test/java/com/independentid/scim/test/mongo/RiscMongoPreImageTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/mongo/RiscMongoPreImageTest.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.independentid.scim.backend.mongo.MongoProvider;
 import com.independentid.scim.core.ConfigMgr;
 import com.independentid.scim.core.InjectionManager;
+import com.independentid.scim.protocol.JsonPatchOp;
+import com.independentid.scim.protocol.JsonPatchRequest;
 import com.independentid.scim.protocol.RequestCtx;
 import com.independentid.scim.protocol.ScimResponse;
 import com.independentid.scim.resource.ScimResource;
+import com.independentid.scim.resource.StringValue;
+import com.independentid.scim.schema.Attribute;
 import com.independentid.scim.schema.SchemaManager;
 import com.independentid.scim.serializer.JsonUtil;
 import com.independentid.scim.test.misc.TestUtils;
@@ -69,5 +73,49 @@ public class RiscMongoPreImageTest {
                 .as("Pre-image captured by MongoProvider.delete()").isNotNull();
         assertThat(preImage.getResourceType())
                 .as("Pre-image is the deleted User").isEqualTo("User");
+    }
+
+    @Test
+    public void mongoPutAndPatchCapturePreImage() throws Exception {
+        logger.info("========== MongoProvider put/patch pre-image capture (RISC) ==========");
+        testUtils.resetProvider(true);
+        MongoProvider mp = (MongoProvider) InjectionManager.getInstance().getProvider();
+        assertThat(mp).isNotNull();
+        assertThat(mp.ready()).isTrue();
+
+        InputStream userStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+        assertThat(userStream).isNotNull();
+        ScimResource user = new ScimResource(smgr, JsonUtil.getJsonTree(userStream), "Users");
+        user.setId(null);
+        RequestCtx createCtx = new RequestCtx("/Users", null, null, smgr);
+        ScimResponse createResp = mp.create(createCtx, user);
+        assertThat(createResp.getStatus())
+                .as("User created").isEqualTo(ScimResponse.ST_CREATED);
+        String userUrl = createResp.getLocation();
+
+        // PUT replaces the resource — the pre-image must be the prior state.
+        InputStream replaceStream = ConfigMgr.findClassLoaderResource(testUserFile1);
+        ScimResource replacement = new ScimResource(smgr, JsonUtil.getJsonTree(replaceStream), "Users");
+        replacement.setId(null);
+        RequestCtx putCtx = new RequestCtx(userUrl, null, null, smgr);
+        ScimResponse putResp = mp.put(putCtx, replacement);
+        assertThat(putResp.getStatus()).as("PUT succeeded").isLessThan(300);
+        assertThat(putCtx.getPreImageResource())
+                .as("Pre-image captured by MongoProvider.put()").isNotNull();
+        assertThat(putCtx.getPreImageResource().getResourceType())
+                .as("PUT pre-image is a User").isEqualTo("User");
+
+        // PATCH mutates the resource — the pre-image must be the prior state.
+        Attribute titleAttr = smgr.findAttribute("User:title", null);
+        JsonPatchRequest jpr = new JsonPatchRequest();
+        jpr.addOperation(new JsonPatchOp(JsonPatchOp.OP_ACTION_REPLACE, "title",
+                new StringValue(titleAttr, "Changed Title")));
+        RequestCtx patchCtx = new RequestCtx(userUrl, null, null, smgr);
+        ScimResponse patchResp = mp.patch(patchCtx, jpr);
+        assertThat(patchResp.getStatus()).as("PATCH succeeded").isLessThan(300);
+        assertThat(patchCtx.getPreImageResource())
+                .as("Pre-image captured by MongoProvider.patch()").isNotNull();
+        assertThat(patchCtx.getPreImageResource().getResourceType())
+                .as("PATCH pre-image is a User").isEqualTo("User");
     }
 }


### PR DESCRIPTION
Implements PRD #86 — derive OpenID RISC events (RISC Profile 1.0) from SCIM `User` state changes and emit them as their own Security Event Tokens on the existing SET push stream. RISC emission is opt-in via `scim.signals.risc.*` and additive to the existing signals push stream; each RISC SET shares `txn`/`toe` with the SCIM events derived from the same operation.

Closes #86. Closes #87. Closes #88. Closes #89. Closes #90.

## Slices

- **#87** — Pre-image plumbing (ADR-0001: resource snapshot carried on `RequestCtx`, populated by providers — zero extra backend reads), `RiscEventTypes`/`RiscConfig`/`RiscEventMapper` framework, and **Account Purged** from a `User` DELETE.
- **#88** — **Account Enabled / Disabled** derived from `User` `active` (absent ⇒ enabled): CREATE always emits; PATCH add/replace/remove and path-less value objects; PUT emits only on an actual change.
- **#89** — **Identifier Changed** on PUT/PATCH via the `IdentifierExtractor` deep module (primary value of singular and multi-valued identifiers). PATCH post-image derived purely by replaying the patch on a pre-image copy — no backend I/O. Config: `scim.signals.risc.identifier.attrs`, `scim.signals.risc.identifier.addRemoveIsChange`.
- **#90** — Configurable RISC **subject formats**: `scim.signals.risc.subject.format` (`scim`/`email`/`username`/`phone`, default `scim`). Non-`scim` formats carry the matching `User` attribute (for Identifier Changed, the prior identifier value); falls back to the `scim` subject when the format cannot be satisfied. Also fixes a `SubjectIdentifier` `phone_number` round-trip bug.

## Design

- `RiscEventMapper` and `IdentifierExtractor` are pure transformations (no I/O, no Quarkus lookups) — unit-tested directly.
- Default `scim.signals.risc.enable=false`: upgrading i2scim never changes what existing receivers receive.
- Out of scope: RISC §2.6–2.11, input-side consumption, soft-delete.

## Testing

Built TDD slice-by-slice (RED→GREEN per behavior). Full affected suite green — `RiscEventMapperTest` (28), `IdentifierExtractorTest` (4), `SubjectIdentifierFormatTest` (4), `RiscEventHandlerTest` (3, end-to-end push), `SignalsEventHandlerTest` (3), `SignalsEventMapperTest` (7), `SetTest` (4); no regressions. `docs/Configuration.md` documents all new `scim.signals.risc.*` properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)