### PR TITLE
Run the full test suite in CI (Docker-backed)

### DIFF
--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -27,6 +27,15 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
+      - name: Run MongoDB-backed tests
+        # The Mongo provider tests run against an ephemeral mongo:8.0 container
+        # started by Quarkus Dev Services; MongoPending*StoreTest and
+        # SignalsDurabilityTest start their own mongo:8.0 via Testcontainers.
+        # Either way the ubuntu-latest runner supplies the Docker daemon. The
+        # -Dtest filter scopes the run to these classes; core and client modules
+        # match nothing, so surefire.failIfNoSpecifiedTests=false keeps them green.
+        run: mvn -B test -Dtest='Mongo*,RiscMongoPreImageTest,SignalsDurabilityTest' -Dsurefire.failIfNoSpecifiedTests=false
+
       - name: Build and Package with Maven
         run: mvn -B package -DskipTests
 

--- a/.github/workflows/build-and-attest.yml
+++ b/.github/workflows/build-and-attest.yml
@@ -27,16 +27,19 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Run MongoDB-backed tests
-        # The Mongo provider tests run against an ephemeral mongo:8.0 container
-        # started by Quarkus Dev Services; MongoPending*StoreTest and
-        # SignalsDurabilityTest start their own mongo:8.0 via Testcontainers.
-        # Either way the ubuntu-latest runner supplies the Docker daemon. The
-        # -Dtest filter scopes the run to these classes; core and client modules
-        # match nothing, so surefire.failIfNoSpecifiedTests=false keeps them green.
-        run: mvn -B test -Dtest='Mongo*,RiscMongoPreImageTest,SignalsDurabilityTest' -Dsurefire.failIfNoSpecifiedTests=false
+      - name: Run test suite
+        # Runs the whole reactor's tests (~421 in i2scim-server; core and client
+        # carry none). The suite needs only a Docker daemon, which ubuntu-latest
+        # supplies: MongoProvider tests use an ephemeral mongo:8.0 from Quarkus
+        # Dev Services, and MongoPending*StoreTest / SignalsDurabilityTest start
+        # their own mongo:8.0 via Testcontainers. No MongoDB on localhost, no OPA
+        # server and no Kafka broker are required. Two classes stay excluded in
+        # i2scim-server/pom.xml -- LoadScimClusterTest (needs a K8s cluster) and
+        # SignalsGoSignalsIT (needs a live goSignals server).
+        run: mvn -B test
 
       - name: Build and Package with Maven
+        # Tests already ran in the previous step; -DskipTests just assembles jars.
         run: mvn -B package -DskipTests
 
       - name: Capture build metadata

--- a/i2scim-server/k8s/mongo/dbmongo-test-service.yaml
+++ b/i2scim-server/k8s/mongo/dbmongo-test-service.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: db-mongodb
-          image: docker.io/library/mongo:6.0.4
+          image: docker.io/library/mongo:8.0
           imagePullPolicy: "IfNotPresent"
           env:
             - name: MONGO_INITDB_ROOT_USERNAME

--- a/i2scim-server/src/main/java/com/independentid/signals/PemReloadWatcher.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PemReloadWatcher.java
@@ -74,13 +74,18 @@ public final class PemReloadWatcher implements AutoCloseable {
     }
 
     private void startPollLoop() {
-        this.thread = new Thread(this::pollLoop, "pem-reload-watcher-poll");
+        // Capture the baseline mtime on the calling thread, before start()
+        // returns. If the poll thread sampled it instead, a rotation landing in
+        // the gap between start() and the thread's first sample would be folded
+        // into the baseline and never reported.
+        long baseline = currentMtime();
+        this.thread = new Thread(() -> pollLoop(baseline), "pem-reload-watcher-poll");
         this.thread.setDaemon(true);
         this.thread.start();
     }
 
-    private void pollLoop() {
-        long lastMtime = currentMtime();
+    private void pollLoop(long startMtime) {
+        long lastMtime = startMtime;
         while (!closed.get()) {
             try {
                 Thread.sleep(pollInterval.toMillis());

--- a/i2scim-server/src/main/resources/application.properties
+++ b/i2scim-server/src/main/resources/application.properties
@@ -20,8 +20,11 @@ quarkus.index-dependency.i2scim-core.artifact-id=i2scim-core
 quarkus.application.name=i2scim
 
 # Test-profile only: enable Quarkus mongodb devservices and a test-mode no-auth flag.
+# The image tag is pinned (not `latest`) so CI builds stay reproducible — a server-side
+# change must arrive as a deliberate commit, not silently on the next run. The bundled
+# MongoDB Java driver (org.mongodb:*:5.6.x, managed by the Quarkus BOM) supports server 8.x.
 %test.quarkus.mongodb.devservices.enabled=true
-%test.quarkus.mongodb.devservices.image-name=mongo:6.0.4
+%test.quarkus.mongodb.devservices.image-name=mongo:8.0
 %test.scim.prov.memory.test.noauth=true
 
 #quarkus.container-image.group=independentid

--- a/i2scim-server/src/test/java/com/independentid/scim/test/misc/TestUtils.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/misc/TestUtils.java
@@ -148,10 +148,9 @@ public class TestUtils {
         } catch (InstantiationException e) {
             logger.error("Error initializing keypair: "+e.getMessage(),e);
         }
-        try {
-            Thread.sleep(12000); // give the container time to start
-        } catch (InterruptedException ignore) {
-        }
+        // No explicit wait for the backing store: Quarkus Dev Services blocks
+        // application boot until the MongoDB container is ready, so by the time
+        // this bean is constructed the database is already accepting connections.
     }
 
     /**

--- a/i2scim-server/src/test/java/com/independentid/scim/test/mongo/MongoConfigTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/mongo/MongoConfigTest.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.text.ParseException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -161,9 +162,12 @@ public class MongoConfigTest {
                     .as("Check date is before now")
                     .isBefore(Instant.now());
 
+            // The persisted sync date carries only whole-second precision, so
+            // compare against the second in which the test started — otherwise a
+            // sync occurring in that same second sorts spuriously before startTime.
             assertThat(cnfRes.getLastSyncDate().toInstant())
                     .as("Check sync date is after start time of test.")
-                    .isAfter(startTime);
+                    .isAfterOrEqualTo(startTime.truncatedTo(ChronoUnit.SECONDS));
 
         } catch (ScimException | IOException | ParseException e) {
             logger.error("Error while loading persistant state config resource", e);

--- a/i2scim-server/src/test/java/com/independentid/scim/test/mongo/MongoTests.md
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/mongo/MongoTests.md
@@ -1,16 +1,51 @@
 ## Mongo Setup and Testing Notes
 
-For testing a mongo server is normally setup on the local host.
+The Mongo provider tests (`MongoConfigTest`, `MongoProviderTest`, `MongoFilterMapTest`,
+`RiscMongoPreImageTest`) run against an ephemeral MongoDB container — **no local Mongo
+install is required**.
 
-Set up an account and enable access control. See [Mongodb: Enable Access Control](https://docs.mongodb.com/manual/tutorial/enable-authentication/).
+### How it works
 
-If the username/password is to be changed, the appropriate settings in ScimMongoTestProfile must also be changed.
+These tests use the `ScimMongoTestProfile` profile. In the `test` profile,
+`application.properties` enables [Quarkus Dev Services for MongoDB](https://quarkus.io/guides/mongodb#dev-services):
 
-In Mongo admin:
+```
+%test.quarkus.mongodb.devservices.enabled=true
+%test.quarkus.mongodb.devservices.image-name=mongo:8.0
+```
 
-`
-db.createUser({user:"admin",pwd:"t0p-Secret",roles:[{role:"userAdminAnyDatabase",db:"admin"},"readWriteAnyDatabase",
-"dbAdminAnyDatabase"]})
-`
+On test startup Quarkus pulls and starts the pinned `mongo:8.0` container, then exposes
+its connection string as `quarkus.mongodb.connection-string`. Both
+`scim.prov.mongo.uri` (in `application.properties`) and `TestUtils.DEF_TEST_MONGO_URI`
+resolve to that string via `${quarkus.mongodb.connection-string:mongodb://localhost:27017}`,
+so the tests connect to the container automatically. The container runs without access
+control, and `TestUtils.resetMongoDb()` connects unauthenticated.
 
-Deploying on MacOS: [Installing MongoDB Community Edition on macOS](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
+**The only prerequisite is a running Docker daemon.** This is what CI uses
+(`.github/workflows/build-and-attest.yml` runs the Mongo tests on `ubuntu-latest`,
+which ships with Docker).
+
+### Running locally
+
+```bash
+# All Mongo provider tests:
+mvn -pl i2scim-server test -Dtest='Mongo*,RiscMongoPreImageTest'
+
+# A single class or method:
+mvn -pl i2scim-server test -Dtest=MongoProviderTest
+mvn -pl i2scim-server test -Dtest=MongoProviderTest#b_ScimAddUserTest
+```
+
+### Optional: running against a pre-existing Mongo
+
+To point the tests at a Mongo you manage yourself instead of Dev Services, set
+`quarkus.mongodb.connection-string` (e.g. via the `QUARKUS_MONGODB_CONNECTION_STRING`
+environment variable). If that server enforces access control, also configure
+`scim.prov.mongo.username` / `scim.prov.mongo.password` — `TestUtils.resetMongoDb()`
+folds those credentials into the connection URI. To create the admin account, see
+[MongoDB: Enable Access Control](https://www.mongodb.com/docs/manual/tutorial/enable-authentication/):
+
+```
+db.createUser({user:"admin",pwd:"t0p-Secret",roles:[{role:"userAdminAnyDatabase",db:"admin"},
+"readWriteAnyDatabase","dbAdminAnyDatabase"]})
+```

--- a/i2scim-server/src/test/java/com/independentid/scim/test/mongo/MongoTests.md
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/mongo/MongoTests.md
@@ -21,9 +21,10 @@ resolve to that string via `${quarkus.mongodb.connection-string:mongodb://localh
 so the tests connect to the container automatically. The container runs without access
 control, and `TestUtils.resetMongoDb()` connects unauthenticated.
 
-**The only prerequisite is a running Docker daemon.** This is what CI uses
-(`.github/workflows/build-and-attest.yml` runs the Mongo tests on `ubuntu-latest`,
-which ships with Docker).
+**The only prerequisite is a running Docker daemon.** This is what CI uses:
+`.github/workflows/build-and-attest.yml` runs the entire `i2scim-server` test
+suite on `ubuntu-latest` (which ships with Docker), so the Mongo tests — along
+with everything else — run on every push and pull request.
 
 ### Running locally
 

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/MongoPendingAckStoreTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/MongoPendingAckStoreTest.java
@@ -29,7 +29,7 @@ class MongoPendingAckStoreTest {
 
     @BeforeAll
     static void start() {
-        mongo = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+        mongo = new MongoDBContainer(DockerImageName.parse("mongo:8.0"));
         mongo.start();
         client = MongoClients.create(mongo.getReplicaSetUrl());
         store = new MongoPendingAckStore(client, DB_NAME);

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/MongoPendingPushStoreTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/MongoPendingPushStoreTest.java
@@ -34,7 +34,7 @@ class MongoPendingPushStoreTest {
 
     @BeforeAll
     static void start() {
-        mongo = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+        mongo = new MongoDBContainer(DockerImageName.parse("mongo:8.0"));
         mongo.start();
         client = MongoClients.create(mongo.getReplicaSetUrl());
         store = new MongoPendingPushStore(client, DB_NAME);

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/SignalsDurabilityTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/SignalsDurabilityTest.java
@@ -61,7 +61,7 @@ class SignalsDurabilityTest {
 
     @BeforeAll
     static void startInfra() {
-        mongo = new MongoDBContainer(DockerImageName.parse("mongo:7.0"));
+        mongo = new MongoDBContainer(DockerImageName.parse("mongo:8.0"));
         mongo.start();
         mongoClient = MongoClients.create(mongo.getReplicaSetUrl());
         store = new MongoPendingPushStore(mongoClient, DB_NAME);


### PR DESCRIPTION
## Summary

CI previously ran **no tests** — `build-and-attest.yml` did `mvn package -DskipTests`. This PR makes every push and PR run the whole `i2scim-server` test suite (421 tests).

The suite is green with **only a Docker daemon** available — no MongoDB on localhost, no OPA server, no Kafka broker. Verified by the CI run on this branch.

## Changes

- **`build-and-attest.yml`** — replace the narrow `-Dtest=Mongo*` filter with a plain `mvn -B test` over the reactor. The package step keeps `-DskipTests` since tests already ran.
- **`PemReloadWatcher`** — fixed a baseline-mtime race: `pollLoop()` sampled the baseline on the background thread, so a rotation between `start()` returning and the first sample was silently lost. On the slower CI runner this made `PemReloadWatcherTest.close_stopsFurtherFires` fail. The baseline is now captured synchronously in `start()`.
- **Test Mongo bumped 7.0 → 8.0** — Quarkus Dev Services image, the three Testcontainers call sites (`MongoPendingAckStoreTest`, `MongoPendingPushStoreTest`, `SignalsDurabilityTest`), and the k8s test-service manifest.
- **`TestUtils`** — dropped the 12s `Thread.sleep` boot hack; Dev Services already blocks app boot until Mongo is ready.
- **`MongoConfigTest.d_PersistedConfig`** — fixed a precision-related flake (whole-second persisted sync date vs. microsecond `startTime`).
- **`MongoTests.md`** — refreshed to document the Dev Services flow and CI behaviour.

## Triage notes

- `LoadScimClusterTest` (needs a K8s cluster) and `SignalsGoSignalsIT` (needs a live goSignals server) remain excluded in `i2scim-server/pom.xml`.
- `OpaTest` runs and passes, but its `opa_start.sh` self-start fails silently (wrong working directory) so OPA is never actually exercised — coverage of OPA authz decisions is effectively nil. Wiring real OPA assertions (the `openpolicyagent/opa` image works fine as a service container) is a worthwhile follow-up, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)