### PR TITLE
Fill in CONTEXT.md glossary with RISC/SCIM event terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,15 +8,20 @@ i2scim is a Quarkus implementation of the IETF SCIM v2 protocol (RFC 7643/7644) 
 
 ## Glossary
 
-<!-- Add terms here as they come up. Keep entries tight: term, one-sentence definition, and any synonyms to avoid. -->
+### SCIM event
+A Security Event Token conforming to RFC 9967 (`urn:ietf:params:scim:event:...`) that describes a SCIM provisioning operation — create, put, patch, or delete. See [RFC 9967](https://www.rfc-editor.org/rfc/rfc9967.txt).
 
-<!-- Example entry:
-### SCIM resource
-A JSON document conforming to a registered resource type (User, Group, etc.). Always carries `id`, `meta`, and `schemas`. Avoid: "record", "entity". See [SCIM RFC](https://datatracker.ietf.org/doc/html/rfc7643#section-3.3)
-### SCIM Schema
-A JSON document conforming to a registered schema type (User, Group, etc.). Always carries `id`, `meta`, and `schemas`. See [SCIM RFC 7643](https://www.rfc-editor.org/rfc/rfc7643.txt)
-### SCIM Protocol
-A set of HTTP methods and URIs for managing SCIM resources. See [SCIM RFC 7644](https://www.rfc-editor.org/rfc/rfc7644.txt)
-### SCIM Security Events
-A set of events that describe security-related actions performed on SCIM resources. See [SCIM RFC 9967](https://www.rfc-editor.org/rfc/rfc9967.txt)
--->
+### RISC event
+A Security Event Token conforming to the OpenID RISC Profile 1.0 (`https://schemas.openid.net/secevent/risc/event-type/...`) that describes an account-level lifecycle/risk change. In i2scim, RISC events are *derived from* SCIM resource state changes and are emitted only for `User` resources. Distinct from a SCIM event: a SCIM event reports the operation, a RISC event reports an account-state consequence of it.
+
+### pre-image
+The state of a SCIM resource immediately *before* an operation modified or deleted it. Used to detect what changed — e.g. an identifier's old value, or an `active` transition on a PUT. Contrast with the post-image, the state after the operation.
+
+### Identifier Changed (RISC)
+A RISC event emitted when a configured login identifier of an existing User is changed on a PUT or PATCH. The identifier attribute set is deployment-configurable (typically `userName` and `emails`); for multi-valued identifiers only the primary value is tracked (a lone value is treated as primary). Not emitted on CREATE or DELETE. The old value is conveyed in the subject when the RISC subject format is `email`/`username`/`phone`, otherwise the new value is conveyed in the payload (`new-value`) against a stable `scim`-format subject.
+
+### RISC subject format
+The `sub_id` format used for RISC events, chosen per deployment: `scim` (default — the same stable id/uri subject used for SCIM events) or `email`/`username`/`phone` (the RISC-style single-identifier subject, carrying the prior value for Identifier Changed).
+
+### `active` transition
+A change to — or the initial value of — a User's `active` attribute that yields a RISC Account Enabled or Account Disabled event. An absent `active` is treated as `true` (Enabled). CREATE always emits, reflecting the resulting `active` value. PATCH emits whenever an `add`/`replace` touches `active` (taking the new value directly) or `remove`s it (Enabled). PUT emits only on a change, detected by diffing pre-image against post-image.


### PR DESCRIPTION
## Summary

`CONTEXT.md`'s Glossary section was an empty placeholder template. This fills it with real definitions for the vocabulary introduced by PRD #86 (RISC events):

- **SCIM event** — RFC 9967 SET describing a provisioning operation
- **RISC event** — OpenID RISC Profile SET derived from User state changes
- **pre-image** — resource state immediately before an operation
- **Identifier Changed (RISC)** — RISC event on a login-identifier change
- **RISC subject format** — `scim` vs `email`/`username`/`phone` subject selection
- **`active` transition** — the change that yields Account Enabled/Disabled

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)