### PR TITLE
Surface push/poll event transfers in the console

### DIFF
--- a/i2scim-client/pom.xml
+++ b/i2scim-client/pom.xml
@@ -39,7 +39,7 @@
     <parent>
         <groupId>com.independentid</groupId>
         <artifactId>i2scim-root</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3</version>
     </parent>
     <scm>
         <connection>scm:git:https://github.com/i2-open/i2scim.git</connection>

--- a/i2scim-core/pom.xml
+++ b/i2scim-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.independentid</groupId>
         <artifactId>i2scim-root</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3</version>
     </parent>
 
     <artifactId>i2scim-core</artifactId>

--- a/i2scim-server/pom.xml
+++ b/i2scim-server/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.independentid</groupId>
         <artifactId>i2scim-root</artifactId>
-        <version>0.10.2</version>
+        <version>0.10.3</version>
     </parent>
 
     <artifactId>i2scim-server</artifactId>

--- a/i2scim-server/src/main/java/com/independentid/scim/server/i2scimHealthCheck.java
+++ b/i2scim-server/src/main/java/com/independentid/scim/server/i2scimHealthCheck.java
@@ -23,7 +23,9 @@ import com.independentid.scim.core.PoolManager;
 import com.independentid.scim.core.err.ScimException;
 import com.independentid.scim.resource.PersistStateResource;
 import com.independentid.scim.schema.SchemaManager;
+import com.independentid.signals.SignalsEventHandler;
 import jakarta.annotation.Resource;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -55,6 +57,9 @@ public class i2scimHealthCheck implements org.eclipse.microprofile.health.Health
 
     @Inject
     SchemaManager schemaManager;
+
+    @Inject
+    Instance<SignalsEventHandler> signalsHandlerInstance;
 
     BackendHandler handler = BackendHandler.getInstance();
 
@@ -100,8 +105,40 @@ public class i2scimHealthCheck implements org.eclipse.microprofile.health.Health
                 .withData("scim.security.authen.jwt", configMgr.isAuthJwt())
                 .withData("scim.security.authen.basic", configMgr.isAuthBasic());
 
+        responseBuilder = addPushMetrics(responseBuilder);
+
         return responseBuilder.up().build();
 
 
+    }
+
+    private HealthCheckResponseBuilder addPushMetrics(HealthCheckResponseBuilder b) {
+        SignalsEventHandler signals;
+        try {
+            if (signalsHandlerInstance == null || signalsHandlerInstance.isUnsatisfied()) return b;
+            signals = signalsHandlerInstance.get();
+        } catch (RuntimeException re) {
+            return b;
+        }
+        SignalsEventHandler.PushMetrics m = signals.getPushMetrics();
+        if (m == null) return b;
+        b = b.withData("scim.signals.push.streamId", m.streamId() == null ? "<unset>" : m.streamId())
+                .withData("scim.signals.push.status", m.status() == null ? "<unset>" : m.status().name())
+                .withData("scim.signals.push.successCount", m.successCount())
+                .withData("scim.signals.push.failureCount", m.failureCount())
+                .withData("scim.signals.push.sendErrorCnt", signals.getSendErrorCnt());
+        if (m.stateErrorMsg() != null) {
+            b = b.withData("scim.signals.push.stateErrorMsg", m.stateErrorMsg());
+        }
+        if (m.lastFailureMessage() != null) {
+            b = b.withData("scim.signals.push.lastFailureMessage", m.lastFailureMessage());
+        }
+        if (m.lastFailureAt() != null) {
+            b = b.withData("scim.signals.push.lastFailureAt", m.lastFailureAt().toString());
+        }
+        if (m.lastSuccessAt() != null) {
+            b = b.withData("scim.signals.push.lastSuccessAt", m.lastSuccessAt().toString());
+        }
+        return b;
     }
 }

--- a/i2scim-server/src/main/java/com/independentid/set/SecurityEventToken.java
+++ b/i2scim-server/src/main/java/com/independentid/set/SecurityEventToken.java
@@ -121,7 +121,8 @@ public class SecurityEventToken {
 
     @JsonSetter("jti")
     public String getJti() {
-        return this.claims.get("jti").asText();
+        JsonNode jtiNode = this.claims.get("jti");
+        return jtiNode == null ? null : jtiNode.asText();
     }
 
     @JsonSetter("txn")

--- a/i2scim-server/src/main/java/com/independentid/signals/PushRetryWorker.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushRetryWorker.java
@@ -161,10 +161,14 @@ public final class PushRetryWorker implements Runnable {
 
             AttemptResult result = stream.attemptOnce(record.jti(), record.payload());
             if (result instanceof AttemptResult.Success) {
+                logger.info("Drained queued SET jti={} stream={} after {} prior attempts",
+                        record.jti(), safeStreamId(), record.attemptCount());
                 store.delete(record.streamId(), record.jti());
                 continue;
             }
-            if (result instanceof AttemptResult.StreamNotEnabled) {
+            if (result instanceof AttemptResult.StreamNotEnabled n) {
+                logger.warn("Drain paused for jti={} stream={} streamStatus={} reason={}",
+                        record.jti(), safeStreamId(), n.status(), n.reason());
                 return true; // outer loop sleeps until state recovers
             }
             AttemptResult.Failure f = (AttemptResult.Failure) result;
@@ -175,13 +179,25 @@ public final class PushRetryWorker implements Runnable {
                     f.classification(), newAttempt, record.queuedAt(), clock.instant(), retryConfig);
             switch (decision) {
                 case RetryDecision.Disable d -> {
-                    logger.error("Push stream {} DISABLED by retry worker: {}",
-                            safeStreamId(), d.reason());
+                    logger.error("Push stream {} DISABLED by retry worker after jti={} attempt {}: {}",
+                            safeStreamId(), record.jti(), newAttempt, d.reason());
                     stream.state.transitionTo(StreamStatus.DISABLED, d.reason());
                     return true;
                 }
-                case RetryDecision.SleepThenRetry s -> sleeper.sleep(s.delay().toMillis());
-                case RetryDecision.RetryNoCap n -> sleeper.sleep(n.delay().toMillis());
+                case RetryDecision.SleepThenRetry s -> {
+                    logger.warn("Drain attempt {} failed jti={} stream={} classification={} msg={} — retrying in {}ms",
+                            newAttempt, record.jti(), safeStreamId(),
+                            f.classification().getClass().getSimpleName(), f.errorMsg(),
+                            s.delay().toMillis());
+                    sleeper.sleep(s.delay().toMillis());
+                }
+                case RetryDecision.RetryNoCap n -> {
+                    logger.warn("Drain attempt {} failed jti={} stream={} classification={} msg={} — retrying (no-cap) in {}ms",
+                            newAttempt, record.jti(), safeStreamId(),
+                            f.classification().getClass().getSimpleName(), f.errorMsg(),
+                            n.delay().toMillis());
+                    sleeper.sleep(n.delay().toMillis());
+                }
             }
         }
         return true;

--- a/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/PushStream.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PushStream {
@@ -82,6 +83,15 @@ public class PushStream {
 
     @JsonIgnore
     private final AtomicReference<Instant> lastSuccessfulPush = new AtomicReference<>(Instant.now());
+
+    @JsonIgnore
+    private final AtomicLong pushSuccessCount = new AtomicLong();
+    @JsonIgnore
+    private final AtomicLong pushFailureCount = new AtomicLong();
+    @JsonIgnore
+    private final AtomicReference<String> lastPushFailureMessage = new AtomicReference<>();
+    @JsonIgnore
+    private final AtomicReference<Instant> lastPushFailureAt = new AtomicReference<>();
 
     @JsonIgnore
     public CloseableHttpClient client;
@@ -159,7 +169,7 @@ public class PushStream {
             }
         }
 
-        AttemptResult r = postOnce(signed);
+        AttemptResult r = postOnce(event.getJti(), signed);
         if (r instanceof AttemptResult.Failure f
                 && f.classification() instanceof FailureClassification.Rfc8935 rfcErr
                 && Rfc8935Error.JWS_SIGNATURE_FAILED.equals(rfcErr.error().code())
@@ -174,7 +184,7 @@ public class PushStream {
                         "Failed to re-sign after PEM reload: " + e.getMessage());
                 return new AttemptResult.StreamNotEnabled(StreamStatus.DISABLED, this.state.getErrorMsg());
             }
-            r = postOnce(signed);
+            r = postOnce(event.getJti(), signed);
         }
         return r;
     }
@@ -196,10 +206,10 @@ public class PushStream {
             return new AttemptResult.StreamNotEnabled(status, "endpoint not configured");
         }
         if (this.client == null) setSslContext(null);
-        return postOnce(signedPayload);
+        return postOnce(jti, signedPayload);
     }
 
-    private AttemptResult postOnce(String signedPayload) {
+    private AttemptResult postOnce(String jti, String signedPayload) {
         FailureClassification classification;
         String errorMsg;
         try {
@@ -218,12 +228,19 @@ public class PushStream {
 
                 if (classification instanceof FailureClassification.Success) {
                     this.lastSuccessfulPush.set(Instant.now());
+                    this.pushSuccessCount.incrementAndGet();
+                    logger.debug("Pushed SET jti={} stream={} -> {} {}", jti, safeStreamId(),
+                            this.endpointUrl, code);
                     if (this.state.getStatus() != StreamStatus.ENABLED) {
                         this.state.transitionTo(StreamStatus.ENABLED, null);
                     }
                     return new AttemptResult.Success();
                 }
                 errorMsg = code + " " + reason;
+                recordFailure(errorMsg);
+                logger.warn("Push of SET jti={} stream={} to {} (auth={}) failed: {} {} [{}]",
+                        jti, safeStreamId(), this.endpointUrl, maskAuth(this.authorization),
+                        code, reason, classification.getClass().getSimpleName());
             }
         } catch (IOException e) {
             if (this.shuttingDown.get()) {
@@ -232,6 +249,10 @@ public class PushStream {
             }
             classification = PushFailureClassifier.classify(e);
             errorMsg = "transport: " + e.getMessage();
+            recordFailure(errorMsg);
+            logger.warn("Push of SET jti={} stream={} to {} (auth={}) transport error: [{}] {}",
+                    jti, safeStreamId(), this.endpointUrl, maskAuth(this.authorization),
+                    e.getClass().getSimpleName(), e.getMessage());
         }
 
         if (classification instanceof FailureClassification.Transport
@@ -241,6 +262,42 @@ public class PushStream {
             }
         }
         return new AttemptResult.Failure(classification, errorMsg);
+    }
+
+    private void recordFailure(String msg) {
+        this.pushFailureCount.incrementAndGet();
+        this.lastPushFailureMessage.set(msg);
+        this.lastPushFailureAt.set(Instant.now());
+    }
+
+    public long getPushSuccessCount() { return pushSuccessCount.get(); }
+    public long getPushFailureCount() { return pushFailureCount.get(); }
+    public String getLastPushFailureMessage() { return lastPushFailureMessage.get(); }
+    public Instant getLastPushFailureAt() { return lastPushFailureAt.get(); }
+
+    /**
+     * Mask an Authorization header so a slice can appear in logs without
+     * leaking the credential. Returns {@code "<none>"} for {@code "NONE"},
+     * {@code "<empty>"} for null/blank, otherwise the scheme (first token)
+     * followed by the first 8 characters of the credential, followed by
+     * {@code "…"}. E.g. {@code "Bearer eyJhbGci…"}.
+     */
+    public static String maskAuth(String header) {
+        if (header == null || header.isEmpty()) return "<empty>";
+        if ("NONE".equals(header)) return "<none>";
+        int sp = header.indexOf(' ');
+        if (sp <= 0 || sp == header.length() - 1) {
+            String prefix = header.length() <= 8 ? header : header.substring(0, 8);
+            return prefix + "…";
+        }
+        String scheme = header.substring(0, sp);
+        String cred = header.substring(sp + 1);
+        String prefix = cred.length() <= 8 ? cred : cred.substring(0, 8);
+        return scheme + " " + prefix + "…";
+    }
+
+    private String safeStreamId() {
+        return streamId == null ? "<unset>" : streamId;
     }
 
     /**

--- a/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SignalsEventHandler.java
@@ -422,13 +422,13 @@ public class SignalsEventHandler implements IEventHandler {
 
         if (txn instanceof SecurityEventToken) {
             SecurityEventToken event = (SecurityEventToken) txn;
+            String jti = event.getJti();
             Operation op = mapper.MapSetToOperation(event, configMgr.getSchemaManager());
             if (logger.isDebugEnabled())
                 logger.debug("\tReceived SCIM Event:\n" + event.toPrettyString());
             if (op == null) {
-                if (logger.isDebugEnabled())
-                    logger.debug("Acking non-provisioning event jti={}", event.getJti());
-                recordAck(this.pendingAckStore, ssfClient.getPollStream(), event.getJti());
+                logger.info("Received non-provisioning SET jti={} — acking only", jti);
+                recordAck(this.pendingAckStore, ssfClient.getPollStream(), jti);
                 return;
             }
             try {
@@ -436,28 +436,63 @@ public class SignalsEventHandler implements IEventHandler {
                 if (tranId != null) {
                     ScimResource txnResource = backendHandler.getTransactionRecord(tranId);
                     if (txnResource != null) {
-                        recordAck(this.pendingAckStore, ssfClient.getPollStream(), event.getJti());
-                        logger.warn("Duplicate transaction detected, ignoring.");
+                        recordAck(this.pendingAckStore, ssfClient.getPollStream(), jti);
+                        logger.warn("Duplicate transaction detected jti={} txn={} — acking, not re-applying",
+                                jti, tranId);
                         return;
                     }
                 }
             } catch (BackendException e) {
-                logger.error("Backend error fetching transaction: " + e.getMessage());
+                logger.error("Backend error fetching transaction (jti={}): {}", jti, e.getMessage());
                 return;
             } catch (MalformedClaimException e) {
-                recordAck(this.pendingAckStore, ssfClient.getPollStream(), event.getJti());
-                logger.error("Invalid txn value. Ignoring event");
+                recordAck(this.pendingAckStore, ssfClient.getPollStream(), jti);
+                logger.error("Invalid txn value jti={} — acking and ignoring event", jti);
                 return;
             }
+            logger.info("Applying received SET jti={} op={}", jti, op.getClass().getSimpleName());
             acceptedOps.add(op);
             pool.addJobAndWait(op);
-            recordAck(this.pendingAckStore, ssfClient.getPollStream(), event.getJti());
+            recordAck(this.pendingAckStore, ssfClient.getPollStream(), jti);
         }
     }
 
     public FifoCache<Operation> getSendErrorOps() { return sendErrorOps; }
 
     public int getSendErrorCnt() { return sendErrorOps.size(); }
+
+    /**
+     * Lightweight push-stream metrics for health/devops surfaces. Returns
+     * {@code null} when signals are disabled or the push stream is not
+     * configured — callers should null-check rather than render zero values
+     * for a non-existent stream.
+     */
+    public PushMetrics getPushMetrics() {
+        if (!enabled || ssfClient == null) return null;
+        PushStream push = ssfClient.getPushStream();
+        if (push == null) return null;
+        return new PushMetrics(
+                push.streamId,
+                push.state.getStatus(),
+                push.state.getErrorMsg(),
+                push.getPushSuccessCount(),
+                push.getPushFailureCount(),
+                push.getLastPushFailureMessage(),
+                push.getLastPushFailureAt(),
+                push.getLastSuccessfulPush()
+        );
+    }
+
+    public record PushMetrics(
+            String streamId,
+            StreamStatus status,
+            String stateErrorMsg,
+            long successCount,
+            long failureCount,
+            String lastFailureMessage,
+            Instant lastFailureAt,
+            Instant lastSuccessAt
+    ) {}
 
     /**
      * PRD-B slice #73: single inline {@link PushStream#attemptOnce} per SET; on
@@ -496,8 +531,24 @@ public class SignalsEventHandler implements IEventHandler {
                                                  PendingPushStore store,
                                                  SecurityEventToken token,
                                                  Operation originatingOp) {
+        String jti = token.getJti();
         AttemptResult result = push.attemptOnce(token);
-        if (result instanceof AttemptResult.Success) return;
+        if (result instanceof AttemptResult.Success) {
+            logger.debug("Inline push of SET succeeded jti={} streamId={}", jti, push.streamId);
+            return;
+        }
+
+        // Per-event WARN so the operator sees the failure once at the producer seam.
+        // PushStream.postOnce already logged the HTTP/transport detail; this line ties
+        // the failure to the originating SCIM op and notes the enqueue-for-retry path.
+        if (result instanceof AttemptResult.Failure f) {
+            logger.warn("Inline push of SET failed jti={} streamId={} classification={} msg={} — enqueueing for retry",
+                    jti, push.streamId,
+                    f.classification().getClass().getSimpleName(), f.errorMsg());
+        } else if (result instanceof AttemptResult.StreamNotEnabled n) {
+            logger.warn("Inline push of SET skipped jti={} streamId={} streamStatus={} reason={} — enqueueing for retry",
+                    jti, push.streamId, n.status(), n.reason());
+        }
 
         String signed = signForStorage(push, token);
         if (signed == null) {
@@ -507,14 +558,14 @@ public class SignalsEventHandler implements IEventHandler {
         try {
             store.enqueue(PendingPushRecord.ofNew(
                     push.streamId,
-                    token.getJti(),
+                    jti,
                     signed,
                     PendingPushState.pending,
                     Instant.now()
             ));
         } catch (RuntimeException re) {
             logger.error("Failed to enqueue pending push (streamId={}, jti={}): {}",
-                    push.streamId, token.getJti(), re.getMessage(), re);
+                    push.streamId, jti, re.getMessage(), re);
             sendErrorOps.add(originatingOp);
         }
     }

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -19,6 +19,7 @@ import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,9 @@ public class SsfHandler {
     CloseableHttpClient client;
     @JsonIgnore
     javax.net.ssl.SSLContext sslContext;
+
+    @ConfigProperty(name = "quarkus.application.version")
+    String version;
 
     public String serverUrl;
     public String iat;
@@ -341,7 +345,7 @@ public class SsfHandler {
         try {
             gen = JsonUtil.getGenerator(stringWriter, true);
             gen.writeStartObject();
-            gen.writeStringField("description", "i2scim.io v0.10.2");
+            gen.writeStringField("description", "i2scim.io " + version);
             gen.writeArrayFieldStart("scopes");
             gen.writeString("admin");
             gen.writeString("stream");

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -19,7 +19,7 @@ import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,9 +51,6 @@ public class SsfHandler {
     @JsonIgnore
     javax.net.ssl.SSLContext sslContext;
 
-    @ConfigProperty(name = "quarkus.application.version")
-    String version;
-
     public String serverUrl;
     public String iat;
     public String clientToken;
@@ -63,6 +60,24 @@ public class SsfHandler {
     public boolean initialized = false;
 
     protected SsfHandler() {
+    }
+
+    /**
+     * Look up the running application version at the point of use.
+     * SsfHandler is constructed outside CDI (Jackson {@code treeToValue} on
+     * a persisted config file, or plain {@code new}), so a {@code @ConfigProperty}
+     * field would be left null. {@link ConfigProvider} resolves against the
+     * same MicroProfile Config sources Quarkus populates, including the
+     * project version that the build wires into {@code quarkus.application.version}.
+     */
+    private static String applicationVersion() {
+        try {
+            return ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.application.version", String.class)
+                    .orElse("unknown");
+        } catch (RuntimeException re) {
+            return "unknown";
+        }
     }
 
     public String toString() {
@@ -345,7 +360,7 @@ public class SsfHandler {
         try {
             gen = JsonUtil.getGenerator(stringWriter, true);
             gen.writeStartObject();
-            gen.writeStringField("description", "i2scim.io " + version);
+            gen.writeStringField("description", "i2scim.io " + applicationVersion());
             gen.writeArrayFieldStart("scopes");
             gen.writeString("admin");
             gen.writeString("stream");

--- a/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/SsfHandler.java
@@ -262,6 +262,7 @@ public class SsfHandler {
 
         StreamConfig pushResp = JsonUtil.getMapper().readValue(body.getContent(), StreamConfig.class);
         this.pushStream.streamId = pushResp.Id;
+        this.pushStream.state.setLabel("push:" + pushResp.Id);
         this.pushStream.endpointUrl = pushResp.Delivery.EndpointUrl;
         this.pushStream.authorization = pushResp.Delivery.AuthorizationHeader;
         this.pushStream.iss = configProps.pubIssuer;
@@ -314,6 +315,7 @@ public class SsfHandler {
 
         StreamConfig pollResp = JsonUtil.getMapper().readValue(body.getContent(), StreamConfig.class);
         this.pollStream.streamId = pollResp.Id;
+        this.pollStream.state.setLabel("poll:" + pollResp.Id);
         this.pollStream.endpointUrl = pollResp.Delivery.EndpointUrl;
         this.pollStream.authorization = pollResp.Delivery.AuthorizationHeader;
         this.pollStream.iss = configProps.rcvIss;

--- a/i2scim-server/src/main/java/com/independentid/signals/StreamStateHolder.java
+++ b/i2scim-server/src/main/java/com/independentid/signals/StreamStateHolder.java
@@ -2,6 +2,8 @@ package com.independentid.signals;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -9,13 +11,27 @@ import java.util.function.BiConsumer;
 
 public class StreamStateHolder {
 
+    private static final Logger logger = LoggerFactory.getLogger(StreamStateHolder.class);
+
     @JsonIgnore
     private StreamStatus status = StreamStatus.ENABLED;
 
     private String errorMsg;
 
     @JsonIgnore
+    private String label;
+
+    @JsonIgnore
     private final List<BiConsumer<StreamStatus, StreamStatus>> listeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Optional human-readable label included in state-transition logs
+     * (e.g. {@code "push:stream-abc"}). Set by the owning stream so operators
+     * can tell which stream changed without grepping by thread/jti.
+     */
+    public void setLabel(String label) {
+        this.label = label;
+    }
 
     public StreamStatus getStatus() {
         return status;
@@ -30,6 +46,14 @@ public class StreamStateHolder {
         this.status = newStatus;
         this.errorMsg = reason;
         if (oldStatus != newStatus) {
+            String who = label == null ? "<unlabeled>" : label;
+            if (newStatus == StreamStatus.DISABLED) {
+                logger.error("Stream {} state {} -> {} ({})", who, oldStatus, newStatus,
+                        reason == null ? "no reason given" : reason);
+            } else {
+                logger.info("Stream {} state {} -> {}{}", who, oldStatus, newStatus,
+                        reason == null ? "" : " (" + reason + ")");
+            }
             for (BiConsumer<StreamStatus, StreamStatus> listener : listeners) {
                 listener.accept(oldStatus, newStatus);
             }

--- a/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamMetricsTest.java
+++ b/i2scim-server/src/test/java/com/independentid/scim/test/signals/PushStreamMetricsTest.java
@@ -1,0 +1,112 @@
+package com.independentid.scim.test.signals;
+
+import com.independentid.set.SecurityEventToken;
+import com.independentid.signals.PushStream;
+import com.independentid.signals.StreamStatus;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for the silent-401 bug: every push attempt now updates
+ * pushSuccessCount/pushFailureCount/lastPushFailureMessage on PushStream, and
+ * those are surfaced through the readiness health endpoint. Asserting on the
+ * counters is the stable signal — log capture under JBoss LogManager is brittle.
+ */
+class PushStreamMetricsTest {
+
+    @Test
+    void successfulPushIncrementsSuccessCountAndLeavesFailuresAtZero() throws Exception {
+        PushStream s = newStream();
+        s.client = mockClient(200, "OK");
+
+        s.attemptOnce(new SecurityEventToken());
+
+        assertThat(s.getPushSuccessCount()).isEqualTo(1);
+        assertThat(s.getPushFailureCount()).isZero();
+        assertThat(s.getLastPushFailureMessage()).isNull();
+        assertThat(s.getLastPushFailureAt()).isNull();
+        assertThat(s.state.getStatus()).isEqualTo(StreamStatus.ENABLED);
+    }
+
+    @Test
+    void failedPushOn401IncrementsFailureCountAndRecordsMessage() throws Exception {
+        PushStream s = newStream();
+        s.client = mockClient(401, "Unauthorized");
+
+        s.attemptOnce(new SecurityEventToken());
+
+        assertThat(s.getPushSuccessCount()).isZero();
+        assertThat(s.getPushFailureCount()).isEqualTo(1);
+        assertThat(s.getLastPushFailureMessage()).contains("401").contains("Unauthorized");
+        assertThat(s.getLastPushFailureAt()).isNotNull();
+    }
+
+    @Test
+    void failedPushOn403IncrementsFailureCountAndRecordsMessage() throws Exception {
+        PushStream s = newStream();
+        s.client = mockClient(403, "Forbidden");
+
+        s.attemptOnce(new SecurityEventToken());
+
+        assertThat(s.getPushFailureCount()).isEqualTo(1);
+        assertThat(s.getLastPushFailureMessage()).contains("403").contains("Forbidden");
+    }
+
+    @Test
+    void countersAccumulateAcrossMultipleAttempts() throws Exception {
+        PushStream s = newStream();
+        s.client = mockClient(401, "Unauthorized");
+
+        s.attemptOnce(new SecurityEventToken());
+        s.attemptOnce(new SecurityEventToken());
+        s.attemptOnce(new SecurityEventToken());
+
+        assertThat(s.getPushFailureCount()).isEqualTo(3);
+        assertThat(s.getPushSuccessCount()).isZero();
+    }
+
+    @Test
+    void maskAuthHidesBearerCredential() {
+        assertThat(PushStream.maskAuth("Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig"))
+                .startsWith("Bearer ")
+                .endsWith("…")
+                .doesNotContain("payload")
+                .doesNotContain("sig");
+        assertThat(PushStream.maskAuth("NONE")).isEqualTo("<none>");
+        assertThat(PushStream.maskAuth(null)).isEqualTo("<empty>");
+        assertThat(PushStream.maskAuth("")).isEqualTo("<empty>");
+        // Scheme-less token (rare but possible): mask the leading prefix.
+        assertThat(PushStream.maskAuth("abcdefghijkl")).isEqualTo("abcdefgh…");
+    }
+
+    private static PushStream newStream() {
+        PushStream s = new PushStream();
+        s.streamId = "metrics-stream";
+        s.endpointUrl = "https://example.com/events";
+        s.authorization = "NONE";
+        s.iss = "test-issuer";
+        s.aud = "test-audience";
+        s.issuerKey = null; // unsigned (NONE alg)
+        s.maxRetries = 0;
+        s.unauthorizedRetryMax = 0;
+        s.initialDelay = 0;
+        s.maxDelay = 0;
+        return s;
+    }
+
+    private static CloseableHttpClient mockClient(int code, String reason) throws Exception {
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        CloseableHttpResponse resp = mock(CloseableHttpResponse.class);
+        when(resp.getCode()).thenReturn(code);
+        when(resp.getReasonPhrase()).thenReturn(reason);
+        when(client.execute(any(HttpPost.class))).thenReturn(resp);
+        return client;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.independentid</groupId>
     <artifactId>i2scim-root</artifactId>
-    <version>0.10.2</version>
+    <version>0.10.3</version>
     <packaging>pom</packaging>
     <name>i2scim-root</name>
     <description>i2scim.io SCIM v2 Server on Quarkus - Root Project</description>


### PR DESCRIPTION
## Summary

- Fix the silent-401 push failure: `PushStream.postOnce` now logs every non-2xx and transport error at WARN with masked Authorization, classification, and jti; success is at DEBUG. Producer hot path (`SignalsEventHandler.attemptInlineAndEnqueueOnFailure`) logs each inline failure before enqueueing for retry, so operators see the cause within milliseconds instead of waiting for the 6h elapsed budget.
- Per-stream push metrics (`successCount`, `failureCount`, `lastFailureMessage`, `lastFailureAt`, `lastSuccessAt`) surfaced on the readiness health endpoint via `getPushMetrics()`.
- `StreamStateHolder` logs every status transition (INFO for ENABLED/PAUSED, ERROR for DISABLED) with a label set from `SsfHandler` so transitions identify their stream.
- `PushRetryWorker` logs each drain attempt + retry decision; recovery after queued attempts now logs INFO.
- `SignalsEventHandler.consume()` promotes received-event dispatch to INFO so the receive side is symmetric.
- Drive-by: `SecurityEventToken.getJti()` is null-safe now (mirrors `getTxn`), fixing an NPE the new logging path exposed in existing PushStream tests.
- Bundles the earlier CONTEXT.md glossary additions for RISC/SCIM event terms (already on the branch).

## Test plan

- [x] `mvn -pl i2scim-server -Dtest='Push*Test,Poll*Test,SignalsEventHandlerTest,RiscEvent*Test,SsfClientTest,SecurityEventTokenTest' test` — 111 tests pass
- [x] New `PushStreamMetricsTest` (5 cases) covers success/401/403 counter behavior + `maskAuth` formatting
- [ ] Manual: hit the readiness endpoint with signals enabled and confirm `scim.signals.push.*` fields are populated
- [ ] Manual: misconfigure the push Authorization header and confirm a WARN appears on the first SCIM op (no need to wait for the 6h drain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)